### PR TITLE
fix: Resolve ffmpeg/ffprobe not found on macOS

### DIFF
--- a/app/core/services/VideoParserService.py
+++ b/app/core/services/VideoParserService.py
@@ -10,7 +10,7 @@ from PySide6.QtCore import QObject, Signal, Slot
 
 from core.services.LoggerService import LoggerService
 from helpers.MetaDataHelper import MetaDataHelper
-from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track
+from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track, is_ffmpeg_available, _FFMPEG_USER_MSG
 
 
 class VideoParserService(QObject):
@@ -72,7 +72,10 @@ class VideoParserService(QObject):
                     fps = cap.get(cv2.CAP_PROP_FPS)
                     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
                 else:
-                    self.sig_msg.emit("Error: Failed to remux video file.")
+                    if not is_ffmpeg_available():
+                        self.sig_msg.emit(f"Error: {_FFMPEG_USER_MSG}")
+                    else:
+                        self.sig_msg.emit("Error: Failed to remux video file.")
                     self.sig_done.emit(self.__id, 0)
                     return
 

--- a/app/core/services/streaming/RTMPStreamService.py
+++ b/app/core/services/streaming/RTMPStreamService.py
@@ -7,7 +7,7 @@ color detection applications. Designed for <250ms latency processing.
 
 # Set environment variable to avoid numpy compatibility issues - MUST be first
 from core.services.LoggerService import LoggerService
-from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track
+from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track, is_ffmpeg_available, _FFMPEG_USER_MSG
 from PySide6.QtCore import QObject, QThread, Signal
 from dataclasses import dataclass
 from enum import Enum
@@ -301,7 +301,11 @@ class RTMPStreamService(QThread):
                         self.logger.error("Failed to read frame from remuxed video")
                         return False
                 else:
-                    self.logger.error("Failed to remux video to select main track")
+                    if not is_ffmpeg_available():
+                        self.logger.error(_FFMPEG_USER_MSG)
+                        self.errorOccurred.emit(_FFMPEG_USER_MSG)
+                    else:
+                        self.logger.error("Failed to remux video to select main track")
                     return False
 
             # Log stream properties

--- a/app/helpers/VideoFileHelper.py
+++ b/app/helpers/VideoFileHelper.py
@@ -6,10 +6,82 @@ first video stream (e.g. Skydio X10), which causes OpenCV to grab the wrong trac
 """
 
 import os
+import platform
+import shutil
 import subprocess
 import tempfile
 import json
 import cv2
+
+# Common Homebrew binary directories that may not be in PATH when the app
+# is launched outside a terminal (e.g. from Finder or a .app bundle).
+_HOMEBREW_BIN_DIRS = [
+    '/opt/homebrew/bin',      # Apple Silicon
+    '/usr/local/bin',         # Intel Mac
+]
+
+
+def _which_with_fallback(name):
+    """Find an executable by name, checking PATH then common Homebrew locations."""
+    path = shutil.which(name)
+    if path:
+        return path
+    if platform.system() == 'Darwin':
+        for d in _HOMEBREW_BIN_DIRS:
+            candidate = os.path.join(d, name)
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+    return None
+
+
+def _find_ffprobe():
+    """Locate the ffprobe binary.
+
+    Checks the system PATH first, then common Homebrew locations on macOS,
+    then falls back to the imageio-ffmpeg bundled binary.
+
+    Returns:
+        Absolute path to ffprobe, or None if not found.
+    """
+    path = _which_with_fallback('ffprobe')
+    if path:
+        return path
+    try:
+        import imageio_ffmpeg
+        ffmpeg_path = imageio_ffmpeg.get_ffmpeg_exe()
+        # imageio-ffmpeg bundles ffprobe next to ffmpeg
+        ffprobe_path = os.path.join(os.path.dirname(ffmpeg_path), 'ffprobe')
+        if os.path.isfile(ffprobe_path):
+            return ffprobe_path
+    except (ImportError, RuntimeError):
+        pass
+    return None
+
+
+def _find_ffmpeg():
+    """Locate the ffmpeg binary.
+
+    Checks the system PATH first, then common Homebrew locations on macOS,
+    then falls back to the imageio-ffmpeg bundled binary.
+
+    Returns:
+        Absolute path to ffmpeg, or None if not found.
+    """
+    path = _which_with_fallback('ffmpeg')
+    if path:
+        return path
+    try:
+        import imageio_ffmpeg
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except (ImportError, RuntimeError):
+        pass
+    return None
+
+
+_FFMPEG_MISSING_MSG = (
+    "ffmpeg not found. Install via 'brew install ffmpeg' on macOS "
+    "or add imageio-ffmpeg to your environment."
+)
 
 
 def detect_thumbnail_track(cap) -> bool:
@@ -54,9 +126,16 @@ def remux_to_main_track(source_path, logger=None):
         Caller is responsible for deleting the temp file when done.
     """
     try:
