### PR TITLE
feat: add interactive AOI creation via circle drawing

### DIFF
--- a/app/core/controllers/viewer/components/AOICreationDialog.py
+++ b/app/core/controllers/viewer/components/AOICreationDialog.py
@@ -1,0 +1,51 @@
+"""AOICreationDialog - Simple confirmation dialog for creating an AOI."""
+
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton
+from PySide6.QtCore import Qt
+
+
+class AOICreationDialog(QDialog):
+    """Simple dialog to confirm AOI creation."""
+
+    def __init__(self, parent):
+        """Initialize the AOI creation confirmation dialog.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self.setupUi()
+
+    def setupUi(self):
+        """Set up the dialog UI."""
+        self.setWindowTitle("Create AOI")
+        self.setModal(True)
+        self.setMinimumWidth(250)
+
+        # Main layout
+        layout = QVBoxLayout()
+
+        # Message label
+        message = QLabel("Create AOI?")
+        message.setAlignment(Qt.AlignCenter)
+        message.setStyleSheet("QLabel { font-size: 12pt; padding: 10px; }")
+        layout.addWidget(message)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+
+        self.yes_button = QPushButton("Yes")
+        self.yes_button.setDefault(True)  # Make Yes the default action
+        self.yes_button.clicked.connect(self.accept)
+
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+
+        button_layout.addStretch()
+        button_layout.addWidget(self.yes_button)
+        button_layout.addWidget(self.cancel_button)
+        button_layout.addStretch()
+
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)

--- a/app/core/controllers/viewer/components/PDFExportDialog.py
+++ b/app/core/controllers/viewer/components/PDFExportDialog.py
@@ -1,0 +1,126 @@
+"""PDFExportDialog - Dialog for collecting PDF export settings."""
+
+import os
+import json
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QFormLayout
+from PySide6.QtCore import Qt
+
+
+class PDFExportDialog(QDialog):
+    """Dialog for entering organization and search name for PDF export."""
+
+    def __init__(self, parent):
+        """Initialize the PDF export settings dialog.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self.config_path = self._get_config_path()
+        self.setupUi()
+        self.load_settings()
+
+    def _get_config_path(self):
+        """Get the path to the PDF export config file.
+
+        Returns:
+            str: Path to the config JSON file
+        """
+        # Store config in user's home directory
+        config_dir = os.path.join(os.path.expanduser("~"), ".adiat")
+        os.makedirs(config_dir, exist_ok=True)
+        return os.path.join(config_dir, "pdf_export_settings.json")
+
+    def setupUi(self):
+        """Set up the dialog UI."""
+        self.setWindowTitle("PDF Export Settings")
+        self.setModal(True)
+        self.setMinimumWidth(400)
+
+        # Main layout
+        layout = QVBoxLayout()
+
+        # Instructions
+        instructions = QLabel("Enter the following information for the PDF report:")
+        instructions.setWordWrap(True)
+        layout.addWidget(instructions)
+
+        # Form layout for inputs
+        form_layout = QFormLayout()
+
+        # Organization name input
+        self.organization_input = QLineEdit()
+        self.organization_input.setPlaceholderText("Enter organization name")
+        form_layout.addRow("Organization:", self.organization_input)
+
+        # Search name input
+        self.search_name_input = QLineEdit()
+        self.search_name_input.setPlaceholderText("Enter search name")
+        form_layout.addRow("Search Name:", self.search_name_input)
+
+        layout.addLayout(form_layout)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        self.ok_button = QPushButton("OK")
+        self.ok_button.clicked.connect(self.on_ok_clicked)
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+
+        button_layout.addStretch()
+        button_layout.addWidget(self.ok_button)
+        button_layout.addWidget(self.cancel_button)
+
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)
+
+        # Set focus to organization input
+        self.organization_input.setFocus()
+
+    def on_ok_clicked(self):
+        """Handle OK button click."""
+        # Save settings before accepting
+        self.save_settings()
+        self.accept()
+
+    def load_settings(self):
+        """Load previously saved settings from config file."""
+        try:
+            if os.path.exists(self.config_path):
+                with open(self.config_path, 'r') as f:
+                    settings = json.load(f)
+                    self.organization_input.setText(settings.get('organization', ''))
+                    self.search_name_input.setText(settings.get('search_name', ''))
+        except Exception:
+            # If loading fails, just use empty values
+            pass
+
+    def save_settings(self):
+        """Save current settings to config file."""
+        try:
+            settings = {
+                'organization': self.organization_input.text().strip(),
+                'search_name': self.search_name_input.text().strip()
+            }
+            with open(self.config_path, 'w') as f:
+                json.dump(settings, f, indent=2)
+        except Exception:
+            # If saving fails, just continue (settings won't persist)
+            pass
+
+    def get_organization(self):
+        """Get the entered organization name.
+
+        Returns:
+            str: The organization name
+        """
+        return self.organization_input.text().strip()
+
+    def get_search_name(self):
+        """Get the entered search name.
+
+        Returns:
+            str: The search name
+        """
+        return self.search_name_input.text().strip()

