### PR TITLE
Add real time image adjustment to ADIAT viewer

### DIFF
--- a/app/core/controllers/ImageAdjustmentDialog.py
+++ b/app/core/controllers/ImageAdjustmentDialog.py
@@ -1,0 +1,264 @@
+"""
+ImageAdjustmentDialog.py - Real-time image adjustment dialog for ADIAT
+
+Provides exposure, highlights, shadows, clarity, and radius adjustments
+with real-time preview similar to Paint.NET functionality.
+"""
+
+import numpy as np
+import cv2
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtWidgets import QDialog
+
+from core.views.components.ImageAdjustmentDialog_ui import Ui_ImageAdjustmentDialog
+
+
+class ImageAdjustmentDialog(QDialog, Ui_ImageAdjustmentDialog):
+    """
+    Dialog for real-time image adjustments including exposure, highlights, shadows, clarity, and radius.
+    
+    Signals:
+        imageAdjusted: Emitted when adjustments are applied with the adjusted QPixmap
+    """
+    
+    imageAdjusted = pyqtSignal(QPixmap)
+    
+    def __init__(self, parent=None, original_pixmap=None):
+        """
+        Initialize the Image Adjustment Dialog.
+        
+        Args:
+            parent: Parent widget
+            original_pixmap (QPixmap): Original image to adjust
+        """
+        super().__init__(parent)
+        self.setupUi(self)
+        
+        self.original_pixmap = original_pixmap
+        self.original_image = None
+        self.adjusted_image = None
+        
+        # Convert QPixmap to numpy array for processing
+        if original_pixmap:
+            self._pixmap_to_array()
+        
+        # Connect signals
+        self._connect_signals()
+        
+        # Initialize adjustments
+        self.adjustments = {
+            'exposure': 0,
+            'highlights': 0,
+            'shadows': 0,
+            'clarity': 0,
+            'radius': 10
+        }
+    
+    def _connect_signals(self):
+        """Connect slider and button signals."""
+        # Slider connections for real-time updates
+        self.exposureSlider.valueChanged.connect(self._on_exposure_changed)
+        self.highlightsSlider.valueChanged.connect(self._on_highlights_changed)
+        self.shadowsSlider.valueChanged.connect(self._on_shadows_changed)
+        self.claritySlider.valueChanged.connect(self._on_clarity_changed)
+        self.radiusSlider.valueChanged.connect(self._on_radius_changed)
+        
+        # Button connections
+        self.resetButton.clicked.connect(self._reset_adjustments)
+        self.applyButton.clicked.connect(self._apply_adjustments)
+        self.closeButton.clicked.connect(self.close)
+    
+    def _pixmap_to_array(self):
+        """Convert QPixmap to numpy array for processing."""
+        if not self.original_pixmap:
+            return
+            
+        qimage = self.original_pixmap.toImage()
+        qimage = qimage.convertToFormat(QImage.Format_RGB888)
+        
+        width = qimage.width()
+        height = qimage.height()
+        ptr = qimage.bits()
+        ptr.setsize(qimage.byteCount())
+        
+        # Convert to numpy array
+        arr = np.frombuffer(ptr, np.uint8).reshape((height, width, 3))
+        self.original_image = arr.copy()
+        self.adjusted_image = arr.copy()
+    
+    def _array_to_pixmap(self, image_array):
+        """Convert numpy array to QPixmap."""
+        if image_array is None:
+            return None
+            
+        height, width, channel = image_array.shape
+        bytes_per_line = 3 * width
+        
+        # Ensure values are in valid range
+        image_array = np.clip(image_array, 0, 255).astype(np.uint8)
+        
+        qimage = QImage(image_array.data, width, height, bytes_per_line, QImage.Format_RGB888)
+        return QPixmap.fromImage(qimage)
+    
+    def _on_exposure_changed(self, value):
+        """Handle exposure slider changes."""
+        self.adjustments['exposure'] = value
+        self.exposureValue.setText(str(value))
+        self._apply_real_time_adjustments()
+    
+    def _on_highlights_changed(self, value):
+        """Handle highlights slider changes."""
+        self.adjustments['highlights'] = value
+        self.highlightsValue.setText(str(value))
+        self._apply_real_time_adjustments()
+    
+    def _on_shadows_changed(self, value):
+        """Handle shadows slider changes."""
+        self.adjustments['shadows'] = value
+        self.shadowsValue.setText(str(value))
+        self._apply_real_time_adjustments()
+    
+    def _on_clarity_changed(self, value):
+        """Handle clarity slider changes."""
+        self.adjustments['clarity'] = value
+        self.clarityValue.setText(str(value))
+        self._apply_real_time_adjustments()
+    
+    def _on_radius_changed(self, value):
+        """Handle radius slider changes."""
+        self.adjustments['radius'] = value
+        self.radiusValue.setText(str(value))
+        self._apply_real_time_adjustments()
+    
+    def _apply_real_time_adjustments(self):
+        """Apply adjustments in real-time and emit signal."""
+        if self.original_image is None:
+            return
+        
+        # Start with original image
+        adjusted = self.original_image.astype(np.float32)
+        
+        # Apply exposure adjustment (affects entire image)
+        if self.adjustments['exposure'] != 0:
+            exposure_factor = 2 ** (self.adjustments['exposure'] / 50.0)
+            adjusted = adjusted * exposure_factor
+        
+        # Apply highlights and shadows adjustments with radius consideration
+        if self.adjustments['highlights'] != 0 or self.adjustments['shadows'] != 0:
+            adjusted = self._apply_highlights_shadows(adjusted)
+        
+        # Apply clarity adjustment
+        if self.adjustments['clarity'] != 0:
+            adjusted = self._apply_clarity(adjusted)
+        
+        # Clip values and convert back
+        adjusted = np.clip(adjusted, 0, 255).astype(np.uint8)
+        self.adjusted_image = adjusted
+        
+        # Convert to pixmap and emit signal
+        adjusted_pixmap = self._array_to_pixmap(adjusted)
+        if adjusted_pixmap:
+            self.imageAdjusted.emit(adjusted_pixmap)
+    
+    def _apply_highlights_shadows(self, image):
+        """Apply highlights and shadows adjustments with radius consideration."""
+        radius = max(1, int(self.adjustments['radius']))
+        highlights_adj = self.adjustments['highlights'] / 100.0
+        shadows_adj = self.adjustments['shadows'] / 100.0
+        
+        # Convert to grayscale for luminance mask
+        gray = cv2.cvtColor(image.astype(np.uint8), cv2.COLOR_RGB2GRAY)
+        
+        # Create luminance masks with gaussian blur for smooth transitions
+        kernel_size = radius * 2 + 1
+        blurred = cv2.GaussianBlur(gray, (kernel_size, kernel_size), radius / 3.0)
+        
+        # Normalize to 0-1 range
+        luminance = blurred.astype(np.float32) / 255.0
+        
+        # Create highlight and shadow masks
+        highlight_mask = luminance  # Bright areas
+        shadow_mask = 1.0 - luminance  # Dark areas
+        
+        # Apply adjustments
+        result = image.copy()
+        
+        if highlights_adj != 0:
+            # Reduce or increase highlights
+            highlight_factor = 1.0 + (highlights_adj * highlight_mask[..., np.newaxis])
+            result = result * highlight_factor
+        
+        if shadows_adj != 0:
+            # Increase or decrease shadows
+            shadow_factor = 1.0 + (shadows_adj * shadow_mask[..., np.newaxis])
+            result = result * shadow_factor
+        
+        return result
+    
+    def _apply_clarity(self, image):
+        """Apply clarity adjustment (unsharp mask effect)."""
+        clarity_strength = self.adjustments['clarity'] / 100.0
+        
+        if abs(clarity_strength) < 0.01:
+            return image
+        
+        # Convert to grayscale for edge detection
+        gray = cv2.cvtColor(image.astype(np.uint8), cv2.COLOR_RGB2GRAY)
+        
+        # Create unsharp mask
+        kernel_size = 5
+        blurred = cv2.GaussianBlur(gray, (kernel_size, kernel_size), 1.0)
+        mask = gray.astype(np.float32) - blurred.astype(np.float32)
+        
+        # Apply mask to each channel
+        result = image.copy()
+        for i in range(3):
+            channel = result[:, :, i]
+            if clarity_strength > 0:
+                # Increase clarity
+                result[:, :, i] = channel + (mask * clarity_strength * 0.5)
+            else:
+                # Decrease clarity (soften)
+                result[:, :, i] = channel + (mask * clarity_strength * 0.3)
+        
+        return result
+    
+    def _reset_adjustments(self):
+        """Reset all adjustments to default values."""
+        # Reset sliders
+        self.exposureSlider.setValue(0)
+        self.highlightsSlider.setValue(0)
+        self.shadowsSlider.setValue(0)
+        self.claritySlider.setValue(0)
+        self.radiusSlider.setValue(10)
+        
+        # Reset adjustments dict
+        self.adjustments = {
+            'exposure': 0,
+            'highlights': 0,
+            'shadows': 0,
+            'clarity': 0,
+            'radius': 10
+        }
+        
+        # Update value labels
+        self.exposureValue.setText("0")
+        self.highlightsValue.setText("0")
+        self.shadowsValue.setText("0")
+        self.clarityValue.setText("0")
+        self.radiusValue.setText("10")
+        
+        # Apply reset
+        self._apply_real_time_adjustments()
+    
+    def _apply_adjustments(self):
+        """Apply current adjustments and close dialog."""
+        self._apply_real_time_adjustments()
+        self.accept()
+    
+    def get_adjusted_pixmap(self):
+        """Get the current adjusted pixmap."""
+        if self.adjusted_image is not None:
+            return self._array_to_pixmap(self.adjusted_image)
+        return self.original_pixmap

