### PR TITLE
feat: Add Skydio CSV flight log support to Video Parser

### DIFF
--- a/app/core/controllers/images/VideoParser.py
+++ b/app/core/controllers/images/VideoParser.py
@@ -62,15 +62,15 @@ class VideoParser(TranslationMixin, QDialog, Ui_VideoParser):
                 self.videoSelectLine.setText(filename.replace('/', '\\'))
 
     def _srtSelectButton_clicked(self):
-        """Handles the subtitle (SRT) file selection button click.
+        """Handles the metadata file selection button click.
 
-        Opens a file dialog for the user to select an SRT file, then
-        updates the `srtSelectLine` text field with the selected file path.
+        Opens a file dialog for the user to select an SRT or CSV metadata file,
+        then updates the `srtSelectLine` text field with the selected file path.
         """
         filename, _ = QFileDialog.getOpenFileName(
             self,
-            self.tr("Select a SRT file"),
-            filter=self.tr("SRT (*.srt)")
+            self.tr("Select a Metadata File"),
+            filter=self.tr("Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)")
         )
         if filename:
             self.srtSelectLine.setText(filename)
@@ -265,7 +265,7 @@ class VideoParser(TranslationMixin, QDialog, Ui_VideoParser):
             theme (str): Name of the active theme used to resolve icon paths.
         """
         self.videoSelectButton.setIcon(IconHelper.create_icon('fa6.file-video', theme))
-        self.srtSelectButton.setIcon(IconHelper.create_icon('mdi.subtitles', theme))
+        self.srtSelectButton.setIcon(IconHelper.create_icon('mdi.file-document-outline', theme))
         self.outputSelectButton.setIcon(IconHelper.create_icon('fa6.folder-open', theme))
         self.startButton.setIcon(IconHelper.create_icon('fa6s.play', theme))
         self.cancelButton.setIcon(IconHelper.create_icon('mdi.close-circle', theme))

--- a/app/core/services/VideoParserService.py
+++ b/app/core/services/VideoParserService.py
@@ -1,16 +1,18 @@
 import os
 import shutil
+from bisect import bisect_left
 from pathlib import Path
 import re
 import cv2
 import math
-from datetime import datetime, timedelta
+import pandas as pd
+from datetime import datetime, timedelta, timezone
 
 from PySide6.QtCore import QObject, Signal, Slot
 
 from core.services.LoggerService import LoggerService
 from helpers.MetaDataHelper import MetaDataHelper
-from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track
+from helpers.VideoFileHelper import get_video_creation_time, detect_thumbnail_track, remux_to_main_track
 
 
 class VideoParserService(QObject):
@@ -28,13 +30,13 @@ class VideoParserService(QObject):
     sig_msg = Signal(str)
     sig_done = Signal(int, int)
 
-    def __init__(self, id, video, srt, output, interval):
+    def __init__(self, id, video, metadata_path, output, interval):
         """Initialize the VideoParserService with parameters for video processing.
 
         Args:
             id: Numeric ID for this parser instance.
             video: Path to the video file to be processed.
-            srt: Path to the SRT file with metadata for processing.
+            metadata_path: Path to a metadata file (SRT or CSV) with GPS data.
             output: Path to the output directory where images will be stored.
             interval: Time interval in seconds between frames to capture.
         """
@@ -42,18 +44,18 @@ class VideoParserService(QObject):
         super().__init__()
         self.__id = id
         self.video_path = video
-        self.srt_path = srt
+        self.metadata_path = metadata_path
         self.output_dir = output
         self.interval = interval
         self.cancelled = False
 
     @Slot()
     def process_video(self):
-        """Convert video frames to still images and attach metadata from an SRT file if provided.
+        """Convert video frames to still images and attach GPS metadata if provided.
 