--- a/app/core/controllers/viewer/components/UpscaleDialog.py
+++ b/app/core/controllers/viewer/components/UpscaleDialog.py
@@ -1,0 +1,773 @@
+"""
+UpscaleDialog.py - Image upscaling dialog for ADIAT Viewer
+
+Provides progressive image upscaling of the currently visible portion of an image.
+User can repeatedly upscale to see higher resolution details.
+
+Features:
+- High-quality image upscaling using Lanczos interpolation
+- Progressive upscaling (2x per iteration by default)
+- Interactive zoom and pan controls (same as main viewer)
+- Can upscale the visible portion again for further magnification
+- Displays current upscale level in title
+"""
+
+import numpy as np
+import cv2
+import os
+import urllib.request
+from pathlib import Path
+from PySide6.QtCore import Qt, QSize
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton,
+    QLabel, QMessageBox, QSizePolicy, QComboBox, QProgressDialog
+)
+from PySide6.QtCore import QThread, Signal
+
+from core.views.components.QtImageViewer import QtImageViewer
+
+try:
+    import qimage2ndarray
+except ImportError:
+    qimage2ndarray = None
+
+try:
+    from cv2 import dnn_superres
+    OPENCV_SR_AVAILABLE = True
+except ImportError:
+    OPENCV_SR_AVAILABLE = False
+
+
+class UpscaleWorker(QThread):
+    """Background worker for upscaling operations."""
+
+    finished = Signal(np.ndarray)  # Emits the upscaled image
+    error = Signal(str)  # Emits error message
+    progress = Signal(int)  # Emits progress percentage (0-100)
+
+    def __init__(self, image_array, factor, method, sr_model=None):
+        super().__init__()
+        self.image_array = image_array
+        self.factor = factor
+        self.method = method
+        self.sr_model = sr_model
+        self._cancelled = False
+
+    def cancel(self):
+        """Request cancellation of the upscaling operation."""
+        self._cancelled = True
+
+    def run(self):
+        """Run the upscaling in background."""
+        try:
+            if self._cancelled:
+                return
+
+            if self.method == 'edsr' and self.sr_model is not None:
+                # Convert RGB to BGR for OpenCV
+                self.progress.emit(10)
+                if self._cancelled:
+                    return
+
+                bgr_image = cv2.cvtColor(self.image_array, cv2.COLOR_RGB2BGR)
+
+                self.progress.emit(30)
+                if self._cancelled:
+                    return
+
+                # Upscale (this is the slow part)
+                upscaled_bgr = self.sr_model.upsample(bgr_image)
+
+                self.progress.emit(80)
+                if self._cancelled:
+                    return
+
+                # Convert back to RGB
+                upscaled_rgb = cv2.cvtColor(upscaled_bgr, cv2.COLOR_BGR2RGB)
+
+                self.progress.emit(100)
+                if self._cancelled:
+                    return
+
+                self.finished.emit(upscaled_rgb)
+
+            elif self.method == 'lanczos':
+                # Fast Lanczos upscaling
+                self.progress.emit(50)
+                if self._cancelled:
+                    return
+
+                height, width = self.image_array.shape[:2]
+                new_width = int(width * self.factor)
+                new_height = int(height * self.factor)
+
+                upscaled = cv2.resize(
+                    self.image_array,
+                    (new_width, new_height),
+                    interpolation=cv2.INTER_LANCZOS4
+                )
+
+                self.progress.emit(100)
+                if self._cancelled:
+                    return
+
+                self.finished.emit(upscaled)
+
+        except Exception as e:
+            if not self._cancelled:
+                self.error.emit(str(e))
+
+
+class UpscaleDialog(QDialog):
+    """
+    Dialog for displaying and progressively upscaling image portions.
+
+    Allows users to upscale the currently visible area multiple times
+    to see enhanced detail.
+    """
+
+    # Maximum total upscale factor to prevent memory issues
+    MAX_UPSCALE_LEVEL = 32
+
+    # Maximum dimension in pixels (to prevent excessive memory usage)
+    MAX_DIMENSION = 16384
+
+    # Model URLs and paths for OpenCV DNN Super-Resolution
+    MODELS = {
+        'EDSR_x2': {
+            'url': 'https://github.com/Saafke/EDSR_Tensorflow/raw/master/models/EDSR_x2.pb',
+            'scale': 2
+        },
+        'EDSR_x3': {
+            'url': 'https://github.com/Saafke/EDSR_Tensorflow/raw/master/models/EDSR_x3.pb',
+            'scale': 3
+        },
+        'EDSR_x4': {
+            'url': 'https://github.com/Saafke/EDSR_Tensorflow/raw/master/models/EDSR_x4.pb',
+            'scale': 4
+        }
+    }
+
+    # Cache for loaded SR models
+    _sr_models = {}
+
+    def __init__(self, parent=None, image_array=None, upscale_factor=2, current_level=1, upscale_method='auto'):
+        """
+        Initialize the upscale dialog.
+
+        Args:
+            parent: Parent widget (usually the Viewer)
+            image_array (np.ndarray): Image data as numpy array (RGB)
+            upscale_factor (int): Upscale multiplier per iteration (default 2x)
+            current_level (int): Current upscale level (1 = original, 2 = 2x, 4 = 4x, etc.)
+            upscale_method (str): 'auto', 'fast', 'balanced', or 'best'
+        """
+        super().__init__(parent)
+
+        self.upscale_factor = upscale_factor
+        self.current_level = current_level
+        self.image_array = image_array
+        self.original_size = image_array.shape[:2] if image_array is not None else (0, 0)
+        self.upscale_method = upscale_method
+
+        # Detect GPU availability
+        self.gpu_available = self._check_gpu_available()
+
+        # Set up the dialog
+        self.setWindowTitle(f"Upscaled View - {current_level}x")
+        self.setModal(False)  # Non-modal so user can interact with main window
+
+        # Create UI
+        self._setup_ui()
+
+        # Display the image
+        if image_array is not None:
+            self._display_image(image_array)
+
+        # Set initial size (will be adjusted after image is loaded)
+        self.resize(1000, 800)
+
+    def _setup_ui(self):
+        """Create the dialog UI components."""
+        # Main layout
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(10, 10, 10, 10)
+
+        # Info label showing resolution
+        self.info_label = QLabel()
+        self.info_label.setAlignment(Qt.AlignCenter)
+        self.info_label.setStyleSheet("QLabel { font-weight: bold; padding: 5px; }")
+        main_layout.addWidget(self.info_label)
+
+        # Method selection layout
+        method_layout = QHBoxLayout()
+        method_label = QLabel("Upscale Method:")
+        method_layout.addWidget(method_label)
+
+        self.method_combo = QComboBox()
+        self.method_combo.addItem("Auto (Recommended)", "auto")
+        self.method_combo.addItem("Fast (Lanczos)", "fast")
+        if OPENCV_SR_AVAILABLE:
+            self.method_combo.addItem("Balanced (OpenCV EDSR)", "balanced")
+        # Don't show "Best" option until it's implemented
+        # self.method_combo.addItem("Best Quality (Real-ESRGAN) - Not Implemented", "best")
+
+        # Set current method
+        for i in range(self.method_combo.count()):
+            if self.method_combo.itemData(i) == self.upscale_method:
+                self.method_combo.setCurrentIndex(i)
+                break
+
+        self.method_combo.currentIndexChanged.connect(self._on_method_changed)
+        method_layout.addWidget(self.method_combo)
+        method_layout.addStretch()
+
+        main_layout.addLayout(method_layout)
+
+        # Image viewer (same as main viewer - supports zoom and pan)
+        self.image_viewer = QtImageViewer(window=self, parent=self)
+        self.image_viewer.setMinimumSize(400, 300)
+        self.image_viewer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        main_layout.addWidget(self.image_viewer)
+
+        # Button layout
+        button_layout = QHBoxLayout()
+        button_layout.setSpacing(10)
+
+        # Upres Again button
+        self.upres_button = QPushButton("Upres Again")
+        self.upres_button.setMinimumHeight(40)
+        self.upres_button.clicked.connect(self._on_upres_again_clicked)
+        self.upres_button.setToolTip(f"Upscale the currently visible portion by {self.upscale_factor}x")
+        button_layout.addWidget(self.upres_button)
+
+        # Quit button
+        quit_button = QPushButton("Quit")
+        quit_button.setMinimumHeight(40)
+        quit_button.clicked.connect(self.close)
+        quit_button.setToolTip("Close this upscale window")
+        button_layout.addWidget(quit_button)
+
+        main_layout.addLayout(button_layout)
+
+        self.setLayout(main_layout)
+
+    def _display_image(self, image_array):
+        """
+        Display the image in the dialog.
+
+        Args:
+            image_array (np.ndarray): Image data as numpy array (RGB or BGR)
+        """
+        if image_array is None or image_array.size == 0:
+            return
+
+        # Store the image array
+        self.image_array = image_array
+
+        # Display directly in the QtImageViewer (it accepts numpy arrays)
+        self.image_viewer.setImage(image_array)
+
+        # Update info label
+        height, width = image_array.shape[:2]
+        orig_h, orig_w = self.original_size
+        self.info_label.setText(
+            f"Resolution: {width} × {height} pixels | "
+            f"Original: {orig_w} × {orig_h} pixels | "
+            f"Upscale: {self.current_level}x | "
+            f"Use mouse wheel to zoom, right-click to pan"
+        )
+
+
+    def _get_visible_portion(self):
+        """
+        Extract the currently visible portion of the image from the viewer.
+
+        Returns:
+            np.ndarray: The visible portion of the image, or None if error
+        """
+        if self.image_array is None or self.image_array.size == 0:
+            return None
+
+        try:
+            # Get the currently visible viewport in scene coordinates
+            visible_rect = self.image_viewer.mapToScene(
+                self.image_viewer.viewport().rect()
+            ).boundingRect()
+
+            # Image dimensions
+            img_height, img_width = self.image_array.shape[:2]
+
+            # Calculate visible region bounds (scene coords map to image pixels)
+            x1 = max(0, int(visible_rect.left()))
+            y1 = max(0, int(visible_rect.top()))
+            x2 = min(img_width, int(visible_rect.right()))
+            y2 = min(img_height, int(visible_rect.bottom()))
+
+            # Ensure valid region
+            if x2 <= x1 or y2 <= y1:
+                return None
+
+            # Extract visible portion
+            visible_portion = self.image_array[y1:y2, x1:x2].copy()
+
+            return visible_portion
+
+        except Exception as e:
+            print(f"Error extracting visible portion: {e}")
+            return None
+
+    def _on_upres_again_clicked(self):
+        """Handle 'Upres Again' button click."""
+        # Get the currently visible portion
+        visible_portion = self._get_visible_portion()
+
+        if visible_portion is None or visible_portion.size == 0:
+            QMessageBox.warning(
+                self,
+                "Upscale Error",
+                "Unable to extract visible image portion."
+            )
+            return
+
+        # Check if we're at maximum upscale level
+        next_level = self.current_level * self.upscale_factor
+        if next_level > self.MAX_UPSCALE_LEVEL:
+            QMessageBox.warning(
+                self,
+                "Maximum Upscale Reached",
+                f"Maximum upscale level of {self.MAX_UPSCALE_LEVEL}x has been reached.\n"
+                f"Further upscaling is not allowed to prevent memory issues."
+            )
+            return
+
+        # Check if resulting image would be too large
+        height, width = visible_portion.shape[:2]
+        new_height = height * self.upscale_factor
+        new_width = width * self.upscale_factor
+
+        if new_height > self.MAX_DIMENSION or new_width > self.MAX_DIMENSION:
+            QMessageBox.warning(
+                self,
+                "Image Too Large",
+                f"Upscaling would result in an image of {new_width}×{new_height} pixels.\n"
+                f"Maximum allowed dimension is {self.MAX_DIMENSION} pixels.\n\n"
+                f"Try zooming in to a smaller area before upscaling."
+            )
+            return
+
+        # Check minimum size
+        if height < 10 or width < 10:
+            QMessageBox.warning(
+                self,
+                "Image Too Small",
+                f"Visible portion is too small ({width}×{height} pixels).\n"
+                f"Please zoom in to a larger area before upscaling."
+            )
+            return
+
+        # Upscale the visible portion
+        self._upscale_image_async(visible_portion, self.upscale_factor, next_level)
+
+    def _upscale_image_async(self, image_array, factor, next_level):
+        """
+        Upscale image asynchronously with progress dialog.
+
+        Args:
+            image_array (np.ndarray): Input image
+            factor (int): Upscale factor
+            next_level (int): Next upscale level for new dialog
+        """
+        if image_array is None or image_array.size == 0:
+            return
+
+        # Get current method
+        method = self.method_combo.currentData()
+
+        # Auto-select method based on image size and hardware
+        if method == 'auto':
+            method = self._auto_select_method(image_array)
+
+        # Check if we need to show progress (only for slower methods)
+        show_progress = method == 'balanced' and OPENCV_SR_AVAILABLE
+
+        # For fast methods, just do it synchronously
+        if not show_progress:
+            try:
+                upscaled_image = self._upscale_image(image_array, factor)
+                self._create_new_dialog(upscaled_image, next_level)
+            except Exception as e:
+                QMessageBox.critical(
+                    self,
+                    "Upscale Error",
+                    f"An error occurred during upscaling:\n{str(e)}"
+                )
+            return
+
+        # For EDSR, show progress dialog
+        try:
+            # Load SR model
+            sr_model = self._load_sr_model(factor)
+            if sr_model is None:
+                # Fallback to fast method
+                upscaled_image = self._upscale_lanczos(image_array, factor)
+                self._create_new_dialog(upscaled_image, next_level)
+                return
+
+            # Create progress dialog with image info
+            height, width = image_array.shape[:2]
+            new_height, new_width = height * factor, width * factor
+            progress_text = (
+                f"Upscaling image with AI enhancement...\n"
+                f"From {width}×{height} to {new_width}×{new_height} pixels\n"
+                f"This may take a few seconds."
+            )
+            self.progress_dialog = QProgressDialog(
+                progress_text,
+                "Cancel",
+                0,
+                100,
+                self
+            )
+            self.progress_dialog.setWindowTitle("Upscaling (OpenCV EDSR)")
+            self.progress_dialog.setWindowModality(Qt.WindowModal)
+            self.progress_dialog.setMinimumDuration(0)  # Show immediately for EDSR
+            self.progress_dialog.setValue(0)
+
+            # Create worker thread
+            self.upscale_worker = UpscaleWorker(
+                image_array.copy(),  # Copy to avoid threading issues
+                factor,
+                'edsr',
+                sr_model
+            )
+
+            # Store next_level for when upscaling completes
+            self._pending_next_level = next_level
+
+            # Connect signals
+            self.upscale_worker.finished.connect(self._on_upscale_finished)
+            self.upscale_worker.error.connect(self._on_upscale_error)
+            self.upscale_worker.progress.connect(self.progress_dialog.setValue)
+            self.progress_dialog.canceled.connect(self._on_upscale_canceled)
+
+            # Start upscaling
+            self.upscale_worker.start()
+
+        except Exception as e:
+            QMessageBox.critical(
+                self,
+                "Upscale Error",
+                f"Failed to start upscaling:\n{str(e)}"
+            )
+
+    def _create_new_dialog(self, upscaled_image, next_level):
+        """Create new dialog with upscaled image."""
+        if upscaled_image is None:
+            return
+
+        new_dialog = UpscaleDialog(
+            self.parent(),
+            upscaled_image,
+            upscale_factor=self.upscale_factor,
+            current_level=next_level,
+            upscale_method=self.upscale_method
+        )
+        new_dialog.show()
+
+    def _on_upscale_finished(self, upscaled_image):
+        """Handle upscaling completion."""
+        if hasattr(self, 'progress_dialog'):
+            self.progress_dialog.close()
+
+        self._create_new_dialog(upscaled_image, self._pending_next_level)
+
+    def _on_upscale_error(self, error_msg):
+        """Handle upscaling error."""
+        if hasattr(self, 'progress_dialog'):
+            self.progress_dialog.close()
+
+        QMessageBox.critical(
+            self,
+            "Upscale Error",
+            f"An error occurred during upscaling:\n{error_msg}"
+        )
+
+    def _on_upscale_canceled(self):
+        """Handle upscaling cancellation."""
+        if hasattr(self, 'upscale_worker'):
+            self.upscale_worker.cancel()
+            self.upscale_worker.wait()  # Wait for thread to finish
+
+    def _upscale_image(self, image_array, factor=2):
+        """
+        Upscale image using selected method.
+
+        Args:
+            image_array (np.ndarray): Input image
+            factor (int): Upscale factor
+
+        Returns:
+            np.ndarray: Upscaled image
+        """
+        if image_array is None or image_array.size == 0:
+            return None
+
+        # Get current method
+        method = self.method_combo.currentData()
+
+        # Auto-select method based on image size and hardware
+        if method == 'auto':
+            method = self._auto_select_method(image_array)
+
+        # Upscale using selected method
+        try:
+            if method == 'balanced' and OPENCV_SR_AVAILABLE:
+                return self._upscale_opencv_edsr(image_array, factor)
+            elif method == 'best':
+                # Real-ESRGAN not implemented yet
+                QMessageBox.warning(
+                    self,
+                    "Method Not Available",
+                    "Real-ESRGAN is not yet implemented.\nFalling back to Lanczos interpolation."
+                )
+                return self._upscale_lanczos(image_array, factor)
+            else:  # 'fast' or fallback
+                return self._upscale_lanczos(image_array, factor)
+        except Exception as e:
+            print(f"Upscaling error with method '{method}': {e}")
+            # Fallback to Lanczos
+            return self._upscale_lanczos(image_array, factor)
+
+    def _upscale_lanczos(self, image_array, factor=2):
+        """
+        Upscale using Lanczos interpolation (fast, traditional method).
+
+        Args:
+            image_array (np.ndarray): Input image
+            factor (int): Upscale factor
+
+        Returns:
+            np.ndarray: Upscaled image
+        """
+        height, width = image_array.shape[:2]
+        new_width = int(width * factor)
+        new_height = int(height * factor)
+
+        upscaled = cv2.resize(
+            image_array,
+            (new_width, new_height),
+            interpolation=cv2.INTER_LANCZOS4
+        )
+
+        return upscaled
+
+    def _upscale_opencv_edsr(self, image_array, factor=2):
+        """
+        Upscale using OpenCV DNN Super-Resolution (EDSR model).
+
+        Args:
+            image_array (np.ndarray): Input image (RGB)
+            factor (int): Upscale factor (2, 3, or 4)
+
+        Returns:
+            np.ndarray: Upscaled image
+        """
+        if not OPENCV_SR_AVAILABLE:
+            raise ImportError("OpenCV DNN Super-Resolution not available")
+
+        # Limit to supported scales
+        if factor not in [2, 3, 4]:
+            print(f"EDSR doesn't support {factor}x, falling back to Lanczos")
+            return self._upscale_lanczos(image_array, factor)
+
+        # Load model
+        sr = self._load_sr_model(factor)
+        if sr is None:
+            print("Failed to load SR model, falling back to Lanczos")
+            return self._upscale_lanczos(image_array, factor)
+
+        # Convert RGB to BGR for OpenCV
+        bgr_image = cv2.cvtColor(image_array, cv2.COLOR_RGB2BGR)
+
+        # Upscale
+        try:
+            upscaled_bgr = sr.upsample(bgr_image)
+            # Convert back to RGB
+            upscaled_rgb = cv2.cvtColor(upscaled_bgr, cv2.COLOR_BGR2RGB)
+            return upscaled_rgb
+        except Exception as e:
+            print(f"EDSR upscaling failed: {e}, falling back to Lanczos")
+            return self._upscale_lanczos(image_array, factor)
+
+    def _check_gpu_available(self):
+        """
+        Check if GPU acceleration is available.
+
+        Returns:
+            bool: True if GPU is available
+        """
+        try:
+            # Check for CUDA
+            if cv2.cuda.getCudaEnabledDeviceCount() > 0:
+                return True
+        except:
+            pass
+        return False
+
+    def _on_method_changed(self, index):
+        """Handle method selection change."""
+        method = self.method_combo.currentData()
+        self.upscale_method = method
+        print(f"Upscale method changed to: {method}")
+
+    def _auto_select_method(self, image_array):
+        """
+        Automatically select upscale method based on image size and hardware.
+
+        Args:
+            image_array (np.ndarray): Image to upscale
+
+        Returns:
+            str: Selected method ('fast', 'balanced', or 'best')
+        """
+        pixels = image_array.shape[0] * image_array.shape[1]
+
+        # Large images (> 4 megapixels) or no OpenCV SR -> use fast
+        if pixels > 4000000 or not OPENCV_SR_AVAILABLE:
+            return 'fast'
+
+        # Medium/small images with OpenCV SR -> use balanced
+        if OPENCV_SR_AVAILABLE:
+            return 'balanced'
+
+        # Fallback
+        return 'fast'
+
+    def _get_models_dir(self):
+        """
+        Get the directory for storing SR models.
+
+        Returns:
+            Path: Path to models directory
+        """
+        # Store models in app data directory
+        app_dir = Path.home() / '.adiat' / 'sr_models'
+        app_dir.mkdir(parents=True, exist_ok=True)
+        return app_dir
+
+    def _download_model(self, model_name):
+        """
+        Download SR model if not already cached.
+
+        Args:
+            model_name (str): Model name (e.g., 'EDSR_x2')
+
+        Returns:
+            Path: Path to downloaded model file, or None if failed
+        """
+        if model_name not in self.MODELS:
+            return None
+
+        model_info = self.MODELS[model_name]
+        model_path = self._get_models_dir() / f"{model_name}.pb"
+
+        # Already downloaded
+        if model_path.exists():
+            return model_path
+
+        # Download model
+        try:
+            print(f"Downloading {model_name} model...")
+
+            # Show progress dialog
+            progress = QProgressDialog(
+                f"Downloading {model_name} model...",
+                "Cancel",
+                0,
+                100,
+                self
+            )
+            progress.setWindowModality(Qt.WindowModal)
+            progress.setMinimumDuration(0)
+            progress.setValue(0)
+
+            def report_hook(block_num, block_size, total_size):
+                if progress.wasCanceled():
+                    raise Exception("Download cancelled")
+                if total_size > 0:
+                    percent = min(100, int(block_num * block_size * 100 / total_size))
+                    progress.setValue(percent)
+
+            urllib.request.urlretrieve(
+                model_info['url'],
+                str(model_path),
+                reporthook=report_hook
+            )
+
+            progress.setValue(100)
+            print(f"Model downloaded to: {model_path}")
+            return model_path
+
+        except Exception as e:
+            print(f"Failed to download model {model_name}: {e}")
+            if model_path.exists():
+                model_path.unlink()  # Remove partial download
+            return None
+
+    def _load_sr_model(self, scale):
+        """
+        Load OpenCV Super-Resolution model.
+
+        Args:
+            scale (int): Upscale factor (2, 3, or 4)
+
+        Returns:
+            dnn_superres.DnnSuperResImpl: Loaded model, or None if failed
+        """
+        if not OPENCV_SR_AVAILABLE:
+            return None
+
+        model_name = f'EDSR_x{scale}'
+
+        # Check cache
+        if model_name in self._sr_models:
+            return self._sr_models[model_name]
+
+        # Download model if needed
+        model_path = self._download_model(model_name)
+        if model_path is None:
+            return None
+
+        try:
+            # Create SR object
+            sr = dnn_superres.DnnSuperResImpl_create()
+
+            # Read and set model
+            sr.readModel(str(model_path))
+            sr.setModel("edsr", scale)
+
+            # Cache the model
+            self._sr_models[model_name] = sr
+
+            print(f"Loaded SR model: {model_name}")
+            return sr
+
+        except Exception as e:
+            print(f"Failed to load SR model {model_name}: {e}")
+            return None
+
+    def keyPressEvent(self, event):
+        """Handle keyboard shortcuts."""
+        # 'E' key to upscale again
+        if event.key() == Qt.Key_E:
+            self._on_upres_again_clicked()
+            event.accept()
+        # 'Q' key to quit
+        elif event.key() == Qt.Key_Q:
+            self.close()
+            event.accept()
+        else:
+            super().keyPressEvent(event)

