### PR TITLE
fix: Handle Skydio X10 MP4 thumbnail track in streaming and video parser

### DIFF
--- a/app/core/services/VideoParserService.py
+++ b/app/core/services/VideoParserService.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import QObject, Signal, Slot
 
 from core.services.LoggerService import LoggerService
 from helpers.MetaDataHelper import MetaDataHelper
+from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track
 
 
 class VideoParserService(QObject):
@@ -54,11 +55,26 @@ class VideoParserService(QObject):
         and embedding it into each image where available. Emits sig_msg for status updates
         and sig_done when complete.
         """
+        remuxed_temp_path = None
         try:
             cap = cv2.VideoCapture(self.video_path)
 
             fps = cap.get(cv2.CAP_PROP_FPS)
             frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+            # Detect thumbnail track (e.g. Skydio X10 embeds MJPEG cover art as stream 0)
+            if cap.isOpened() and detect_thumbnail_track(cap):
+                self.sig_msg.emit("Detected thumbnail track in video, remuxing to select main video track...")
+                cap.release()
+                remuxed_temp_path = remux_to_main_track(self.video_path, self.logger)
+                if remuxed_temp_path:
+                    cap = cv2.VideoCapture(remuxed_temp_path)
+                    fps = cap.get(cv2.CAP_PROP_FPS)
+                    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                else:
+                    self.sig_msg.emit("Error: Failed to remux video file.")
+                    self.sig_done.emit(self.__id, 0)
+                    return
 
             if not cap.isOpened() or fps == 0 or frame_count == 0:
                 self.sig_msg.emit("Error: Invalid video file or unreadable format.")
@@ -143,11 +159,21 @@ class VideoParserService(QObject):
                     self.sig_msg.emit(f"{image_count} images captured")
 
             cap.release()  # Ensure proper cleanup
+            if remuxed_temp_path:
+                try:
+                    os.unlink(remuxed_temp_path)
+                except OSError:
+                    pass
             self.sig_done.emit(self.__id, image_count)
 
         except Exception as e:
             self.logger.error(f"Error in process_video: {str(e)}")
             self.sig_msg.emit(f"Processing error: {str(e)}")
+            if remuxed_temp_path:
+                try:
+                    os.unlink(remuxed_temp_path)
+                except OSError:
+                    pass
             self.sig_done.emit(self.__id, 0)
 
     @Slot()

--- a/app/core/services/streaming/MaskManager.py
+++ b/app/core/services/streaming/MaskManager.py
@@ -255,11 +255,7 @@ class MaskManager:
     def _compute_config_hash(self, config: Dict[str, Any],
                              resolution: Tuple[int, int]) -> str:
         """Compute hash of config for cache invalidation."""
-        return f"{
-            config.get('frame_mask_enabled')}_{
-            config.get('image_mask_enabled')}_{
-            config.get('frame_buffer_pixels')}_{
-                config.get('mask_image_path')}_{resolution}"
+        return f"{config.get('frame_mask_enabled')}_{config.get('image_mask_enabled')}_{config.get('frame_buffer_pixels')}_{config.get('mask_image_path')}_{resolution}"
 
     def invalidate_cache(self):
         """Force cache invalidation."""

--- a/app/core/services/streaming/RTMPStreamService.py
+++ b/app/core/services/streaming/RTMPStreamService.py
@@ -7,6 +7,7 @@ color detection applications. Designed for <250ms latency processing.
 
 # Set environment variable to avoid numpy compatibility issues - MUST be first
 from core.services.LoggerService import LoggerService
+from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track
 from PySide6.QtCore import QObject, QThread, Signal
 from dataclasses import dataclass
 from enum import Enum
@@ -87,6 +88,7 @@ class RTMPStreamService(QThread):
         self._should_stop = False
         self._frame_number = 0
         self._last_frame_time = 0
+        self._remuxed_temp_path = None
 
         # Performance tracking
         self._fps_counter = 0
@@ -279,6 +281,28 @@ class RTMPStreamService(QThread):
             if not ret or frame is None:
                 self.logger.error("Failed to read initial frame")
                 return False
+
+            # Detect and fix MP4s where OpenCV grabbed a thumbnail track
+            # (e.g. Skydio X10 embeds MJPEG cover art as stream 0)
+            if self._is_file and detect_thumbnail_track(self._cap):
+                self.logger.info("Detected thumbnail track in video file, remuxing to select main video track")
+                temp_path = remux_to_main_track(self.config.url, self.logger)
+                if temp_path:
+                    self._cap.release()
+                    self._remuxed_temp_path = temp_path
+                    self._cap = cv2.VideoCapture(temp_path)
+                    if not self._cap.isOpened():
+                        self.logger.error("Failed to open remuxed video")
+                        os.unlink(temp_path)
+                        self._remuxed_temp_path = None
+                        return False
+                    ret, frame = self._cap.read()
+                    if not ret or frame is None:
+                        self.logger.error("Failed to read frame from remuxed video")
+                        return False
+                else:
+                    self.logger.error("Failed to remux video to select main track")
+                    return False
 
             # Log stream properties
             fps = self._cap.get(cv2.CAP_PROP_FPS)
@@ -658,6 +682,15 @@ class RTMPStreamService(QThread):
         finally:
             self._connected = False
             self._cap = None  # Ensure cap is cleared even if release failed
+
+            # Clean up remuxed temp file
+            if self._remuxed_temp_path:
+                try:
+                    os.unlink(self._remuxed_temp_path)
+                    self.logger.info(f"Cleaned up temp file: {self._remuxed_temp_path}")
+                except OSError:
+                    pass
+                self._remuxed_temp_path = None
 
     def is_connected(self) -> bool:
         """Check if stream is currently connected."""

--- a/app/helpers/VideoFileHelper.py
+++ b/app/helpers/VideoFileHelper.py
@@ -1,0 +1,110 @@
+"""
+VideoFileHelper.py - Utilities for handling video files with non-standard stream layouts.
+
+Detects and works around MP4 files that embed a thumbnail/cover image as the
+first video stream (e.g. Skydio X10), which causes OpenCV to grab the wrong track.
+"""
+
+import os
+import subprocess
+import tempfile
+import json
+import cv2
+
+
+def detect_thumbnail_track(cap) -> bool:
+    """Check if OpenCV grabbed a thumbnail track instead of the real video.
+
+    Some drones (e.g. Skydio X10) embed an MJPEG cover image as stream 0.
+    OpenCV picks it up, reports an absurd FPS (the MP4 timescale), and fails
+    to read a second frame. This function detects that situation.
+
+    After calling, the capture position is reset to frame 0.
+
+    Args:
+        cap: An opened cv2.VideoCapture instance.
+
+    Returns:
+        True if the capture appears to be on a thumbnail track.
+    """
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    if fps > 1000:
+        return True
+    # Also check if second frame fails immediately
+    ret2, _ = cap.read()
+    if not ret2:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+        return True
+    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    return False
+
+
+def remux_to_main_track(source_path, logger=None):
+    """Remux an MP4 to select the main video track, skipping thumbnail/cover tracks.
+
+    Uses ffprobe to identify the real video stream (highest resolution, not
+    marked as attached_pic), then ffmpeg to remux with -c copy (no re-encoding).
+
+    Args:
+        source_path: Path to the source MP4 file.
+        logger: Optional logger instance with .info() and .error() methods.
+
+    Returns:
+        Path to a temporary remuxed MP4 file on success, None on failure.
+        Caller is responsible for deleting the temp file when done.
+    """
+    try:
+        # Use ffprobe to find the real video stream
+        probe = subprocess.run(
+            ['ffprobe', '-v', 'error', '-show_streams', '-of', 'json', source_path],
+            capture_output=True, text=True, timeout=10
+        )
+        if probe.returncode != 0:
+            if logger:
+                logger.error(f"ffprobe failed: {probe.stderr}")
+            return None
+
+        streams = json.loads(probe.stdout).get('streams', [])
+
+        # Find best video stream: not attached_pic, highest resolution
+        best_idx = None
+        best_pixels = 0
+        for s in streams:
+            if s.get('codec_type') != 'video':
+                continue
+            if s.get('disposition', {}).get('attached_pic', 0):
+                continue
+            pixels = int(s.get('width', 0)) * int(s.get('height', 0))
+            if pixels > best_pixels:
+                best_pixels = pixels
+                best_idx = s['index']
+
+        if best_idx is None:
+            if logger:
+                logger.error("No suitable video stream found in file")
+            return None
+
+        # Remux to temp file (copy codec, no re-encoding)
+        temp_fd, temp_path = tempfile.mkstemp(suffix='.mp4')
+        os.close(temp_fd)
+        result = subprocess.run(
+            ['ffmpeg', '-y', '-i', source_path, '-map', f'0:{best_idx}', '-c', 'copy', temp_path],
+            capture_output=True, text=True, timeout=60
+        )
+        if result.returncode != 0:
+            if logger:
+                logger.error(f"ffmpeg remux failed: {result.stderr}")
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+            return None
+
+        if logger:
+            logger.info(f"Remuxed video to temp file: {temp_path}")
+        return temp_path
+
+    except Exception as e:
+        if logger:
+            logger.error(f"Remux error: {e}")
+        return None


### PR DESCRIPTION
## Summary

- Skydio X10 drones embed an MJPEG cover image as video stream 0 in MP4 files, with the actual H.264 video as stream 1. OpenCV always selects stream 0, causing playback to fail after the first frame.
- Adds shared `VideoFileHelper` utility that uses ffprobe to detect thumbnail tracks (FPS > 1000 or immediate second-frame failure) and ffmpeg to remux the correct stream to a temp file (codec copy, no re-encoding).
- Applies the fix in both `RTMPStreamService` (real-time streaming viewer) and `VideoParserService` (video-to-image extraction).
- Fixes a Python 3.12+ f-string syntax in `MaskManager.py` that causes SyntaxError on Python 3.11.

## Test plan

- [ ] Open streaming viewer, set source to File, load a Skydio X10 MP4 — should play at full resolution/FPS with no "Failed to read frame" errors
- [ ] Open Video Parser, select same Skydio X10 MP4 — should extract frames successfully
- [ ] Test with a normal (non-Skydio) MP4 to confirm no regression
- [ ] Verify temp files are cleaned up after disconnect/completion
- [ ] Verify no MaskManager SyntaxError in console on Python 3.11