+        ffprobe = _find_ffprobe()
+        ffmpeg = _find_ffmpeg()
+        if not ffprobe or not ffmpeg:
+            if logger:
+                logger.error(_FFMPEG_MISSING_MSG)
+            return None
+
         # Use ffprobe to find the real video stream
         probe = subprocess.run(
-            ['ffprobe', '-v', 'error', '-show_streams', '-of', 'json', source_path],
+            [ffprobe, '-v', 'error', '-show_streams', '-of', 'json', source_path],
             capture_output=True, text=True, timeout=10
         )
         if probe.returncode != 0:
@@ -88,7 +167,7 @@ def remux_to_main_track(source_path, logger=None):
         temp_fd, temp_path = tempfile.mkstemp(suffix='.mp4')
         os.close(temp_fd)
         result = subprocess.run(
-            ['ffmpeg', '-y', '-i', source_path, '-map', f'0:{best_idx}', '-c', 'copy', temp_path],
+            [ffmpeg, '-y', '-i', source_path, '-map', f'0:{best_idx}', '-c', 'copy', temp_path],
             capture_output=True, text=True, timeout=60
         )
         if result.returncode != 0:

--- a/app/helpers/VideoFileHelper.py
+++ b/app/helpers/VideoFileHelper.py
@@ -83,6 +83,20 @@ _FFMPEG_MISSING_MSG = (
     "or add imageio-ffmpeg to your environment."
 )
 
+_FFMPEG_USER_MSG = (
+    "This video requires ffmpeg to process, but ffmpeg was not found. "
+    "Please install ffmpeg (on macOS: 'brew install ffmpeg') and restart the application."
+)
+
+
+def is_ffmpeg_available():
+    """Check whether both ffmpeg and ffprobe can be found.
+
+    Returns:
+        True if both binaries are available, False otherwise.
+    """
+    return _find_ffprobe() is not None and _find_ffmpeg() is not None
+
 
 def detect_thumbnail_track(cap) -> bool:
     """Check if OpenCV grabbed a thumbnail track instead of the real video.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ fastkml
 lxml
 gpxpy>=1.5.0
 imagecodecs
+imageio-ffmpeg


### PR DESCRIPTION
## Summary
- Add helper functions to locate ffmpeg/ffprobe by checking system PATH, common Homebrew locations (`/opt/homebrew/bin`, `/usr/local/bin`), and the `imageio-ffmpeg` bundled binary as a fallback
- Add `imageio-ffmpeg` as a dependency in `requirements.txt`
- Show user-friendly error message in the app UI when ffmpeg is missing, instead of a generic "Failed to remux" or a `FileNotFoundError` crash

## Context
The Skydio X10 thumbnail track fix (commit 7d5a4b8) added `remux_to_main_track()` which calls `ffprobe`/`ffmpeg` as bare command names via `subprocess.run()`. This fails on macOS because:
1. ffmpeg isn't installed by default
2. Even when installed via Homebrew, the process PATH often doesn't include `/opt/homebrew/bin` when the app is launched outside a terminal

## Test plan
- [x] Verified on macOS (Apple Silicon) with ffmpeg installed via Homebrew
- [x] All existing tests pass (860 passed)
- [x] `flake8` lint passes
- [ ] Verify on Windows (ffmpeg found via system PATH — existing behavior unchanged)
- [ ] Test with compiled PyInstaller build on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)