--- a/app/core/controllers/viewer/coordinates/CoordinateController.py
+++ b/app/core/controllers/viewer/coordinates/CoordinateController.py
@@ -171,13 +171,13 @@ class CoordinateController:
         if not coord_text:
             return
         QApplication.clipboard().setText(str(coord_text))
-        self.parent._show_toast("Coordinates copied", 3000, color="#00C853")
+        self.parent.status_controller.show_toast("Coordinates copied", 3000, color="#00C853")
 
     def open_in_maps(self):
         """Open coordinates in Google Maps."""
         lat_lon = self.get_decimals_or_parse()
         if not lat_lon:
-            self.parent._show_toast("Coordinates unavailable", 3000, color="#F44336")
+            self.parent.status_controller.show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
         lat, lon = lat_lon
         url = QUrl(f"https://www.google.com/maps?q={lat},{lon}")
@@ -187,7 +187,7 @@ class CoordinateController:
         """Open coordinates in Google Earth."""
         lat_lon = self.get_decimals_or_parse()
         if not lat_lon:
-            self.parent._show_toast("Coordinates unavailable", 3000, color="#F44336")
+            self.parent.status_controller.show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
 
         lat, lon = lat_lon
@@ -244,7 +244,7 @@ class CoordinateController:
         """Share coordinates via WhatsApp."""
         lat_lon = self.get_decimals_or_parse()
         if not lat_lon:
-            self.parent._show_toast("Coordinates unavailable", 3000, color="#F44336")
+            self.parent.status_controller.show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
         lat, lon = lat_lon
         maps = f"https://www.google.com/maps?q={lat},{lon}"
@@ -256,7 +256,7 @@ class CoordinateController:
         """Share coordinates via Telegram."""
         lat_lon = self.get_decimals_or_parse()
         if not lat_lon:
-            self.parent._show_toast("Coordinates unavailable", 3000, color="#F44336")
+            self.parent.status_controller.show_toast("Coordinates unavailable", 3000, color="#F44336")
             return
         lat, lon = lat_lon
         maps = f"https://www.google.com/maps?q={lat},{lon}"
@@ -292,11 +292,12 @@ class CoordinateController:
 
             # Get the drone orientation (yaw/bearing)
             image_service = ImageService(image_path, mask_path)
+            # Use get_drone_orientation() to match the Drone Orientation shown in the status bar
             direction = image_service.get_drone_orientation()
 
             if direction is None:
                 # Show message that no bearing info is available
-                self.parent._show_toast("No bearing info available", 3000, color="#F44336")
+                self.parent.status_controller.show_toast("No bearing info available", 3000, color="#F44336")
                 return
 
             # Get the current image array
@@ -372,7 +373,7 @@ class CoordinateController:
 
         except Exception as e:
             self.logger.error(f"Error showing north-oriented image: {e}")
-            self.parent._show_toast(f"Error: {str(e)}", 3000, color="#F44336")
+            self.parent.status_controller.show_toast(f"Error: {str(e)}", 3000, color="#F44336")
 
     def update_current_coordinates(self, decimal_coords):
         """Update the current decimal coordinates.

--- a/app/core/controllers/viewer/exports/CalTopoExportController.py
+++ b/app/core/controllers/viewer/exports/CalTopoExportController.py
@@ -200,7 +200,8 @@ class CalTopoExportController:
                 image_center = (width/2, height/2)
 
                 # Get bearing
-                bearing = image_service.get_drone_orientation()
+                # Use get_image_bearing() which accounts for both Flight Yaw and Gimbal Yaw
+                bearing = image_service.get_image_bearing()
                 if bearing is None:
                     bearing = 0  # Default to north
 

--- a/app/core/services/KMLGeneratorService.py
+++ b/app/core/services/KMLGeneratorService.py
@@ -1,9 +1,13 @@
 import simplekml
+import colorsys
+import numpy as np
 from helpers.LocationInfo import LocationInfo
+from helpers.MetaDataHelper import MetaDataHelper
+from core.services.ImageService import ImageService
 
 
 class KMLGeneratorService:
-    """Service to generate a KML file with points representing locations where images with areas of interest were taken."""
+    """Service to generate a KML file with placemarks for flagged AOIs."""
 
     def __init__(self):
         """
@@ -11,18 +15,28 @@ class KMLGeneratorService:
         """
         self.kml = simplekml.Kml()
 
-    def add_points(self, points):
+    def add_aoi_placemark(self, name, lat, lon, description, color_rgb=None):
         """
-        Adds a list of geographic points to the KML document.
+        Adds an AOI placemark to the KML document with optional color.
 
         Args:
-            points (list of dict): A list of dictionaries, each containing:
-                - 'name' (str): The name/label for the point.
-                - 'lat' (float): Latitude of the point.
-                - 'long' (float): Longitude of the point.
+            name (str): The name/label for the placemark.
+            lat (float): Latitude of the point.
+            lon (float): Longitude of the point.
+            description (str): Description text for the placemark.
+            color_rgb (tuple): Optional RGB color tuple (R, G, B) for the icon.
         """
-        for point in points:
-            self.kml.newpoint(name=point["name"], coords=[(point["long"], point["lat"])])
+        pnt = self.kml.newpoint(name=name, coords=[(lon, lat)])
+        pnt.description = description
+
+        # Set icon color if provided
+        if color_rgb:
+            # KML uses ABGR format (Alpha, Blue, Green, Red) in hex
+            r, g, b = color_rgb
+            # Full opacity (FF) + BGR
+            kml_color = f'ff{b:02x}{g:02x}{r:02x}'
+            pnt.style.iconstyle.color = kml_color
+            pnt.style.iconstyle.scale = 1.2
 
     def save_kml(self, path):
         """