--- a/app/core/views/components/ImageAdjustmentDialog_ui.py
+++ b/app/core/views/components/ImageAdjustmentDialog_ui.py
@@ -31,12 +31,12 @@ class Ui_ImageAdjustmentDialog(object):
         self.titleLabel.setObjectName("titleLabel")
         self.verticalLayout.addWidget(self.titleLabel)
         
-        # Create adjustment controls
-        self._create_slider_group("Exposure", "exposureSlider", "exposureLabel", "exposureValue", -100, 100, 0)
-        self._create_slider_group("Highlights", "highlightsSlider", "highlightsLabel", "highlightsValue", -100, 100, 0)
-        self._create_slider_group("Shadows", "shadowsSlider", "shadowsLabel", "shadowsValue", -100, 100, 0)
-        self._create_slider_group("Clarity", "claritySlider", "clarityLabel", "clarityValue", -100, 100, 0)
-        self._create_slider_group("Radius", "radiusSlider", "radiusLabel", "radiusValue", 1, 50, 10)
+        # Create adjustment controls with expanded ranges for more pronounced effects
+        self._create_slider_group("Exposure", "exposureSlider", "exposureLabel", "exposureValue", -200, 200, 0)
+        self._create_slider_group("Highlights", "highlightsSlider", "highlightsLabel", "highlightsValue", -200, 200, 0)
+        self._create_slider_group("Shadows", "shadowsSlider", "shadowsLabel", "shadowsValue", -200, 200, 0)
+        self._create_slider_group("Clarity", "claritySlider", "clarityLabel", "clarityValue", -200, 200, 0)
+        self._create_slider_group("Radius", "radiusSlider", "radiusLabel", "radiusValue", 1, 100, 10)
         
         # Spacer
         spacerItem = QtWidgets.QSpacerItem(20, 20, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)