-        Captures images at specified intervals, extracting GPS metadata from the SRT file
-        and embedding it into each image where available. Emits sig_msg for status updates
-        and sig_done when complete.
+        Supports SRT subtitle files (DJI) and CSV flight logs (Skydio).
+        Captures images at specified intervals, embedding GPS metadata into each
+        image where available. Emits sig_msg for status updates and sig_done when complete.
         """
         remuxed_temp_path = None
         try:
@@ -85,38 +87,29 @@ class VideoParserService(QObject):
             est_capture = math.floor(duration / self.interval) + 1
             self.sig_msg.emit(f"Video length: {duration} seconds. Estimated {est_capture} images will be captured.")
 
-            # Parse SRT file if provided
+            # Parse metadata file if provided
             srt_list = []
-            if self.srt_path:
-                self.sig_msg.emit("Parsing SRT File")
-                try:
-                    srt_data = Path(self.srt_path).read_text()
-                    srt_entries = re.split("(?:\r?\n){2,}", srt_data)
-                    for entry in srt_entries:
-                        data = re.split("(?:\r?\n)", entry)
-                        if len(data) >= 5:
-                            times = re.split(r"\s.*\s", data[1])
-                            start_time = datetime.strptime(times[0], '%H:%M:%S,%f')
-                            end_time = datetime.strptime(times[1], '%H:%M:%S,%f')
+            csv_entries = []
+            video_start_utc = None
+            metadata_format = self._detect_metadata_format(self.metadata_path)
 
-                            uav_data = re.findall(r'(?<=\[).+?(?=\])', data[4])
-                            uav_dict = {split[0]: split[1] for entry in uav_data for split in [re.split(r"\s*:\s*", entry)]}
-                            longitude = float(uav_dict.get('longitude')) if 'longitude' in uav_dict else None
-                            # Extra logic for longitude misspelling in some SRT files
-                            if longitude is None:
-                                longitude = float(uav_dict.get('longtitude')) if 'longtitude' in uav_dict else None
-                            srt_list.append({
-                                "start": start_time,
-                                "end": end_time,
-                                "latitude": float(uav_dict.get('latitude')) if 'latitude' in uav_dict else None,
-                                "longitude": longitude,
-                                "altitude": float(uav_dict.get('altitude', 0))
-                            })
-                except Exception as e:
-                    self.sig_msg.emit(f"Error parsing SRT file: {str(e)}")
+            if metadata_format == 'srt':
+                srt_list = self._parse_srt_file(self.metadata_path)
+                if srt_list is None:
+                    return
+            elif metadata_format == 'csv':
+                result = self._parse_csv_flight_log(self.metadata_path, self.video_path)
+                if result is None:
+                    return
+                video_start_utc, csv_entries = result
+                if video_start_utc is None:
+                    self.sig_msg.emit("Error: Could not determine video start time from MP4 metadata.")
+                    self.sig_msg.emit("Ensure the video file has creation_time metadata (ffprobe required).")
+                    self.sig_done.emit(self.__id, 0)
                     return
             else:
-                self.sig_msg.emit("SRT File Not Provided")
+                self.sig_msg.emit("Metadata File Not Provided")
+
             self._setup_output_dir()
             time_marker = 0
             image_count = 0
@@ -139,18 +132,21 @@ class VideoParserService(QObject):
                     self.sig_msg.emit(f"Frame capture failed at frame {frame_id}, stopping.")
                     break
 
-                # Get the actual timestamp after reading the frame
-                ms = cap.get(cv2.CAP_PROP_POS_MSEC)
-                video_time = datetime(1900, 1, 1) + timedelta(milliseconds=ms)
-
-                # Find corresponding SRT metadata
-                item = next((item for item in srt_list if item["start"] <= video_time <= item["end"]), None)
-
                 output_file = f"{self.output_dir}/{base_name}_{time_marker}s.jpg"
                 cv2.imwrite(output_file, image)
 
-                if item and item["latitude"] and item["longitude"]:
-                    MetaDataHelper.add_gps_data(output_file, item["latitude"], item["longitude"], item["altitude"])
+                if metadata_format == 'srt':
+                    # Get the actual timestamp after reading the frame
+                    ms = cap.get(cv2.CAP_PROP_POS_MSEC)
+                    video_time = datetime(1900, 1, 1) + timedelta(milliseconds=ms)
+                    item = next((item for item in srt_list if item["start"] <= video_time <= item["end"]), None)
+                    if item and item["latitude"] and item["longitude"]:
+                        MetaDataHelper.add_gps_data(output_file, item["latitude"], item["longitude"], item["altitude"])
+                elif metadata_format == 'csv':
+                    frame_utc = video_start_utc + timedelta(seconds=time_marker)
+                    entry = self._find_closest_csv_entry(csv_entries, frame_utc)
+                    if entry and entry['latitude'] and entry['longitude']:
+                        MetaDataHelper.add_gps_data(output_file, entry['latitude'], entry['longitude'], entry['altitude_m'])
 
                 image_count += 1
                 time_marker += self.interval
@@ -175,6 +171,145 @@ class VideoParserService(QObject):
                 except OSError:
                     pass
             self.sig_done.emit(self.__id, 0)
+
+    def _detect_metadata_format(self, path):
+        """Determine the metadata file format from its extension.
+
+        Args:
+            path: File path string.
+
+        Returns:
+            'srt', 'csv', or None.
+        """
+        if not path:
+            return None
+        ext = os.path.splitext(path)[1].lower()
+        if ext == '.srt':
+            return 'srt'
+        if ext == '.csv':
+            return 'csv'
+        return None
+
+    def _parse_srt_file(self, srt_path):
+        """Parse a DJI SRT subtitle file for GPS metadata.
+
+        Args:
+            srt_path: Path to the SRT file.
+
+        Returns:
+            List of dicts with start, end, latitude, longitude, altitude keys,
+            or None on parse failure.
+        """
+        self.sig_msg.emit("Parsing SRT File")
+        srt_list = []
+        try:
+            srt_data = Path(srt_path).read_text()
+            srt_entries = re.split("(?:\r?\n){2,}", srt_data)
+            for entry in srt_entries:
+                data = re.split("(?:\r?\n)", entry)
+                if len(data) >= 5:
+                    times = re.split(r"\s.*\s", data[1])
+                    start_time = datetime.strptime(times[0], '%H:%M:%S,%f')
+                    end_time = datetime.strptime(times[1], '%H:%M:%S,%f')
+
+                    uav_data = re.findall(r'(?<=\[).+?(?=\])', data[4])
+                    uav_dict = {split[0]: split[1] for entry in uav_data for split in [re.split(r"\s*:\s*", entry)]}
+                    longitude = float(uav_dict.get('longitude')) if 'longitude' in uav_dict else None
+                    # Extra logic for longitude misspelling in some SRT files
+                    if longitude is None:
+                        longitude = float(uav_dict.get('longtitude')) if 'longtitude' in uav_dict else None
+                    srt_list.append({
+                        "start": start_time,
+                        "end": end_time,
+                        "latitude": float(uav_dict.get('latitude')) if 'latitude' in uav_dict else None,
+                        "longitude": longitude,
+                        "altitude": float(uav_dict.get('altitude', 0))
+                    })
+            return srt_list
+        except Exception as e:
+            self.sig_msg.emit(f"Error parsing SRT file: {str(e)}")
+            return None
+
+    def _parse_csv_flight_log(self, csv_path, video_path):
+        """Parse a Skydio CSV flight log for GPS metadata.
+
+        Args:
+            csv_path: Path to the CSV flight log.
+            video_path: Path to the video file (used to extract creation_time).
+
+        Returns:
+            Tuple of (video_start_utc, sorted list of entry dicts) or None on failure.
+            Each entry dict has: utc_time, latitude, longitude, altitude_m.
+        """
+        self.sig_msg.emit("Parsing CSV flight log...")
+        try:
+            df = pd.read_csv(csv_path)
+
+            # Validate required columns
+            required_cols = ['Datetime (UTC)', 'Latitude', 'Longitude', 'GPS Altitude (ft MSL)']
+            missing = [col for col in required_cols if col not in df.columns]
+            if missing:
+                self.sig_msg.emit(f"Error: CSV missing required columns: {', '.join(missing)}")
+                return None
+
+            # Parse timestamps and convert altitude from feet to meters
+            df['utc_time'] = pd.to_datetime(df['Datetime (UTC)'], utc=True)
+            df['altitude_m'] = df['GPS Altitude (ft MSL)'] * 0.3048
+            df = df.sort_values('utc_time').reset_index(drop=True)
+
+            csv_entries = []
+            for _, row in df.iterrows():
+                csv_entries.append({
+                    'utc_time': row['utc_time'].to_pydatetime(),
+                    'latitude': row['Latitude'],
+                    'longitude': row['Longitude'],
+                    'altitude_m': row['altitude_m']
+                })
+
+            self.sig_msg.emit(f"Loaded {len(csv_entries)} GPS entries from CSV")
+
+            # Get video start time from MP4 container metadata
+            video_start_utc = get_video_creation_time(video_path, self.logger)
+            if video_start_utc:
+                self.sig_msg.emit(f"Video start time (UTC): {video_start_utc.isoformat()}")
+            return (video_start_utc, csv_entries)
+
+        except Exception as e:
+            self.sig_msg.emit(f"Error parsing CSV flight log: {str(e)}")
+            return None
+
+    def _find_closest_csv_entry(self, csv_entries, target_utc, max_delta_seconds=5.0):
+        """Find the CSV entry closest in time to the target UTC timestamp.
+
+        Uses binary search for efficiency on the sorted entry list.
+
+        Args:
+            csv_entries: Sorted list of entry dicts with 'utc_time' keys.
+            target_utc: Target UTC datetime to match.
+            max_delta_seconds: Maximum allowed time difference in seconds.
+
+        Returns:
+            The closest entry dict, or None if no entry is within max_delta_seconds.
+        """
+        if not csv_entries:
+            return None
+
+        timestamps = [e['utc_time'] for e in csv_entries]
+        pos = bisect_left(timestamps, target_utc)
+
+        # Check the entries at pos and pos-1 to find the closest
+        best = None
+        best_delta = None
+        for i in [pos - 1, pos]:
+            if 0 <= i < len(csv_entries):
+                delta = abs((csv_entries[i]['utc_time'] - target_utc).total_seconds())
+                if best_delta is None or delta < best_delta:
+                    best_delta = delta
+                    best = csv_entries[i]
+
+        if best_delta is not None and best_delta <= max_delta_seconds:
+            return best
+        return None
 
     @Slot()
     def process_cancel(self):

--- a/app/core/views/images/VideoParser_ui.py
+++ b/app/core/views/images/VideoParser_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'VideoParser.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QApplication, QDialog, QDoubleSpinBox, QFrame,
     QGridLayout, QHBoxLayout, QLabel, QLineEdit,
     QPlainTextEdit, QPushButton, QSizePolicy, QSpacerItem,
     QVBoxLayout, QWidget)
-from . import resources_rc
+import resources_rc
 
 class Ui_VideoParser(object):
     def setupUi(self, VideoParser):
@@ -209,14 +209,15 @@ class Ui_VideoParser(object):
 "Click the Select button to browse for a video file.", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(tooltip)
-        self.srtSelectLabel.setToolTip(QCoreApplication.translate("VideoParser", u"SRT subtitle file containing GPS telemetry and timestamp data.\n"
+        self.srtSelectLabel.setToolTip(QCoreApplication.translate("VideoParser", u"Metadata file containing GPS telemetry data.\n"
+"Supports DJI SRT subtitle files and Skydio CSV flight logs.\n"
 "Optional: Provides location information for extracted frames.\n"
-"Without SRT file, frames will have no GPS metadata.", None))
+"Without a metadata file, frames will have no GPS data.", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(whatsthis)
-        self.srtSelectLabel.setWhatsThis(QCoreApplication.translate("VideoParser", u"The SRT file contains timestamped information about the video file.  It is optional, but without it output images won't include location information.", None))
+        self.srtSelectLabel.setWhatsThis(QCoreApplication.translate("VideoParser", u"The metadata file contains timestamped GPS information for the video.  It is optional, but without it output images won't include location information.  Supports SRT (DJI) and CSV (Skydio) formats.", None))
 #endif // QT_CONFIG(whatsthis)
-        self.srtSelectLabel.setText(QCoreApplication.translate("VideoParser", u"SRT File (optional): ", None))
+        self.srtSelectLabel.setText(QCoreApplication.translate("VideoParser", u"Metadata File (optional): ", None))
 #if QT_CONFIG(tooltip)
         self.outputLabel.setToolTip(QCoreApplication.translate("VideoParser", u"Destination folder where extracted frame images will be saved.\n"
 "Each frame is saved as a separate image file with timestamp information.", None))
@@ -244,15 +245,15 @@ class Ui_VideoParser(object):
 #endif // QT_CONFIG(tooltip)
         self.videoSelectButton.setText(QCoreApplication.translate("VideoParser", u"Select", None))
 #if QT_CONFIG(tooltip)
-        self.srtSelectLine.setToolTip(QCoreApplication.translate("VideoParser", u"Path to the optional SRT subtitle file with GPS telemetry data.\n"
-"SRT files contain timestamp and location information for video frames.\n"
+        self.srtSelectLine.setToolTip(QCoreApplication.translate("VideoParser", u"Path to the optional metadata file with GPS telemetry data.\n"
+"Supports DJI SRT subtitle files and Skydio CSV flight logs.\n"
 "If provided, extracted frames will include GPS metadata (latitude, longitude, altitude).\n"
 "Can be left empty if location data is not needed.", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(tooltip)
-        self.srtSelectButton.setToolTip(QCoreApplication.translate("VideoParser", u"Browse for optional SRT subtitle file containing GPS telemetry.\n"
-"SRT files are commonly created by DJI drones and other video recording devices.\n"
-"Opens a file selection dialog for SRT files.", None))
+        self.srtSelectButton.setToolTip(QCoreApplication.translate("VideoParser", u"Browse for optional metadata file containing GPS telemetry.\n"
+"Supports DJI SRT subtitle files and Skydio CSV flight logs.\n"
+"Opens a file selection dialog for SRT and CSV files.", None))
 #endif // QT_CONFIG(tooltip)
         self.srtSelectButton.setText(QCoreApplication.translate("VideoParser", u"Select", None))
 #if QT_CONFIG(tooltip)
@@ -276,7 +277,7 @@ class Ui_VideoParser(object):
 "\u2022 Output folder must be selected\n"
 "\u2022 Time interval must be set (default: 5 seconds)\n"
 "The process will extract frames at the specified interval and save them as images.\n"
-"If SRT file is provided, GPS metadata will be embedded in the extracted frames.", None))
+"If a metadata file (SRT or CSV) is provided, GPS metadata will be embedded in the extracted frames.", None))
 #endif // QT_CONFIG(tooltip)
         self.startButton.setText(QCoreApplication.translate("VideoParser", u"Start", None))
 #if QT_CONFIG(tooltip)

--- a/app/helpers/VideoFileHelper.py
+++ b/app/helpers/VideoFileHelper.py
@@ -3,6 +3,7 @@ VideoFileHelper.py - Utilities for handling video files with non-standard stream
 
 Detects and works around MP4 files that embed a thumbnail/cover image as the
 first video stream (e.g. Skydio X10), which causes OpenCV to grab the wrong track.
+Also provides utilities for extracting metadata from video containers.
 """
 
 import os