@@ -35,27 +49,167 @@ class KMLGeneratorService:
 
     def generate_kml_export(self, images, output_path):
         """
-        Filters and extracts GPS coordinates from a list of images, then generates and saves a KML file.
+        Generates KML file with placemarks for each flagged AOI.
 
         Args:
-            images (list of dict): List of image metadata dictionaries. Each should contain:
-                - 'name' (str): Image name.
-                - 'path' (str): Path to the image file.
-                - 'hidden' (bool): Whether the image is marked as hidden.
-
+            images (list of dict): List of image metadata dictionaries with flagged AOIs.
             output_path (str): The path to save the generated KML file.
         """
-        kml_points = []
-        for image in images:
-            if image['hidden']:
+        for img_idx, image in enumerate(images):
+            # Skip hidden images
+            if image.get('hidden', False):
                 continue
-            gps_coords = LocationInfo.get_gps(full_path=image['path'])
-            if gps_coords:
-                point = {
-                    "name": image['name'],
-                    "long": gps_coords['longitude'],
-                    "lat": gps_coords['latitude']
-                }
-                kml_points.append(point)
-        self.add_points(kml_points)
+
+            image_name = image.get('name', f'Image {img_idx + 1}')
+            image_path = image.get('path', '')
+
+            # Get image GPS coordinates and metadata
+            try:
+                # Create ImageService to extract EXIF data
+                image_service = ImageService(image_path, image.get('mask_path', ''))
+
+                # Get GPS from EXIF data
+                exif_data = MetaDataHelper.get_exif_data_piexif(image_path)
+                image_gps = LocationInfo.get_gps(exif_data=exif_data)
+
+                if not image_gps:
+                    continue
+
+                # Get image dimensions and metadata
+                img_array = image_service.img_array
+                height, width = img_array.shape[:2]
+                image_center = (width/2, height/2)
+                bearing = image_service.get_drone_orientation() or 0
+                gsd_cm = image_service.get_average_gsd()
+
+                # Check gimbal angle
+                _, gimbal_pitch = image_service.get_gimbal_orientation()
+                is_nadir = True
+                if gimbal_pitch is not None:
+                    is_nadir = (-95 <= gimbal_pitch <= -85)
+
+            except Exception:
+                continue
+
+            # Process each flagged AOI
+            aois = image.get('areas_of_interest', [])
+            for aoi_idx, aoi in enumerate(aois):
+                # Only export flagged AOIs
+                if not aoi.get('flagged', False):
+                    continue
+
+                center = aoi.get('center', [0, 0])
+                area = aoi.get('area', 0)
+                radius = aoi.get('radius', 0)
+
+                # Calculate AOI-specific GPS coordinates with fallback
+                aoi_lat = image_gps['latitude']
+                aoi_lon = image_gps['longitude']
+                gps_note = ""
+
+                # Try to calculate precise AOI GPS if conditions are met
+                if gsd_cm and is_nadir:
+                    try:
+                        from core.controllers.viewer.gps.GPSMapController import GPSMapController
+                        gps_controller = GPSMapController(None)
+
+                        aoi_gps = gps_controller.calculate_aoi_gps_coordinates(
+                            image_gps,
+                            center,
+                            image_center,
+                            gsd_cm,
+                            bearing
+                        )
+
+                        if aoi_gps:
+                            aoi_lat = aoi_gps['latitude']
+                            aoi_lon = aoi_gps['longitude']
+                            gps_note = f"Precise AOI GPS (GSD: {gsd_cm:.2f} cm/px, Bearing: {bearing:.1f}°)\n"
+                        else:
+                            gps_note = "Image GPS (calculation failed)\n"
+                    except Exception:
+                        gps_note = "Image GPS (calculation error)\n"
+                else:
+                    # Missing required data - use image GPS
+                    reasons = []
+                    if not gsd_cm:
+                        reasons.append("no GSD")
+                    if not is_nadir and gimbal_pitch is not None:
+                        reasons.append(f"gimbal {gimbal_pitch:.1f}°")
+                    elif gimbal_pitch is None:
+                        reasons.append("no gimbal data")
+
+                    gps_note = f"Image GPS ({', '.join(reasons) if reasons else 'missing data'})\n"
+
+                # Calculate color information
+                color_info = ""
+                marker_rgb = None
+                try:
+                    # Collect RGB values within the AOI
+                    colors = []
+                    cx, cy = center
+
+                    # If we have detected pixels, use those
+                    if 'detected_pixels' in aoi and aoi['detected_pixels']:
+                        for pixel in aoi['detected_pixels']:
+                            if isinstance(pixel, (list, tuple)) and len(pixel) >= 2:
+                                px, py = int(pixel[0]), int(pixel[1])
+                                if 0 <= py < height and 0 <= px < width:
+                                    colors.append(img_array[py, px])
+                    # Otherwise sample within the circle
+                    else:
+                        for y in range(max(0, cy - radius), min(height, cy + radius + 1)):
+                            for x in range(max(0, cx - radius), min(width, cx + radius + 1)):
+                                if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                                    colors.append(img_array[y, x])
+
+                    if colors:
+                        # Calculate average RGB
+                        avg_rgb = np.mean(colors, axis=0).astype(int)
+                        r, g, b = int(avg_rgb[0]), int(avg_rgb[1]), int(avg_rgb[2])
+
+                        # Convert to HSV
+                        h, _, _ = colorsys.rgb_to_hsv(r / 255.0, g / 255.0, b / 255.0)
+
+                        # Create full saturation and full value version
+                        full_sat_rgb = colorsys.hsv_to_rgb(h, 1.0, 1.0)
+                        marker_rgb = tuple(int(c * 255) for c in full_sat_rgb)
+
+                        # Format color info
+                        hex_color = '#{:02x}{:02x}{:02x}'.format(*marker_rgb)
+                        hue_degrees = int(h * 360)
+                        color_info = f"Color: Hue: {hue_degrees}° {hex_color}\n"
+
+                except Exception:
+                    pass
+
+                # Create placemark name
+                placemark_name = f"{image_name} - AOI {aoi_idx + 1}"
+
+                # Get user comment if available
+                user_comment = aoi.get('user_comment', '')
+
+                # Build description
+                description = ""
+                if user_comment:
+                    description = f'"{user_comment}"\n\n'
+
+                description += (
+                    f"Flagged AOI from {image_name}\n"
+                    f"{gps_note}"
+                    f"AOI Index: {aoi_idx + 1}\n"
+                    f"Center: ({center[0]}, {center[1]})\n"
+                    f"Area: {area:.0f} pixels\n"
+                    f"{color_info}"
+                )
+
+                # Add placemark to KML
+                self.add_aoi_placemark(
+                    placemark_name,
+                    aoi_lat,
+                    aoi_lon,
+                    description,
+                    marker_rgb
+                )
+
         self.save_kml(output_path)

--- a/app/core/services/KMLGeneratorService.py
+++ b/app/core/services/KMLGeneratorService.py
@@ -79,7 +79,8 @@ class KMLGeneratorService:
                 img_array = image_service.img_array
                 height, width = img_array.shape[:2]
                 image_center = (width/2, height/2)
-                bearing = image_service.get_drone_orientation() or 0
+                # Use get_image_bearing() which accounts for both Flight Yaw and Gimbal Yaw
+                bearing = image_service.get_image_bearing() or 0
                 gsd_cm = image_service.get_average_gsd()
 
                 # Check gimbal angle

--- a/app/core/services/PdfGeneratorService.py
+++ b/app/core/services/PdfGeneratorService.py
@@ -893,7 +893,8 @@ class PdfGeneratorService:
                 return None
 
             # Get bearing and GSD
-            bearing = image_service.get_drone_orientation() or 0
+            # Use get_image_bearing() which accounts for both Flight Yaw and Gimbal Yaw
+            bearing = image_service.get_image_bearing() or 0
             gsd_cm = image_service.get_average_gsd()
             if not gsd_cm:
                 return None

--- a/app/core/services/PdfGeneratorService.py
+++ b/app/core/services/PdfGeneratorService.py
@@ -8,13 +8,20 @@ from reportlab.platypus.doctemplate import PageTemplate, BaseDocTemplate
 from reportlab.platypus.frames import Frame
 
 from PySide6.QtGui import QPixmap
-from PySide6.QtCore import QBuffer
+from PySide6.QtCore import QBuffer, QUrl, QEventLoop
+from PySide6.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
 
 import os
 import cv2
+import numpy as np
 from io import BytesIO
 from datetime import datetime
 import re
+import math
+import colorsys
+import requests
+from pathlib import Path
+import tempfile
 
 from helpers.LocationInfo import LocationInfo
 from helpers.ColorUtils import ColorUtils
@@ -28,29 +35,51 @@ import traceback
 class PDFDocTemplate(BaseDocTemplate):
     """Custom document template with TOC support."""
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, organization="[ORGANIZATION]", **kwargs):
         """
         Initialize a custom document template.
 
         Args:
             filename (str): The file path for the generated PDF document.
+            organization (str): Organization name for the footer
             **kwargs: Additional arguments for the BaseDocTemplate class.
         """
         self.allowSplitting = 0
+        self.organization = organization
         BaseDocTemplate.__init__(self, filename, **kwargs)
 
         # Letter dimensions in cm
         page_width, page_height = letter  # (21.59 cm, 27.94 cm)
         min_margin = 0.635 * cm
 
-        # Frame dimensions
-        frame_width = page_width - (2 * min_margin)  # Minimize left and right margins
-        frame_height = page_height - (2 * min_margin)  # Optional: Minimize top and bottom margins
-        x_margin = min_margin  # Left margin
-        y_margin = min_margin  # Bottom margin
+        # Frame dimensions - leave space at bottom for footer
+        footer_space = 1.5 * cm
+        frame_width = page_width - (2 * min_margin)
+        frame_height = page_height - (2 * min_margin) - footer_space
+        x_margin = min_margin
+        y_margin = min_margin + footer_space
 
-        template = PageTemplate('normal', [Frame(x_margin, y_margin, frame_width, frame_height, id='F1')])
+        template = PageTemplate('normal', [Frame(x_margin, y_margin, frame_width, frame_height, id='F1')],
+                               onPage=self.add_footer)
         self.addPageTemplates(template)
+
+    def add_footer(self, canvas, doc):
+        """
+        Add footer to each page.
+
+        Args:
+            canvas: The canvas object to draw on
+            doc: The document object
+        """
+        canvas.saveState()
+        page_width, page_height = letter
+
+        # Draw footer text
+        footer_text = f"CONFIDENTIAL | {self.organization} | Page {doc.page}"
+        canvas.setFont('Helvetica', 10)
+        canvas.drawCentredString(page_width / 2, 0.5 * cm, footer_text)
+
+        canvas.restoreState()
 
     def afterFlowable(self, flowable):
         """
@@ -82,16 +111,20 @@ class PDFDocTemplate(BaseDocTemplate):
 class PdfGeneratorService:
     """Service for generating PDF reports from analysis results."""
 
-    def __init__(self, viewer):
+    def __init__(self, viewer, organization="", search_name=""):
         """
         Initialize the PDF generator service.
 
         Args:
             viewer: Reference to the viewer instance for accessing necessary data and methods.