--- a/app/core/views/components/ImageAdjustmentDialog_ui.py
+++ b/app/core/views/components/ImageAdjustmentDialog_ui.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation for Image Adjustment Dialog
+# ADIAT - Automated Drone Image Analysis Tool
+# Image adjustment dialog with real-time sliders for exposure, highlights, shadows, clarity, and radius
+
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+
+class Ui_ImageAdjustmentDialog(object):
+    def setupUi(self, ImageAdjustmentDialog):
+        ImageAdjustmentDialog.setObjectName("ImageAdjustmentDialog")
+        ImageAdjustmentDialog.resize(350, 400)
+        ImageAdjustmentDialog.setWindowTitle("Image Adjustments")
+        ImageAdjustmentDialog.setModal(True)
+        
+        # Main layout
+        self.verticalLayout = QtWidgets.QVBoxLayout(ImageAdjustmentDialog)
+        self.verticalLayout.setContentsMargins(15, 15, 15, 15)
+        self.verticalLayout.setSpacing(15)
+        self.verticalLayout.setObjectName("verticalLayout")
+        
+        # Title label
+        self.titleLabel = QtWidgets.QLabel(ImageAdjustmentDialog)
+        font = QtGui.QFont()
+        font.setPointSize(12)
+        font.setBold(True)
+        self.titleLabel.setFont(font)
+        self.titleLabel.setText("Image Adjustments")
+        self.titleLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.titleLabel.setObjectName("titleLabel")
+        self.verticalLayout.addWidget(self.titleLabel)
+        
+        # Create adjustment controls
+        self._create_slider_group("Exposure", "exposureSlider", "exposureLabel", "exposureValue", -100, 100, 0)
+        self._create_slider_group("Highlights", "highlightsSlider", "highlightsLabel", "highlightsValue", -100, 100, 0)
+        self._create_slider_group("Shadows", "shadowsSlider", "shadowsLabel", "shadowsValue", -100, 100, 0)
+        self._create_slider_group("Clarity", "claritySlider", "clarityLabel", "clarityValue", -100, 100, 0)
+        self._create_slider_group("Radius", "radiusSlider", "radiusLabel", "radiusValue", 1, 50, 10)
+        
+        # Spacer
+        spacerItem = QtWidgets.QSpacerItem(20, 20, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem)
+        
+        # Button layout
+        self.buttonLayout = QtWidgets.QHBoxLayout()
+        self.buttonLayout.setObjectName("buttonLayout")
+        
+        # Reset button
+        self.resetButton = QtWidgets.QPushButton(ImageAdjustmentDialog)
+        self.resetButton.setText("Reset")
+        self.resetButton.setObjectName("resetButton")
+        self.buttonLayout.addWidget(self.resetButton)
+        
+        # Button spacer
+        buttonSpacer = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        self.buttonLayout.addItem(buttonSpacer)
+        
+        # Apply button
+        self.applyButton = QtWidgets.QPushButton(ImageAdjustmentDialog)
+        self.applyButton.setText("Apply")
+        self.applyButton.setObjectName("applyButton")
+        self.buttonLayout.addWidget(self.applyButton)
+        
+        # Close button
+        self.closeButton = QtWidgets.QPushButton(ImageAdjustmentDialog)
+        self.closeButton.setText("Close")
+        self.closeButton.setObjectName("closeButton")
+        self.buttonLayout.addWidget(self.closeButton)
+        
+        self.verticalLayout.addLayout(self.buttonLayout)
+
+    def _create_slider_group(self, label_text, slider_name, label_name, value_name, min_val, max_val, default_val):
+        """Create a labeled slider group with value display."""
+        # Group widget
+        group_widget = QtWidgets.QWidget()
+        group_widget.setObjectName(f"{slider_name}Group")
+        
+        # Group layout
+        group_layout = QtWidgets.QVBoxLayout(group_widget)
+        group_layout.setContentsMargins(0, 0, 0, 0)
+        group_layout.setSpacing(5)
+        
+        # Label and value layout
+        label_layout = QtWidgets.QHBoxLayout()
+        
+        # Label
+        label = QtWidgets.QLabel()
+        label.setText(label_text)
+        font = QtGui.QFont()
+        font.setPointSize(10)
+        label.setFont(font)
+        label.setObjectName(label_name)
+        setattr(self, label_name, label)
+        label_layout.addWidget(label)
+        
+        # Spacer
+        label_spacer = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        label_layout.addItem(label_spacer)
+        
+        # Value label
+        value_label = QtWidgets.QLabel()
+        value_label.setText(str(default_val))
+        value_label.setMinimumWidth(30)
+        value_label.setAlignment(QtCore.Qt.AlignRight)
+        font = QtGui.QFont()
+        font.setPointSize(10)
+        value_label.setFont(font)
+        value_label.setObjectName(value_name)
+        setattr(self, value_name, value_label)
+        label_layout.addWidget(value_label)
+        
+        group_layout.addLayout(label_layout)
+        
+        # Slider
+        slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        slider.setMinimum(min_val)
+        slider.setMaximum(max_val)
+        slider.setValue(default_val)
+        slider.setTickPosition(QtWidgets.QSlider.TicksBelow)
+        slider.setTickInterval((max_val - min_val) // 4)
+        slider.setObjectName(slider_name)
+        setattr(self, slider_name, slider)
+        group_layout.addWidget(slider)
+        
+        self.verticalLayout.addWidget(group_widget)
+
+    def retranslateUi(self, ImageAdjustmentDialog):
+        _translate = QtCore.QCoreApplication.translate
+        ImageAdjustmentDialog.setWindowTitle(_translate("ImageAdjustmentDialog", "Image Adjustments"))


### PR DESCRIPTION
  - CTRL-H launches the image adjustment dialog.
  - Changes are not permanent.
  - Can adjust exposure, highlights, shadows, and radius.
  - Add debounced slider updates (150ms delay) to prevent excessive processing during user interaction
  - Expand slider ranges from ±100 to ±200 for exposure, highlights, shadows, and clarity for more pronounced effects
  - Expand radius range from 1-50 to 1-100 for greater control
  - Add configurable debouncing option for users who prefer immediate feedback
  - Optimize algorithm scaling factors for expanded ranges
  - Maintains real-time preview quality while dramatically improving responsiveness