@@ -10,6 +11,46 @@ import subprocess
 import tempfile
 import json
 import cv2
+from datetime import datetime, timezone
+
+
+def get_video_creation_time(video_path, logger=None):
+    """Extract creation_time from MP4 container via ffprobe.
+
+    Args:
+        video_path: Path to the video file.
+        logger: Optional logger for error reporting.
+
+    Returns:
+        A timezone-aware UTC datetime, or None if extraction fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                'ffprobe', '-v', 'error',
+                '-show_entries', 'format_tags=creation_time',
+                '-of', 'json', video_path
+            ],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            if logger:
+                logger.error(f"ffprobe failed: {result.stderr}")
+            return None
+
+        data = json.loads(result.stdout)
+        creation_time_str = data.get('format', {}).get('tags', {}).get('creation_time')
+        if not creation_time_str:
+            return None
+
+        # Parse ISO 8601 UTC timestamp (e.g. "2024-02-24T19:09:57.000000Z")
+        creation_time_str = creation_time_str.replace('Z', '+00:00')
+        return datetime.fromisoformat(creation_time_str).astimezone(timezone.utc)
+
+    except Exception as e:
+        if logger:
+            logger.error(f"Error extracting video creation time: {e}")
+        return None
 
 
 def detect_thumbnail_track(cap) -> bool:

--- a/app/tests/core/services/test_video_parser_service.py
+++ b/app/tests/core/services/test_video_parser_service.py
@@ -24,7 +24,7 @@ def video_parser_service():
         service = VideoParserService(
             id=1,
             video=video_path,
-            srt=srt_path,
+            metadata_path=srt_path,
             output=output_dir,
             interval=1.0
         )

--- a/resources/views/images/VideoParser.ui
+++ b/resources/views/images/VideoParser.ui
@@ -59,15 +59,16 @@ Click the Select button to browse for a video file.</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>SRT subtitle file containing GPS telemetry and timestamp data.
+           <string>Metadata file containing GPS telemetry data.
+Supports DJI SRT subtitle files and Skydio CSV flight logs.
 Optional: Provides location information for extracted frames.
-Without SRT file, frames will have no GPS metadata.</string>
+Without a metadata file, frames will have no GPS data.</string>
           </property>
           <property name="whatsThis">
-           <string>The SRT file contains timestamped information about the video file.  It is optional, but without it output images won't include location information.</string>
+           <string>The metadata file contains timestamped GPS information for the video.  It is optional, but without it output images won't include location information.  Supports SRT (DJI) and CSV (Skydio) formats.</string>
           </property>
           <property name="text">
-           <string>SRT File (optional): </string>
+           <string>Metadata File (optional): </string>
           </property>
          </widget>
         </item>
@@ -173,8 +174,8 @@ Opens a file selection dialog for video files (MP4, AVI, MOV, etc.).</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>Path to the optional SRT subtitle file with GPS telemetry data.
-SRT files contain timestamp and location information for video frames.
+           <string>Path to the optional metadata file with GPS telemetry data.
+Supports DJI SRT subtitle files and Skydio CSV flight logs.
 If provided, extracted frames will include GPS metadata (latitude, longitude, altitude).
 Can be left empty if location data is not needed.</string>
           </property>
@@ -191,9 +192,9 @@ Can be left empty if location data is not needed.</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>Browse for optional SRT subtitle file containing GPS telemetry.
-SRT files are commonly created by DJI drones and other video recording devices.
-Opens a file selection dialog for SRT files.</string>
+           <string>Browse for optional metadata file containing GPS telemetry.
+Supports DJI SRT subtitle files and Skydio CSV flight logs.
+Opens a file selection dialog for SRT and CSV files.</string>
           </property>
           <property name="text">
            <string>Select</string>
@@ -303,7 +304,7 @@ Requirements:
 • Output folder must be selected
 • Time interval must be set (default: 5 seconds)
 The process will extract frames at the specified interval and save them as images.
-If SRT file is provided, GPS metadata will be embedded in the extracted frames.</string>
+If a metadata file (SRT or CSV) is provided, GPS metadata will be embedded in the extracted frames.</string>
        </property>
        <property name="layoutDirection">
         <enum>Qt::LeftToRight</enum>


### PR DESCRIPTION
## Summary
- Adds support for Skydio X10 CSV flight logs as a metadata source in the Video Parser, alongside existing DJI SRT subtitle files
- Extracts video start time (UTC) from MP4 container via ffprobe, computes each frame's absolute UTC timestamp, and matches to the closest CSV row using binary search
- Converts Skydio GPS altitude from feet MSL to meters for EXIF embedding
- Updates UI label from "SRT File" to "Metadata File" and file picker to accept both `*.srt` and `*.csv`

## Test plan
- [ ] Select a Skydio X10 MP4 + CSV flight log in Video Parser, verify frames are extracted with GPS EXIF data
- [ ] Select a DJI MP4 + SRT file, verify existing SRT flow still works unchanged
- [ ] Run with no metadata file selected, verify frames are created without GPS (no errors)
- [ ] Verify CSV with missing required columns shows a clear error message
- [ ] Run existing tests: `pytest app/tests/core/services/test_video_parser_service.py`