+            organization: Organization name for the report
+            search_name: Search/mission name for the report
         """
 
         self.logger = LoggerService()
         self.viewer = viewer
+        self.organization = organization if organization else "[ORGANIZATION]"
+        self.search_name = search_name if search_name else "Analysis"
         self.story = []
         self.doc = None
         self._initialize_styles()
@@ -115,7 +148,7 @@ class PdfGeneratorService:
                 if not os.path.exists(img['path']):
                     raise FileNotFoundError(f"Image not found: {img['path']}")
 
-            self.doc = PDFDocTemplate(output_path, pagesize=letter)
+            self.doc = PDFDocTemplate(output_path, organization=self.organization, pagesize=letter)
 
             # Add title with date/time and placeholder logo
             current_datetime = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -136,7 +169,16 @@ class PdfGeneratorService:
             self.story.append(logo)
             self.story.append(Spacer(1, 12))
 
-            self.story.append(Paragraph(f"ADIAT Analysis Report {current_datetime}", self.h1))
+            self.story.append(Paragraph(f"{self.organization} - {self.search_name}<br/>{current_datetime}", self.h1))
+            self.story.append(Spacer(1, 20))
+
+            # Add overview map
+            map_bytes = self._generate_overview_map()
+            if map_bytes:
+                map_img = Image(map_bytes, width=7*inch, height=5.25*inch)
+                map_img.hAlign = 'CENTER'
+                self.story.append(map_img)
+                self.story.append(Spacer(1, 20))
 
             # Add TOC
             toc = self._create_toc()
@@ -222,32 +264,133 @@ class PdfGeneratorService:
 
     def _add_image_details(self):
         """
-        Add details about images to the report.
+        Add detailed AOI pages to the report.
+        Each flagged AOI gets its own page with zoomed views and metadata.
         """
-        visible_images = [img for img in self.viewer.images if not img.get('hidden', False)]
-        self.story.append(Paragraph(f"Images ({len(visible_images)})", self.h2))
-        for img in visible_images:
-            image_service = ImageService(img['path'])
-            if img.get('hidden', True):
+        identifier_color = self.viewer.settings.get('identifier_color', (255, 255, 0))
+
+        for img in self.viewer.images:
+            if img.get('hidden', False):
                 continue
 
-            gps_coords = LocationInfo.get_gps(full_path=img['path'])
-            info = {}
-            if gps_coords:
-                position = image_service.get_position(self.viewer.position_format)
-                info['Location'] = position
-            info['AGL'] = f"{image_service.get_relative_altitude(self.viewer.distance_unit)}{self.viewer.distance_unit}"
-            info['Drone Orientation'] = f"{image_service.get_drone_orientation()}°"
-            info['Estimated Average GSD'] = f"{image_service.get_average_gsd()}cm/px"
-            info_str = " | ".join(f"{key}: {value}" for key, value in info.items())
-            self.story.append(Paragraph(img['name'], self.h3))
-            self.story.append(Paragraph(info_str))
+            # Only process images with flagged AOIs
+            flagged_aois = [aoi for aoi in img.get('areas_of_interest', []) if aoi.get('flagged', False)]
+            if not flagged_aois:
+                continue
 
-            self.story.append(Spacer(1, 5))
-            self._add_full_image(img)
-            self.story.append(Spacer(1, 10))
-            self._add_areas_of_interest(img)
-            self.story.append(PageBreak())
+            # Get image path (use 'path' field which viewer uses for display)
+            image_path = img.get('path', '')
+            mask_path = img.get('mask_path', '')
+
+            # Get original image path for GPS metadata
+            original_path = img.get('original_path', image_path) if 'original_path' in img else image_path
+
+            # Load image using ImageService (same as viewer)
+            image_service = ImageService(image_path, mask_path)
+
+            # Get img_array for color calculations (matches viewer's current_image_array)
+            display_img_array = image_service.img_array  # Already in RGB format
+
+            # Load original image for rotation/zooming
+            img_array = cv2.imread(original_path)
+            if img_array is None:
+                continue
+
+            # Get image metadata
+            bearing = image_service.get_drone_orientation() or 0
+
+            # Get GPS and other metadata from original image
+            gps_coords = LocationInfo.get_gps(full_path=original_path)
+            position_str = image_service.get_position(self.viewer.position_format) if gps_coords else "N/A"
+            agl_str = f"{image_service.get_relative_altitude(self.viewer.distance_unit)}{self.viewer.distance_unit}"
+            orientation_str = f"{bearing}°"
+            gsd_str = f"{image_service.get_average_gsd()}cm/px"
+
+            # Process each flagged AOI
+            for aoi_idx, aoi in enumerate(flagged_aois):
+                # Get original source image path from the image name
+                original_source_path = self._find_original_image_from_name(img['name'])
+                if original_source_path and os.path.exists(original_source_path):
+                    # Re-load metadata from original source using same method as viewer
+                    original_image_service = ImageService(original_source_path, '')
+                    # Use get_position just like the viewer does
+                    position_str = original_image_service.get_position(self.viewer.position_format)
+                    if not position_str:
+                        position_str = "N/A"
+                    agl_str = f"{original_image_service.get_relative_altitude(self.viewer.distance_unit)}{self.viewer.distance_unit}"
+                    orientation_str = f"{original_image_service.get_drone_orientation() or 0}°"
+                    gsd_str = f"{original_image_service.get_average_gsd()}cm/px"
+                else:
+                    # Fallback to existing values
+                    position_str = position_str if position_str != "N/A" else position_str
+
+                # Create header with metadata
+                header_text = f"<b>{img['name']}</b><br/>"
+                header_text += f"GPS Coordinates: {position_str} (camera's position, not ground location) | "
+                header_text += f"AGL: {agl_str} | Drone Orientation: {orientation_str} | Estimated Average GSD: {gsd_str}"
+                self.story.append(Paragraph(header_text, self.styles['Normal']))
+                self.story.append(Spacer(1, 10))
+
+                # Create 0x (full image, north-up) - top half, edge to edge
+                full_img, full_aoi_pos = self._create_full_rotated_image(
+                    img_array, aoi, bearing, identifier_color
+                )
+
+                # Create 3x and 6x images (without circles - they'll be added in composite)
+                medium_img, medium_aoi_pos = self._create_zoomed_aoi_image(
+                    img_array, aoi, 3, bearing, identifier_color, draw_circle=False
+                )
+                closeup_img, closeup_aoi_pos = self._create_zoomed_aoi_image(
+                    img_array, aoi, 6, bearing, identifier_color, draw_circle=False
+                )
+
+                # Create composite image with connector lines between images
+                if full_img is not None and medium_img is not None and closeup_img is not None:
+                    composite_img = self._create_composite_with_connectors(
+                        full_img, full_aoi_pos,
+                        medium_img, medium_aoi_pos,
+                        closeup_img, closeup_aoi_pos,
+                        aoi['radius']
+                    )
+
+                    # Add composite image
+                    _, buffer = cv2.imencode('.jpg', composite_img, [cv2.IMWRITE_JPEG_QUALITY, 90])
+                    composite_bytes = BytesIO(buffer)
+
+                    # Use full page width
+                    composite_img_obj = Image(composite_bytes, width=7.5*inch, height=6*inch)
+                    composite_img_obj.hAlign = 'CENTER'
+                    self.story.append(composite_img_obj)
+                    self.story.append(Spacer(1, 10))
+
+                # Add additional metadata
+                metadata_lines = []
+
+                # Add AOI GPS coordinates if available
+                aoi_gps = self._calculate_aoi_gps(img, aoi)
+                if aoi_gps:
+                    aoi_gps_str = f"{aoi_gps['latitude']:.6f}, {aoi_gps['longitude']:.6f}"
+                    metadata_lines.append(f"<b>Estimated AOI GPS Location:</b> {aoi_gps_str}")
+
+                metadata_lines.append(f"<b>AOI Pixel Area:</b> {aoi.get('area', 0):.0f}")
+
+                # Add average color info from displayed image (matching viewer behavior)
+                avg_color_info = self._get_aoi_average_info(display_img_array, aoi)
+                if avg_color_info:
+                    metadata_lines.append(f"<b>Average Color:</b> {avg_color_info}")
+
+                # Add user comment
+                user_comment = aoi.get('user_comment', '')
+                if user_comment:
+                    metadata_lines.append(f"<b>Comment:</b> {user_comment}")
+
+                # Add metadata as paragraph
+                if metadata_lines:
+                    metadata_text = "<br/>".join(metadata_lines)
+                    self.story.append(Paragraph(metadata_text, self.styles['Normal']))
+
+                # Page break between AOIs
+                self.story.append(PageBreak())
 
     def _add_full_image(self, img):
         """
@@ -385,3 +528,875 @@ class PdfGeneratorService:
             alignment=0,
             spaceAfter=0
         )
+
+    def _generate_overview_map(self):
+        """
+        Generate an overview map showing all images and flagged AOIs with map tile background.
+
+        Returns:
+            BytesIO: Image bytes of the overview map, or None if no GPS data
+        """
+        try:
+            # Collect GPS data for ALL images (not just flagged)
+            gps_locations = []
+            identifier_color = self.viewer.settings.get('identifier_color', (255, 255, 0))
+
+            # Get ALL images (use all_images_for_map if available, otherwise filtered images)
+            all_images = getattr(self, 'all_images_for_map', self.viewer.images)
+
+            for idx, img in enumerate(all_images):
+                # Include hidden images in the map
+
+                # Get GPS coords from original image path
+                image_path = img.get('original_path', img['path']) if 'original_path' in img else img['path']
+                exif_data = MetaDataHelper.get_exif_data_piexif(image_path)
+                gps_coords = LocationInfo.get_gps(exif_data=exif_data)
+
+                if not gps_coords:
+                    continue
+
+                # Check for flagged AOIs
+                has_flagged = False
+                flagged_aoi_coords = []
+                if 'areas_of_interest' in img:
+                    for aoi in img['areas_of_interest']:
+                        if aoi.get('flagged', False):
+                            has_flagged = True
+                            # Calculate AOI GPS coordinates if possible
+                            aoi_gps = self._calculate_aoi_gps(img, aoi)
+                            if aoi_gps:
+                                flagged_aoi_coords.append(aoi_gps)
+
+                gps_locations.append({
+                    'lat': gps_coords['latitude'],
+                    'lon': gps_coords['longitude'],
+                    'has_flagged': has_flagged,
+                    'flagged_aois': flagged_aoi_coords,
+                    'name': img.get('name', f'Image {idx}')
+                })
+
+            if not gps_locations:
+                return None
+
+            # Calculate bounds
+            lats = [loc['lat'] for loc in gps_locations]
+            lons = [loc['lon'] for loc in gps_locations]
+
+            # Add flagged AOI coordinates to bounds
+            for loc in gps_locations:
+                for aoi in loc['flagged_aois']:
+                    lats.append(aoi['latitude'])
+                    lons.append(aoi['longitude'])
+
+            min_lat, max_lat = min(lats), max(lats)
+            min_lon, max_lon = min(lons), max(lons)
+
+            # Add padding (10% of range)
+            lat_range = max_lat - min_lat or 0.01
+            lon_range = max_lon - min_lon or 0.01
+            min_lat -= lat_range * 0.1
+            max_lat += lat_range * 0.1
+            min_lon -= lon_range * 0.1
+            max_lon += lon_range * 0.1
+
+            # Map image dimensions
+            img_width, img_height = 2000, 1500
+
+            # Download and composite map tiles as background
+            map_img = self._download_map_tiles(min_lat, max_lat, min_lon, max_lon, img_width, img_height)
+
+            def lat_lon_to_pixel(lat, lon):
+                """Convert lat/lon to pixel coordinates."""
+                x = int((lon - min_lon) / (max_lon - min_lon) * img_width)
+                y = int((max_lat - lat) / (max_lat - min_lat) * img_height)
+                return x, y
+
+            # Draw connections between points (chronologically)
+            for i in range(len(gps_locations) - 1):
+                pt1 = lat_lon_to_pixel(gps_locations[i]['lat'], gps_locations[i]['lon'])
+                pt2 = lat_lon_to_pixel(gps_locations[i+1]['lat'], gps_locations[i+1]['lon'])
+                cv2.line(map_img, pt1, pt2, (255, 255, 255), 3)  # White line with border
+                cv2.line(map_img, pt1, pt2, (150, 150, 150), 2)
+
+            # Draw image locations
+            for loc in gps_locations:
+                pt = lat_lon_to_pixel(loc['lat'], loc['lon'])
+                # Use different colors based on whether image has flagged AOIs
+                if loc['has_flagged']:
+                    cv2.circle(map_img, pt, 12, (0, 100, 255), -1)  # Orange for images with flagged AOIs
+                    cv2.circle(map_img, pt, 14, (0, 0, 0), 2)  # Black outline
+                else:
+                    cv2.circle(map_img, pt, 8, (100, 100, 100), -1)  # Gray for images without flagged AOIs
+                    cv2.circle(map_img, pt, 10, (255, 255, 255), 2)  # White outline
+
+                # Draw flagged AOI markers
+                for aoi in loc['flagged_aois']:
+                    aoi_pt = lat_lon_to_pixel(aoi['latitude'], aoi['longitude'])
+                    # Use identifier color for AOI markers
+                    color_bgr = (identifier_color[2], identifier_color[1], identifier_color[0])  # RGB to BGR
+                    cv2.circle(map_img, aoi_pt, 8, color_bgr, -1)
+                    cv2.circle(map_img, aoi_pt, 10, (0, 0, 0), 2)
+
+            # Add north arrow with white background
+            arrow_x, arrow_y = img_width - 80, 80
+            cv2.circle(map_img, (arrow_x, arrow_y + 20), 35, (255, 255, 255), -1)
+            cv2.circle(map_img, (arrow_x, arrow_y + 20), 35, (0, 0, 0), 2)
+            cv2.arrowedLine(map_img, (arrow_x, arrow_y + 40), (arrow_x, arrow_y), (0, 0, 0), 3, tipLength=0.3)
+            cv2.putText(map_img, 'N', (arrow_x - 10, arrow_y - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 0, 0), 2)
+
+            # Add title with white background
+            title_text = 'GPS Overview Map'
+            (text_width, text_height), baseline = cv2.getTextSize(title_text, cv2.FONT_HERSHEY_SIMPLEX, 1.2, 2)
+            cv2.rectangle(map_img, (10, 10), (30 + text_width, 50 + text_height), (255, 255, 255), -1)
+            cv2.rectangle(map_img, (10, 10), (30 + text_width, 50 + text_height), (0, 0, 0), 2)
+            cv2.putText(map_img, title_text, (20, 40), cv2.FONT_HERSHEY_SIMPLEX, 1.2, (0, 0, 0), 2)
+
+            # Add legend with white background
+            legend_x, legend_y_start = 20, img_height - 120
+            cv2.rectangle(map_img, (legend_x - 10, legend_y_start - 10),
+                         (350, img_height - 20), (255, 255, 255), -1)
+            cv2.rectangle(map_img, (legend_x - 10, legend_y_start - 10),
+                         (350, img_height - 20), (0, 0, 0), 2)
+
+            legend_y = legend_y_start
+            cv2.circle(map_img, (legend_x + 20, legend_y), 12, (0, 100, 255), -1)
+            cv2.circle(map_img, (legend_x + 20, legend_y), 14, (0, 0, 0), 2)
+            cv2.putText(map_img, 'Images with flagged AOIs', (legend_x + 40, legend_y + 5),
+                       cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
+
+            legend_y += 30
+            cv2.circle(map_img, (legend_x + 20, legend_y), 8, (100, 100, 100), -1)
+            cv2.circle(map_img, (legend_x + 20, legend_y), 10, (255, 255, 255), 2)
+            cv2.putText(map_img, 'Images without flagged AOIs', (legend_x + 40, legend_y + 5),
+                       cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
+
+            legend_y += 30
+            color_bgr = (identifier_color[2], identifier_color[1], identifier_color[0])
+            cv2.circle(map_img, (legend_x + 20, legend_y), 8, color_bgr, -1)
+            cv2.circle(map_img, (legend_x + 20, legend_y), 10, (0, 0, 0), 2)
+            cv2.putText(map_img, 'Flagged AOI locations', (legend_x + 40, legend_y + 5),
+                       cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 0), 1)
+
+            # Encode to bytes
+            _, buffer = cv2.imencode('.jpg', map_img, [cv2.IMWRITE_JPEG_QUALITY, 95])
+            return BytesIO(buffer)
+
+        except Exception as e:
+            self.logger.error(f"Error generating overview map: {e}")
+            return None
+
+    def _download_map_tiles(self, min_lat, max_lat, min_lon, max_lon, img_width, img_height):
+        """
+        Download and composite map tiles for the given bounds.
+
+        Args:
+            min_lat, max_lat, min_lon, max_lon: Geographic bounds
+            img_width, img_height: Target image dimensions
+
+        Returns:
+            np.ndarray: Composited map image
+        """
+        try:
+            # Tile size (standard for OSM and ESRI)
+            tile_size = 256
+
+            # Calculate appropriate zoom level
+            zoom = self._calculate_tile_zoom(min_lat, max_lat, min_lon, max_lon, img_width, img_height, tile_size)
+
+            # Convert bounds to tile coordinates
+            min_tile_x, max_tile_y = self._lat_lon_to_tile(min_lat, min_lon, zoom)
+            max_tile_x, min_tile_y = self._lat_lon_to_tile(max_lat, max_lon, zoom)
+
+            # Ensure correct order
+            if min_tile_x > max_tile_x:
+                min_tile_x, max_tile_x = max_tile_x, min_tile_x
+            if min_tile_y > max_tile_y:
+                min_tile_y, max_tile_y = max_tile_y, min_tile_y
+
+            # Calculate number of tiles needed
+            num_tiles_x = max_tile_x - min_tile_x + 1
+            num_tiles_y = max_tile_y - min_tile_y + 1
+
+            # Create canvas for tiles
+            canvas_width = num_tiles_x * tile_size
+            canvas_height = num_tiles_y * tile_size
+            tile_canvas = np.ones((canvas_height, canvas_width, 3), dtype=np.uint8) * 245
+
+            # Setup cache directory
+            cache_dir = Path(tempfile.gettempdir()) / "adiat_map_cache"
+            cache_dir.mkdir(exist_ok=True)
+
+            # Download and place tiles
+            for ty in range(min_tile_y, max_tile_y + 1):
+                for tx in range(min_tile_x, max_tile_x + 1):
+                    tile_img = self._get_tile(tx, ty, zoom, cache_dir)
+                    if tile_img is not None:
+                        # Calculate position in canvas
+                        x_offset = (tx - min_tile_x) * tile_size
+                        y_offset = (ty - min_tile_y) * tile_size
+
+                        # Place tile
+                        tile_canvas[y_offset:y_offset+tile_size, x_offset:x_offset+tile_size] = tile_img
+
+            # Convert geographic bounds to pixel coordinates in tile canvas
+            min_lat_pixel_y = self._lat_to_pixel_y(min_lat, zoom, tile_size)
+            max_lat_pixel_y = self._lat_to_pixel_y(max_lat, zoom, tile_size)
+            min_lon_pixel_x = self._lon_to_pixel_x(min_lon, zoom, tile_size)
+            max_lon_pixel_x = self._lon_to_pixel_x(max_lon, zoom, tile_size)
+
+            # Calculate crop region (to match exact bounds)
+            crop_x1 = int(min_lon_pixel_x - min_tile_x * tile_size)
+            crop_y1 = int(max_lat_pixel_y - min_tile_y * tile_size)
+            crop_x2 = int(max_lon_pixel_x - min_tile_x * tile_size)
+            crop_y2 = int(min_lat_pixel_y - min_tile_y * tile_size)
+
+            # Ensure crop bounds are valid
+            crop_x1 = max(0, min(crop_x1, canvas_width))
+            crop_y1 = max(0, min(crop_y1, canvas_height))
+            crop_x2 = max(crop_x1, min(crop_x2, canvas_width))
+            crop_y2 = max(crop_y1, min(crop_y2, canvas_height))
+
+            # Crop to exact bounds
+            cropped = tile_canvas[crop_y1:crop_y2, crop_x1:crop_x2]
+
+            # Resize to target dimensions
+            if cropped.shape[0] > 0 and cropped.shape[1] > 0:
+                resized = cv2.resize(cropped, (img_width, img_height), interpolation=cv2.INTER_AREA)
+                return resized
+            else:
+                # Fallback to gray background
+                return np.ones((img_height, img_width, 3), dtype=np.uint8) * 245
+
+        except Exception as e:
+            self.logger.error(f"Error downloading map tiles: {e}")
+            # Fallback to gray background
+            return np.ones((img_height, img_width, 3), dtype=np.uint8) * 245
+
+    def _lat_lon_to_tile(self, lat, lon, zoom):
+        """Convert latitude/longitude to tile coordinates."""
+        lat_rad = math.radians(lat)
+        n = 2.0 ** zoom
+        x_tile = int((lon + 180.0) / 360.0 * n)
+        y_tile = int((1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n)
+        return x_tile, y_tile
+
+    def _lat_to_pixel_y(self, lat, zoom, tile_size):
+        """Convert latitude to pixel Y coordinate."""
+        lat_rad = math.radians(lat)
+        n = 2.0 ** zoom
+        return (1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n * tile_size
+
+    def _lon_to_pixel_x(self, lon, zoom, tile_size):
+        """Convert longitude to pixel X coordinate."""
+        n = 2.0 ** zoom
+        return (lon + 180.0) / 360.0 * n * tile_size
+
+    def _calculate_tile_zoom(self, min_lat, max_lat, min_lon, max_lon, map_width, map_height, tile_size):
+        """Calculate appropriate zoom level for given bounds."""
+        lat_diff = max_lat - min_lat
+        lon_diff = max_lon - min_lon
+
+        # Prevent division by zero
+        if lat_diff == 0:
+            lat_diff = 0.001
+        if lon_diff == 0:
+            lon_diff = 0.001
+
+        # Calculate zoom for width and height
+        zoom_x = math.log2(360 / lon_diff * map_width / tile_size)
+        zoom_y = math.log2(180 / lat_diff * map_height / tile_size)
+
+        # Use minimum zoom to ensure all points fit
+        zoom = min(zoom_x, zoom_y)
+
+        # Clamp to valid range (0-18) and leave some margin
+        return max(1, min(18, int(zoom) - 1))
+
+    def _get_tile(self, x_tile, y_tile, zoom, cache_dir):
+        """
+        Get a tile (from cache or download).
+
+        Args:
+            x_tile, y_tile: Tile coordinates
+            zoom: Zoom level
+            cache_dir: Cache directory path
+
+        Returns:
+            np.ndarray: Tile image (256x256x3) or None
+        """
+        try:
+            # Use OpenStreetMap tiles (prefer 'map' for streets/trails visibility)
+            tile_source = 'map'
+            cache_path = cache_dir / f"{tile_source}_{zoom}_{x_tile}_{y_tile}.png"
+
+            # Check cache first
+            if cache_path.exists():
+                tile_img = cv2.imread(str(cache_path))
+                if tile_img is not None and tile_img.shape[0] == 256 and tile_img.shape[1] == 256:
+                    return tile_img
+
+            # Download tile
+            url = f"https://tile.openstreetmap.org/{zoom}/{x_tile}/{y_tile}.png"
+
+            # Use requests with timeout
+            headers = {'User-Agent': 'ADIAT/1.0'}
+            response = requests.get(url, headers=headers, timeout=10)
+
+            if response.status_code == 200:
+                # Save to cache
+                with open(cache_path, 'wb') as f:
+                    f.write(response.content)
+
+                # Convert to numpy array
+                image_array = np.asarray(bytearray(response.content), dtype=np.uint8)
+                tile_img = cv2.imdecode(image_array, cv2.IMREAD_COLOR)
+
+                if tile_img is not None:
+                    return tile_img
+
+            # Fallback to gray tile
+            return np.ones((256, 256, 3), dtype=np.uint8) * 230
+
+        except Exception as e:
+            # Return gray tile on error
+            return np.ones((256, 256, 3), dtype=np.uint8) * 230
+
+    def _calculate_aoi_gps(self, img, aoi):
+        """
+        Calculate GPS coordinates for an AOI.
+
+        Args:
+            img: Image dictionary
+            aoi: AOI dictionary
+
+        Returns:
+            Dict with latitude/longitude or None
+        """
+        try:
+            # Get original image path (not mask/thumbnail)
+            original_path = img.get('original_path', img['path']) if 'original_path' in img else img['path']
+
+            # Get image GPS from original image
+            exif_data = MetaDataHelper.get_exif_data_piexif(original_path)
+            gps_coords = LocationInfo.get_gps(exif_data=exif_data)
+            if not gps_coords:
+                return None
+
+            # Get image service from original image
+            image_service = ImageService(original_path, img.get('mask_path', ''))
+            img_array = image_service.img_array
+            height, width = img_array.shape[:2]
+
+            # Check gimbal pitch (must be nadir)
+            _, gimbal_pitch = image_service.get_gimbal_orientation()
+            if gimbal_pitch is not None and not (-95 <= gimbal_pitch <= -85):
+                return None
+
+            # Get bearing and GSD
+            bearing = image_service.get_drone_orientation() or 0
+            gsd_cm = image_service.get_average_gsd()
+            if not gsd_cm:
+                return None
+
+            # Calculate offset from image center
+            gsd_m = gsd_cm / 100.0
+            dx_pixels = aoi['center'][0] - width / 2
+            dy_pixels = aoi['center'][1] - height / 2
+
+            dx_image = dx_pixels * gsd_m
+            dy_image = dy_pixels * gsd_m
+
+            bearing_rad = math.radians(-bearing)
+            north_meters = -dy_image * math.cos(bearing_rad) + dx_image * math.sin(bearing_rad)
+            east_meters = dx_image * math.cos(bearing_rad) + dy_image * math.sin(bearing_rad)
+
+            # Convert to lat/lon
+            earth_radius = 6371000
+            delta_lat = north_meters / earth_radius * (180 / math.pi)
+            delta_lon = east_meters / (earth_radius * math.cos(math.radians(gps_coords['latitude']))) * (180 / math.pi)
+
+            return {
+                'latitude': gps_coords['latitude'] + delta_lat,
+                'longitude': gps_coords['longitude'] + delta_lon
+            }
+
+        except Exception:
+            return None
+
+    def _rotate_image_north_up(self, img_array, bearing):
+        """
+        Rotate image so north is up.
+
+        Args:
+            img_array: Image as numpy array
+            bearing: Drone bearing in degrees (0-360)
+
+        Returns:
+            Rotated image array
+        """
+        if bearing is None:
+            return img_array
+
+        height, width = img_array.shape[:2]
+        center = (width / 2, height / 2)
+
+        # Rotate by -bearing to make north up
+        rotation_matrix = cv2.getRotationMatrix2D(center, -bearing, 1.0)
+
+        # Calculate new dimensions to fit rotated image
+        cos = abs(rotation_matrix[0, 0])
+        sin = abs(rotation_matrix[0, 1])
+        new_width = int((height * sin) + (width * cos))
+        new_height = int((height * cos) + (width * sin))
+
+        # Adjust rotation matrix for translation
+        rotation_matrix[0, 2] += (new_width / 2) - center[0]
+        rotation_matrix[1, 2] += (new_height / 2) - center[1]
+
+        # Perform rotation
+        rotated = cv2.warpAffine(img_array, rotation_matrix, (new_width, new_height),
+                                 borderMode=cv2.BORDER_CONSTANT, borderValue=(255, 255, 255))
+        return rotated
+
+    def _transform_aoi_center(self, aoi_center, bearing, img_width, img_height):
+        """
+        Transform AOI center coordinates after image rotation using the same matrix as cv2.warpAffine.
+
+        Args:
+            aoi_center: Original (x, y) center
+            bearing: Rotation angle in degrees
+            img_width: Original image width
+            img_height: Original image height
+
+        Returns:
+            Transformed (x, y) center in rotated image
+        """
+        if bearing is None:
+            return aoi_center
+
+        # Create the same rotation matrix as used in _rotate_image_north_up
+        center = (img_width / 2, img_height / 2)
+        rotation_matrix = cv2.getRotationMatrix2D(center, -bearing, 1.0)
+
+        # Calculate new dimensions
+        cos = abs(rotation_matrix[0, 0])
+        sin = abs(rotation_matrix[0, 1])
+        new_width = int((img_height * sin) + (img_width * cos))
+        new_height = int((img_height * cos) + (img_width * sin))
+
+        # Adjust rotation matrix for translation (same as image rotation)
+        rotation_matrix[0, 2] += (new_width / 2) - center[0]
+        rotation_matrix[1, 2] += (new_height / 2) - center[1]
+
+        # Apply the transformation to the AOI point
+        aoi_point = np.array([[aoi_center]], dtype=np.float32)
+        transformed_point = cv2.transform(aoi_point, rotation_matrix)
+        new_x, new_y = transformed_point[0][0]
+
+        return (int(new_x), int(new_y))
+
+    def _create_zoomed_aoi_image(self, img_array, aoi, zoom_level, bearing, identifier_color, draw_circle=True):
+        """
+        Create a zoomed view of an AOI with optional connector line.
+
+        Args:
+            img_array: Original image array
+            aoi: AOI dictionary
+            zoom_level: Zoom factor (2, 3, 4, 10, or 'closeup')
+            bearing: Drone bearing for north rotation
+            identifier_color: RGB tuple for AOI circle
+            draw_circle: Whether to draw the AOI circle
+
+        Returns:
+            Tuple of (zoomed_image_array, aoi_position_in_crop) or None
+        """
+        try:
+            # First rotate the image
+            rotated_img = self._rotate_image_north_up(img_array, bearing)
+            height, width = img_array.shape[:2]
+            rot_height, rot_width = rotated_img.shape[:2]
+
+            # Transform AOI center to rotated coordinates
+            transformed_center = self._transform_aoi_center(aoi['center'], bearing, width, height)
+            x, y = transformed_center
+            radius = aoi['radius']
+
+            # Calculate crop size based on zoom level
+            # Use larger multipliers for better context
+            if zoom_level == 2:
+                crop_radius = radius * 8  # Show good context around AOI
+            elif zoom_level == 3:
+                crop_radius = radius * 3
+            elif zoom_level == 4:
+                crop_radius = radius * 5  # Moderate zoom
+            elif zoom_level == 6:
+                crop_radius = radius * 6  # Moderate zoom for 6x
+            elif zoom_level == 10:
+                crop_radius = int(radius * 1.5)
+            else:  # closeup
+                crop_radius = int(radius * 1.1)
+
+            # Calculate crop bounds centered on AOI
+            sx = max(0, int(x - crop_radius))
+            sy = max(0, int(y - crop_radius))
+            ex = min(rot_width, int(x + crop_radius))
+            ey = min(rot_height, int(y + crop_radius))
+
+            # Crop the image
+            cropped = rotated_img[sy:ey, sx:ex].copy()
+
+            # Calculate AOI position in cropped image
+            aoi_x_in_crop = int(x - sx)
+            aoi_y_in_crop = int(y - sy)
+
+            # Draw AOI circle on the image (if requested)
+            if draw_circle:
+                color_bgr = (identifier_color[2], identifier_color[1], identifier_color[0])  # RGB to BGR
+                cv2.circle(cropped, (aoi_x_in_crop, aoi_y_in_crop), radius, color_bgr, 3)
+
+            return cropped, (aoi_x_in_crop, aoi_y_in_crop)
+
+        except Exception as e:
+            self.logger.error(f"Error creating zoomed AOI image: {e}")
+            return None, None
+
+    def _create_context_image(self, img_array, aoi, bearing, identifier_color):
+        """
+        Create a 3x zoomed context image from the full original image.
+
+        Args:
+            img_array: Original full image array
+            aoi: AOI dictionary
+            bearing: Drone bearing for north rotation
+            identifier_color: RGB tuple for AOI circle
+
+        Returns:
+            Tuple of (context_image_array, aoi_position_in_context)
+        """
+        try:
+            # First rotate the full image
+            rotated_img = self._rotate_image_north_up(img_array, bearing)
+            height, width = img_array.shape[:2]
+            rot_height, rot_width = rotated_img.shape[:2]
+
+            # Transform AOI center to rotated coordinates
+            transformed_center = self._transform_aoi_center(aoi['center'], bearing, width, height)
+            x, y = transformed_center
+            radius = aoi['radius']
+
+            # Calculate crop for 3x zoom (larger area showing context)
+            crop_radius = radius * 3
+
+            # Calculate crop bounds
+            sx = max(0, x - crop_radius)
+            sy = max(0, y - crop_radius)
+            ex = min(rot_width, x + crop_radius)
+            ey = min(rot_height, y + crop_radius)
+
+            # Crop the image
+            cropped = rotated_img[sy:ey, sx:ex].copy()
+
+            # Calculate AOI position in cropped image
+            aoi_x_in_crop = x - sx
+            aoi_y_in_crop = y - sy
+
+            # Draw AOI circle
+            color_bgr = (identifier_color[2], identifier_color[1], identifier_color[0])
+            cv2.circle(cropped, (aoi_x_in_crop, aoi_y_in_crop), radius, color_bgr, 3)
+
+            return cropped, (aoi_x_in_crop, aoi_y_in_crop)
+
+        except Exception as e:
+            self.logger.error(f"Error creating context image: {e}")
+            return None, None
+
+    def _draw_connector_line_to_target(self, detail_img, detail_aoi_pos, context_aoi_pos):
+        """
+        Draw a connector line from detail image pointing towards the AOI in context image.
+
+        Args:
+            detail_img: Detail/closeup image array
+            detail_aoi_pos: (x, y) position of AOI in detail image
+            context_aoi_pos: (x, y) position of AOI in context image (for direction)
+
+        Returns:
+            Image with connector line drawn
+        """
+        try:
+            h, w = detail_img.shape[:2]
+
+            # Start from the AOI center in the detail image
+            start_pt = detail_aoi_pos
+
+            # Arrow should point upward (towards the 0x image which is above on the page)
+            # Calculate angle based on horizontal position difference
+            # Since context image spans full width above, point generally upward
+            arrow_length = 80
+
+            # Point straight up or slightly angled based on position
+            end_x = start_pt[0]
+            end_y = max(5, start_pt[1] - arrow_length)
+
+            end_pt = (end_x, end_y)
+
+            # Draw arrow from AOI towards top
+            cv2.arrowedLine(detail_img, start_pt, end_pt,
+                           (255, 0, 255), 3, tipLength=0.3)
+
+            return detail_img
+
+        except Exception as e:
+            self.logger.error(f"Error drawing connector line: {e}")
+            return detail_img
+
+    def _get_aoi_average_info(self, img_array, aoi):
+        """
+        Calculate average color information for an AOI.
+
+        Args:
+            img_array: Image array in RGB format (from ImageService.img_array)
+            aoi: AOI dictionary with center, radius, and optionally detected_pixels
+
+        Returns:
+            String with hue color info, or None
+        """
+        try:
+            center = aoi['center']
+            radius = aoi.get('radius', 0)
+            cx, cy = center
+
+            # Collect RGB values within the AOI
+            colors = []
+            shape = img_array.shape
+
+            # If we have detected pixels, use those (from AOI detection)
+            if 'detected_pixels' in aoi and aoi['detected_pixels']:
+                for pixel in aoi['detected_pixels']:
+                    if isinstance(pixel, (list, tuple)) and len(pixel) >= 2:
+                        px, py = int(pixel[0]), int(pixel[1])
+                        if 0 <= py < shape[0] and 0 <= px < shape[1]:
+                            colors.append(img_array[py, px])
+            # Otherwise sample within the circle
+            else:
+                for y in range(max(0, cy - radius), min(shape[0], cy + radius + 1)):
+                    for x in range(max(0, cx - radius), min(shape[1], cx + radius + 1)):
+                        # Check if pixel is within circle
+                        if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                            colors.append(img_array[y, x])
+
+            if colors:
+                # Calculate average RGB (image is already in RGB format)
+                avg_rgb = np.mean(colors, axis=0).astype(int)
+
+                # Extract RGB values (already in RGB, not BGR)
+                r, g, b = int(avg_rgb[0]), int(avg_rgb[1]), int(avg_rgb[2])
+
+                # Convert to HSV to get hue
+                r_norm, g_norm, b_norm = r / 255.0, g / 255.0, b / 255.0
+                h, _, _ = colorsys.rgb_to_hsv(r_norm, g_norm, b_norm)
+
+                # Create full saturation and full value version (matching viewer behavior)
+                full_sat_rgb = colorsys.hsv_to_rgb(h, 1.0, 1.0)
+                full_sat_rgb = tuple(int(c * 255) for c in full_sat_rgb)
+
+                # Format as hex color for the swatch
+                color_hex = '#{:02x}{:02x}{:02x}'.format(*full_sat_rgb)
+
+                # Return hue angle with color square (matching viewer display)
+                hue_degrees = int(h * 360)
+                return f"Hue: {hue_degrees}° {color_hex} <font color='{color_hex}'>■</font>"
+
+            return None
+
+        except Exception as e:
+            self.logger.error(f"Error calculating average color: {e}")
+            return None
+
+    def _find_original_image_from_name(self, image_name):
+        """
+        Find the original source image path from the image name.
+
+        Args:
+            image_name: Name of the image (e.g., "JTDE-1-0_I_20250611145701_1626_V.JPG")
+
+        Returns:
+            Path to original image or None
+        """
+        try:
+            # Get the settings to find input directory
+            if hasattr(self.viewer, 'settings'):
+                input_dir = self.viewer.settings.get('input_dir', '')
+                if input_dir and os.path.exists(input_dir):
+                    # Try to find the image in the input directory
+                    potential_path = os.path.join(input_dir, image_name)
+                    if os.path.exists(potential_path):
+                        return potential_path
+
+                    # Try recursive search if not found directly
+                    for root, dirs, files in os.walk(input_dir):
+                        if image_name in files:
+                            return os.path.join(root, image_name)
+
+            return None
+
+        except Exception as e:
+            self.logger.error(f"Error finding original image: {e}")
+            return None
+
+    def _create_composite_with_connectors(self, full_img, full_aoi_pos, medium_img, medium_aoi_pos, closeup_img, closeup_aoi_pos, aoi_radius):
+        """
+        Create a composite image with all three zoom levels and connector lines between them.
+
+        Args:
+            full_img: 0x full rotated image
+            full_aoi_pos: AOI position in full image
+            medium_img: 3x zoomed image
+            medium_aoi_pos: AOI position in medium image
+            closeup_img: 6x zoomed image
+            closeup_aoi_pos: AOI position in closeup image
+            aoi_radius: Radius of the AOI circle
+
+        Returns:
+            Composite image with connector lines
+        """
+        try:
+            # Get dimensions
+            full_h, full_w = full_img.shape[:2]
+            medium_h, medium_w = medium_img.shape[:2]
+            closeup_h, closeup_w = closeup_img.shape[:2]
+
+            # Calculate composite dimensions
+            # Use full image width as reference
+            composite_w = full_w
+
+            # Calculate target dimensions for bottom images (each takes half width)
+            bottom_target_w = composite_w // 2
+
+            # Scale medium image to fit half width while maintaining aspect ratio
+            medium_scale = bottom_target_w / medium_w
+            medium_scaled_h = int(medium_h * medium_scale)
+            medium_scaled_w = bottom_target_w
+            medium_scaled = cv2.resize(medium_img, (medium_scaled_w, medium_scaled_h), interpolation=cv2.INTER_AREA)
+            medium_aoi_scaled = (int(medium_aoi_pos[0] * medium_scale), int(medium_aoi_pos[1] * medium_scale))
+
+            # Scale closeup image to fit half width while maintaining aspect ratio
+            closeup_scale = bottom_target_w / closeup_w
+            closeup_scaled_h = int(closeup_h * closeup_scale)
+            closeup_scaled_w = bottom_target_w
+            closeup_scaled = cv2.resize(closeup_img, (closeup_scaled_w, closeup_scaled_h), interpolation=cv2.INTER_AREA)
+            closeup_aoi_scaled = (int(closeup_aoi_pos[0] * closeup_scale), int(closeup_aoi_pos[1] * closeup_scale))
+
+            # Calculate composite height
+            max_bottom_h = max(medium_scaled_h, closeup_scaled_h)
+            composite_h = full_h + max_bottom_h + 20  # 20px gap
+
+            # Create white canvas
+            composite = np.ones((composite_h, composite_w, 3), dtype=np.uint8) * 255
+
+            # Place full image at top (already full width)
+            composite[0:full_h, 0:full_w] = full_img
+
+            # Place closeup (6x) image bottom left (fill left half)
+            closeup_y = full_h + 20
+            closeup_x = 0
+            composite[closeup_y:closeup_y+closeup_scaled_h, closeup_x:closeup_x+closeup_scaled_w] = closeup_scaled
+
+            # Place medium (3x) image bottom right (fill right half)
+            medium_y = full_h + 20
+            medium_x = composite_w // 2
+            composite[medium_y:medium_y+medium_scaled_h, medium_x:medium_x+medium_scaled_w] = medium_scaled
+
+            # Calculate AOI positions in composite image
+            full_aoi_composite = (full_aoi_pos[0], full_aoi_pos[1])
+            medium_aoi_composite = (medium_x + medium_aoi_scaled[0], medium_y + medium_aoi_scaled[1])
+            closeup_aoi_composite = (closeup_x + closeup_aoi_scaled[0], closeup_y + closeup_aoi_scaled[1])
+
+            # Helper function to calculate line endpoint at circle edge
+            def calculate_circle_edge_point(start_pt, circle_center, circle_radius):
+                # Calculate direction vector
+                dx = circle_center[0] - start_pt[0]
+                dy = circle_center[1] - start_pt[1]
+                distance = math.sqrt(dx*dx + dy*dy)
+
+                if distance == 0:
+                    return circle_center
+
+                # Normalize and scale to circle edge
+                scale = (distance - circle_radius) / distance
+                end_x = int(start_pt[0] + dx * scale)
+                end_y = int(start_pt[1] + dy * scale)
+                return (end_x, end_y)
+
+            # Draw connector lines to edge of AOI circle
+            # Medium to full (straight line to circle edge)
+            medium_line_end = calculate_circle_edge_point(medium_aoi_composite, full_aoi_composite, aoi_radius)
+            cv2.line(composite, medium_aoi_composite, medium_line_end, (255, 0, 255), 3)
+
+            # Closeup to full (straight line to circle edge)
+            closeup_line_end = calculate_circle_edge_point(closeup_aoi_composite, full_aoi_composite, aoi_radius)
+            cv2.line(composite, closeup_aoi_composite, closeup_line_end, (255, 0, 255), 3)
+
+            return composite
+
+        except Exception as e:
+            self.logger.error(f"Error creating composite image: {e}")
+            # Return full image as fallback
+            return full_img
+
+    def _create_full_rotated_image(self, img_array, aoi, bearing, identifier_color):
+        """
+        Create a full rotated image (0x zoom) with AOI marked, cropped to fit without stretching.
+
+        Args:
+            img_array: Original full image array
+            aoi: AOI dictionary
+            bearing: Drone bearing for north rotation
+            identifier_color: RGB tuple for AOI circle
+
+        Returns:
+            Tuple of (cropped_rotated_image, aoi_position_in_cropped_image)
+        """
+        try:
+            # Rotate the full image
+            rotated_img = self._rotate_image_north_up(img_array, bearing)
+            height, width = img_array.shape[:2]
+            rot_height, rot_width = rotated_img.shape[:2]
+
+            # Transform AOI center to rotated coordinates
+            transformed_center = self._transform_aoi_center(aoi['center'], bearing, width, height)
+            x, y = transformed_center
+            radius = aoi['radius']
+
+            # Calculate crop to fit page width while maintaining aspect ratio
+            # Target: 7.5 inch width, ~3.5 inch height (for top half of page)
+            target_aspect = 7.5 / 3.5  # Width / Height ratio
+
+            # Calculate crop dimensions maintaining aspect ratio
+            crop_width = rot_width
+            crop_height = int(crop_width / target_aspect)
+
+            # If calculated height exceeds image, adjust
+            if crop_height > rot_height:
+                crop_height = rot_height
+                crop_width = int(crop_height * target_aspect)
+
+            # Ensure AOI is in the crop - center crop around AOI
+            crop_x = max(0, min(x - crop_width // 2, rot_width - crop_width))
+            crop_y = max(0, min(y - crop_height // 2, rot_height - crop_height))
+
+            # Crop the rotated image
+            cropped = rotated_img[crop_y:crop_y + crop_height, crop_x:crop_x + crop_width].copy()
+
+            # Calculate AOI position in cropped image
+            aoi_x_in_crop = x - crop_x
+            aoi_y_in_crop = y - crop_y
+
+            # Draw AOI circle on the cropped image
+            color_bgr = (identifier_color[2], identifier_color[1], identifier_color[0])
+            cv2.circle(cropped, (aoi_x_in_crop, aoi_y_in_crop), radius, color_bgr, 3)
+
+            return cropped, (aoi_x_in_crop, aoi_y_in_crop)
+
+        except Exception as e:
+            self.logger.error(f"Error creating full rotated image: {e}")
+            return None, None


### PR DESCRIPTION
## Summary
Implements interactive AOI creation in the viewer, allowing users to press 'C' and draw circles to create Areas of Interest.

## Features
- **Press 'C' key** to enter AOI creation mode
- **Click and drag** to draw a circle preview with real-time feedback
- **Circle center** becomes the AOI X,Y coordinates
- **Pixel color at center** determines the Hue color for the AOI
- **2/3 of drawn circle area** becomes the pixel area for the AOI
- **Confirmation dialog** ("Create AOI?" with Yes/Cancel) before creation
- **Auto-save** to XML and immediate display refresh

## Implementation Details
- New `AOICreationDialog.py` - Simple confirmation dialog
- Updated `Viewer.py` - Added creation mode state management and key handler
- Updated `QtImageViewer.py` - Mouse event handling for interactive circle drawing
- Updated `AOIController.py` - New `create_aoi_from_circle()` method

## User Experience Flow
1. User presses 'C' → Enters creation mode (crosshair cursor + toast message)
2. User clicks on image → Stores center point, starts drawing preview circle
3. User drags mouse → Circle expands/contracts dynamically
4. User releases mouse → Shows "Create AOI?" confirmation dialog
5. If "Yes" → AOI created with hue from center pixel, area = 2/3 × πr², saved to XML
6. If "Cancel" → Preview removed, returns to normal mode

## Testing
- Tested AOI creation with various circle sizes
- Verified hue calculation from center pixel
- Confirmed area calculation (2/3 of circle area)
- Verified XML persistence and reload
- Tested cancel/confirm dialog flow