### PR TITLE
feat: Add image mask filter to Results Viewer

### DIFF
--- a/app/core/controllers/images/VideoParser.py
+++ b/app/core/controllers/images/VideoParser.py
@@ -62,15 +62,15 @@ class VideoParser(TranslationMixin, QDialog, Ui_VideoParser):
                 self.videoSelectLine.setText(filename.replace('/', '\\'))
 
     def _srtSelectButton_clicked(self):
-        """Handles the subtitle (SRT) file selection button click.
+        """Handles the metadata file selection button click.
 
-        Opens a file dialog for the user to select an SRT file, then
-        updates the `srtSelectLine` text field with the selected file path.
+        Opens a file dialog for the user to select an SRT or CSV metadata file,
+        then updates the `srtSelectLine` text field with the selected file path.
         """
         filename, _ = QFileDialog.getOpenFileName(
             self,
-            self.tr("Select a SRT file"),
-            filter=self.tr("SRT (*.srt)")
+            self.tr("Select a Metadata File"),
+            filter=self.tr("Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)")
         )
         if filename:
             self.srtSelectLine.setText(filename)
@@ -265,7 +265,7 @@ class VideoParser(TranslationMixin, QDialog, Ui_VideoParser):
             theme (str): Name of the active theme used to resolve icon paths.
         """
         self.videoSelectButton.setIcon(IconHelper.create_icon('fa6.file-video', theme))
-        self.srtSelectButton.setIcon(IconHelper.create_icon('mdi.subtitles', theme))
+        self.srtSelectButton.setIcon(IconHelper.create_icon('mdi.file-document-outline', theme))
         self.outputSelectButton.setIcon(IconHelper.create_icon('fa6.folder-open', theme))
         self.startButton.setIcon(IconHelper.create_icon('fa6s.play', theme))
         self.cancelButton.setIcon(IconHelper.create_icon('mdi.close-circle', theme))

--- a/app/core/controllers/images/viewer/aoi/AOIController.py
+++ b/app/core/controllers/images/viewer/aoi/AOIController.py
@@ -6,6 +6,7 @@ UI manipulation is handled by AOIUIComponent.
 """
 
 import colorsys
+import cv2
 import fnmatch
 import json
 import math
@@ -66,6 +67,13 @@ class AOIController(TranslationMixin):
         self.filter_temperature_max = None  # Maximum temperature (Celsius) for filtering
         self.filter_heatmap_mode = 'off'  # 'off', 'filter', or 'display'
         self.filter_heatmap_threshold = 75  # Percentile threshold (0-100)
+        self.filter_mask_path = None  # File path to mask image
+        self.filter_mask_mode = 'include'  # 'include' or 'exclude'
+
+        # Mask cache for image mask filter
+        self._mask_image_raw = None  # Raw grayscale mask (loaded once from file)
+        self._mask_cache = {}  # {(width, height): binary_mask_ndarray}
+        self._mask_cache_path = None  # Path of currently cached mask file
 
         # Index mapping from original AOI index to visible container index
         # This is rebuilt when thumbnails are loaded (after sorting and filtering)
@@ -1005,10 +1013,70 @@ class AOIController(TranslationMixin):
                             if self.filter_heatmap_mode == 'display' and not inHotZone:
                                 continue
 
+            # Apply image mask filter
+            if self.filter_mask_path is not None:
+                image = self.parent.images[img_idx] if hasattr(self.parent, 'images') else None
+                if image:
+                    imgWidth = image.get('width')
+                    imgHeight = image.get('height')
+                    if imgWidth and imgHeight:
+                        mask = self._get_scaled_mask(imgWidth, imgHeight)
+                        if mask is not None:
+                            cx, cy = aoi.get('center', (0, 0))
+                            cx = max(0, min(int(cx), imgWidth - 1))
+                            cy = max(0, min(int(cy), imgHeight - 1))
+                            in_mask = mask[int(cy), int(cx)] > 0
+                            if self.filter_mask_mode == 'include' and not in_mask:
+                                continue
+                            if self.filter_mask_mode == 'exclude' and in_mask:
+                                continue
+
             # AOI passed all filters
             filtered.append((original_idx, aoi))
 
         return filtered
+
+    def _get_scaled_mask(self, width, height):
+        """Get binary mask scaled to the specified dimensions, using cache.
+
+        Args:
+            width: Target width
+            height: Target height
+
+        Returns:
+            Binary numpy array (height, width) where 255=white, 0=black, or None
+        """
+        if self.filter_mask_path is None:
+            return None
+
+        # Reload if path changed
+        if self._mask_cache_path != self.filter_mask_path:
+            self._mask_image_raw = cv2.imread(self.filter_mask_path, cv2.IMREAD_GRAYSCALE)
+            self._mask_cache = {}
+            self._mask_cache_path = self.filter_mask_path
+            if self._mask_image_raw is None:
+                self.logger.warning(f"Could not load mask image: {self.filter_mask_path}")
+                return None
+
+        if self._mask_image_raw is None:
+            return None
+
+        # Check cache
+        key = (width, height)
+        if key in self._mask_cache:
+            return self._mask_cache[key]
+
+        # Resize and threshold
+        scaled = cv2.resize(self._mask_image_raw, (width, height), interpolation=cv2.INTER_LINEAR)
+        _, binary = cv2.threshold(scaled, 127, 255, cv2.THRESH_BINARY)
+        self._mask_cache[key] = binary
+        return binary
+
+    def _invalidate_mask_cache(self):
+        """Clear the mask image cache."""
+        self._mask_image_raw = None
+        self._mask_cache = {}
+        self._mask_cache_path = None
 
     def set_sort_method(self, method, color_hue=None):
         """Set the sort method for AOIs.
@@ -1056,6 +1124,11 @@ class AOIController(TranslationMixin):
         self.filter_temperature_max = filters.get('temperature_max')
         self.filter_heatmap_mode = filters.get('heatmap_mode', 'off')
         self.filter_heatmap_threshold = filters.get('heatmap_threshold', 75)
+        new_mask_path = filters.get('mask_filter_path')
+        if new_mask_path != self.filter_mask_path:
+            self._invalidate_mask_cache()
+        self.filter_mask_path = new_mask_path
+        self.filter_mask_mode = filters.get('mask_filter_mode', 'include')
 
         # Refresh AOI display
         self.refresh_aoi_display()
@@ -1290,7 +1363,9 @@ class AOIController(TranslationMixin):
             'temperature_min': self.filter_temperature_min,
             'temperature_max': self.filter_temperature_max,
             'heatmap_mode': self.filter_heatmap_mode,
-            'heatmap_threshold': self.filter_heatmap_threshold
+            'heatmap_threshold': self.filter_heatmap_threshold,
+            'mask_filter_path': self.filter_mask_path,
+            'mask_filter_mode': self.filter_mask_mode
         }
 
         # Get temperature unit and thermal flag from parent viewer

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -66,6 +66,8 @@ class GalleryController:
         self.filter_temperature_max = None
         self.filter_heatmap_mode = 'off'
         self.filter_heatmap_threshold = 75
+        self.filter_mask_path = None
+        self.filter_mask_mode = 'include'
 
         # Heatmap service for spatial density filtering
         self.heatmap_service = HeatmapService()
@@ -464,6 +466,24 @@ class GalleryController:
                         if self.filter_heatmap_mode == 'display' and not inHotZone:
                             continue
 
+            # Apply image mask filter
+            if self.filter_mask_path is not None and hasattr(self.parent, 'aoi_controller'):
+                image = self.parent.images[img_idx] if self.parent and hasattr(self.parent, 'images') else None
+                if image:
+                    imgWidth = image.get('width')
+                    imgHeight = image.get('height')
+                    if imgWidth and imgHeight:
+                        mask = self.parent.aoi_controller._get_scaled_mask(imgWidth, imgHeight)
+                        if mask is not None:
+                            cx, cy = aoi.get('center', (0, 0))
+                            cx = max(0, min(int(cx), imgWidth - 1))
+                            cy = max(0, min(int(cy), imgHeight - 1))
+                            in_mask = mask[int(cy), int(cx)] > 0
+                            if self.filter_mask_mode == 'include' and not in_mask:
+                                continue
+                            if self.filter_mask_mode == 'exclude' and in_mask:
+                                continue
+
             # AOI passed all filters
             filtered.append((img_idx, aoi_idx, aoi))
 
@@ -588,6 +608,8 @@ class GalleryController:
         self.filter_temperature_max = filters.get('temperature_max')
         self.filter_heatmap_mode = filters.get('heatmap_mode', 'off')
         self.filter_heatmap_threshold = filters.get('heatmap_threshold', 75)
+        self.filter_mask_path = filters.get('mask_filter_path')
+        self.filter_mask_mode = filters.get('mask_filter_mode', 'include')
 
         self.load_all_aois()  # Reload with new filters
 
@@ -620,6 +642,10 @@ class GalleryController:
             self.filter_heatmap_mode = aoi_ctrl.filter_heatmap_mode
         if hasattr(aoi_ctrl, 'filter_heatmap_threshold'):
             self.filter_heatmap_threshold = aoi_ctrl.filter_heatmap_threshold
+        if hasattr(aoi_ctrl, 'filter_mask_path'):
+            self.filter_mask_path = aoi_ctrl.filter_mask_path
+        if hasattr(aoi_ctrl, 'filter_mask_mode'):
+            self.filter_mask_mode = aoi_ctrl.filter_mask_mode
 
         # Sync sort settings
         self.sort_method = aoi_ctrl.sort_method

--- a/app/core/services/VideoParserService.py
+++ b/app/core/services/VideoParserService.py
@@ -1,16 +1,18 @@
 import os
 import shutil
+from bisect import bisect_left
 from pathlib import Path
 import re
 import cv2
 import math
-from datetime import datetime, timedelta
+import pandas as pd
+from datetime import datetime, timedelta, timezone
 
 from PySide6.QtCore import QObject, Signal, Slot
 
 from core.services.LoggerService import LoggerService
 from helpers.MetaDataHelper import MetaDataHelper
-from helpers.VideoFileHelper import detect_thumbnail_track, remux_to_main_track
+from helpers.VideoFileHelper import get_video_creation_time, detect_thumbnail_track, remux_to_main_track
 
 
 class VideoParserService(QObject):
@@ -28,13 +30,13 @@ class VideoParserService(QObject):
     sig_msg = Signal(str)
     sig_done = Signal(int, int)
 
-    def __init__(self, id, video, srt, output, interval):
+    def __init__(self, id, video, metadata_path, output, interval):
         """Initialize the VideoParserService with parameters for video processing.
 
         Args:
             id: Numeric ID for this parser instance.
             video: Path to the video file to be processed.
-            srt: Path to the SRT file with metadata for processing.
+            metadata_path: Path to a metadata file (SRT or CSV) with GPS data.
             output: Path to the output directory where images will be stored.
             interval: Time interval in seconds between frames to capture.
         """
@@ -42,18 +44,18 @@ class VideoParserService(QObject):
         super().__init__()
         self.__id = id
         self.video_path = video
-        self.srt_path = srt
+        self.metadata_path = metadata_path
         self.output_dir = output
         self.interval = interval
         self.cancelled = False
 
     @Slot()
     def process_video(self):
-        """Convert video frames to still images and attach metadata from an SRT file if provided.
+        """Convert video frames to still images and attach GPS metadata if provided.
 
-        Captures images at specified intervals, extracting GPS metadata from the SRT file
-        and embedding it into each image where available. Emits sig_msg for status updates
-        and sig_done when complete.
+        Supports SRT subtitle files (DJI) and CSV flight logs (Skydio).
+        Captures images at specified intervals, embedding GPS metadata into each
+        image where available. Emits sig_msg for status updates and sig_done when complete.
         """
         remuxed_temp_path = None
         try:
@@ -85,38 +87,29 @@ class VideoParserService(QObject):
             est_capture = math.floor(duration / self.interval) + 1
             self.sig_msg.emit(f"Video length: {duration} seconds. Estimated {est_capture} images will be captured.")
 
-            # Parse SRT file if provided
+            # Parse metadata file if provided
             srt_list = []
-            if self.srt_path:
-                self.sig_msg.emit("Parsing SRT File")
-                try:
-                    srt_data = Path(self.srt_path).read_text()
-                    srt_entries = re.split("(?:\r?\n){2,}", srt_data)
-                    for entry in srt_entries:
-                        data = re.split("(?:\r?\n)", entry)
-                        if len(data) >= 5:
-                            times = re.split(r"\s.*\s", data[1])
-                            start_time = datetime.strptime(times[0], '%H:%M:%S,%f')
-                            end_time = datetime.strptime(times[1], '%H:%M:%S,%f')
+            csv_entries = []
+            video_start_utc = None
+            metadata_format = self._detect_metadata_format(self.metadata_path)
 
-                            uav_data = re.findall(r'(?<=\[).+?(?=\])', data[4])
-                            uav_dict = {split[0]: split[1] for entry in uav_data for split in [re.split(r"\s*:\s*", entry)]}
-                            longitude = float(uav_dict.get('longitude')) if 'longitude' in uav_dict else None
-                            # Extra logic for longitude misspelling in some SRT files
-                            if longitude is None:
-                                longitude = float(uav_dict.get('longtitude')) if 'longtitude' in uav_dict else None
-                            srt_list.append({
-                                "start": start_time,
-                                "end": end_time,
-                                "latitude": float(uav_dict.get('latitude')) if 'latitude' in uav_dict else None,
-                                "longitude": longitude,
-                                "altitude": float(uav_dict.get('altitude', 0))
-                            })
-                except Exception as e:
-                    self.sig_msg.emit(f"Error parsing SRT file: {str(e)}")
+            if metadata_format == 'srt':
+                srt_list = self._parse_srt_file(self.metadata_path)
+                if srt_list is None:
+                    return
+            elif metadata_format == 'csv':
+                result = self._parse_csv_flight_log(self.metadata_path, self.video_path)
+                if result is None:
+                    return
+                video_start_utc, csv_entries = result
+                if video_start_utc is None:
+                    self.sig_msg.emit("Error: Could not determine video start time from MP4 metadata.")
+                    self.sig_msg.emit("Ensure the video file has creation_time metadata (ffprobe required).")
+                    self.sig_done.emit(self.__id, 0)
                     return
             else:
-                self.sig_msg.emit("SRT File Not Provided")
+                self.sig_msg.emit("Metadata File Not Provided")
+
             self._setup_output_dir()
             time_marker = 0
             image_count = 0
@@ -139,18 +132,21 @@ class VideoParserService(QObject):
                     self.sig_msg.emit(f"Frame capture failed at frame {frame_id}, stopping.")
                     break
 
-                # Get the actual timestamp after reading the frame
-                ms = cap.get(cv2.CAP_PROP_POS_MSEC)
-                video_time = datetime(1900, 1, 1) + timedelta(milliseconds=ms)
-
-                # Find corresponding SRT metadata
-                item = next((item for item in srt_list if item["start"] <= video_time <= item["end"]), None)
-
                 output_file = f"{self.output_dir}/{base_name}_{time_marker}s.jpg"
                 cv2.imwrite(output_file, image)
 
-                if item and item["latitude"] and item["longitude"]:
-                    MetaDataHelper.add_gps_data(output_file, item["latitude"], item["longitude"], item["altitude"])
+                if metadata_format == 'srt':
+                    # Get the actual timestamp after reading the frame
+                    ms = cap.get(cv2.CAP_PROP_POS_MSEC)
+                    video_time = datetime(1900, 1, 1) + timedelta(milliseconds=ms)
+                    item = next((item for item in srt_list if item["start"] <= video_time <= item["end"]), None)
+                    if item and item["latitude"] and item["longitude"]:
+                        MetaDataHelper.add_gps_data(output_file, item["latitude"], item["longitude"], item["altitude"])
+                elif metadata_format == 'csv':
+                    frame_utc = video_start_utc + timedelta(seconds=time_marker)
+                    entry = self._find_closest_csv_entry(csv_entries, frame_utc)
+                    if entry and entry['latitude'] and entry['longitude']:
+                        MetaDataHelper.add_gps_data(output_file, entry['latitude'], entry['longitude'], entry['altitude_m'])
 
                 image_count += 1
                 time_marker += self.interval
@@ -175,6 +171,145 @@ class VideoParserService(QObject):
                 except OSError:
                     pass
             self.sig_done.emit(self.__id, 0)
+
+    def _detect_metadata_format(self, path):
+        """Determine the metadata file format from its extension.
+
+        Args:
+            path: File path string.
+
+        Returns:
+            'srt', 'csv', or None.
+        """
+        if not path:
+            return None
+        ext = os.path.splitext(path)[1].lower()
+        if ext == '.srt':
+            return 'srt'
+        if ext == '.csv':
+            return 'csv'
+        return None
+
+    def _parse_srt_file(self, srt_path):
+        """Parse a DJI SRT subtitle file for GPS metadata.
+
+        Args:
+            srt_path: Path to the SRT file.
+
+        Returns:
+            List of dicts with start, end, latitude, longitude, altitude keys,
+            or None on parse failure.
+        """
+        self.sig_msg.emit("Parsing SRT File")
+        srt_list = []
+        try:
+            srt_data = Path(srt_path).read_text()
+            srt_entries = re.split("(?:\r?\n){2,}", srt_data)
+            for entry in srt_entries:
+                data = re.split("(?:\r?\n)", entry)
+                if len(data) >= 5:
+                    times = re.split(r"\s.*\s", data[1])
+                    start_time = datetime.strptime(times[0], '%H:%M:%S,%f')
+                    end_time = datetime.strptime(times[1], '%H:%M:%S,%f')
+
+                    uav_data = re.findall(r'(?<=\[).+?(?=\])', data[4])
+                    uav_dict = {split[0]: split[1] for entry in uav_data for split in [re.split(r"\s*:\s*", entry)]}
+                    longitude = float(uav_dict.get('longitude')) if 'longitude' in uav_dict else None
+                    # Extra logic for longitude misspelling in some SRT files
+                    if longitude is None:
+                        longitude = float(uav_dict.get('longtitude')) if 'longtitude' in uav_dict else None
+                    srt_list.append({
+                        "start": start_time,
+                        "end": end_time,
+                        "latitude": float(uav_dict.get('latitude')) if 'latitude' in uav_dict else None,
+                        "longitude": longitude,
+                        "altitude": float(uav_dict.get('altitude', 0))
+                    })
+            return srt_list
+        except Exception as e:
+            self.sig_msg.emit(f"Error parsing SRT file: {str(e)}")
+            return None
+
+    def _parse_csv_flight_log(self, csv_path, video_path):
+        """Parse a Skydio CSV flight log for GPS metadata.
+
+        Args:
+            csv_path: Path to the CSV flight log.
+            video_path: Path to the video file (used to extract creation_time).
+
+        Returns:
+            Tuple of (video_start_utc, sorted list of entry dicts) or None on failure.
+            Each entry dict has: utc_time, latitude, longitude, altitude_m.
+        """
+        self.sig_msg.emit("Parsing CSV flight log...")
+        try:
+            df = pd.read_csv(csv_path)
+
+            # Validate required columns
+            required_cols = ['Datetime (UTC)', 'Latitude', 'Longitude', 'GPS Altitude (ft MSL)']
+            missing = [col for col in required_cols if col not in df.columns]
+            if missing:
+                self.sig_msg.emit(f"Error: CSV missing required columns: {', '.join(missing)}")
+                return None
+
+            # Parse timestamps and convert altitude from feet to meters
+            df['utc_time'] = pd.to_datetime(df['Datetime (UTC)'], utc=True)
+            df['altitude_m'] = df['GPS Altitude (ft MSL)'] * 0.3048
+            df = df.sort_values('utc_time').reset_index(drop=True)
+
+            csv_entries = []
+            for _, row in df.iterrows():
+                csv_entries.append({
+                    'utc_time': row['utc_time'].to_pydatetime(),
+                    'latitude': row['Latitude'],
+                    'longitude': row['Longitude'],
+                    'altitude_m': row['altitude_m']
+                })
+
+            self.sig_msg.emit(f"Loaded {len(csv_entries)} GPS entries from CSV")
+
+            # Get video start time from MP4 container metadata
+            video_start_utc = get_video_creation_time(video_path, self.logger)
+            if video_start_utc:
+                self.sig_msg.emit(f"Video start time (UTC): {video_start_utc.isoformat()}")
+            return (video_start_utc, csv_entries)
+
+        except Exception as e:
+            self.sig_msg.emit(f"Error parsing CSV flight log: {str(e)}")
+            return None
+
+    def _find_closest_csv_entry(self, csv_entries, target_utc, max_delta_seconds=5.0):
+        """Find the CSV entry closest in time to the target UTC timestamp.
+
+        Uses binary search for efficiency on the sorted entry list.
+
+        Args:
+            csv_entries: Sorted list of entry dicts with 'utc_time' keys.
+            target_utc: Target UTC datetime to match.
+            max_delta_seconds: Maximum allowed time difference in seconds.
+
+        Returns:
+            The closest entry dict, or None if no entry is within max_delta_seconds.
+        """
+        if not csv_entries:
+            return None
+
+        timestamps = [e['utc_time'] for e in csv_entries]
+        pos = bisect_left(timestamps, target_utc)
+
+        # Check the entries at pos and pos-1 to find the closest
+        best = None
+        best_delta = None
+        for i in [pos - 1, pos]:
+            if 0 <= i < len(csv_entries):
+                delta = abs((csv_entries[i]['utc_time'] - target_utc).total_seconds())
+                if best_delta is None or delta < best_delta:
+                    best_delta = delta
+                    best = csv_entries[i]
+
+        if best_delta is not None and best_delta <= max_delta_seconds:
+            return best
+        return None
 
     @Slot()
     def process_cancel(self):

--- a/app/core/views/images/VideoParser_ui.py
+++ b/app/core/views/images/VideoParser_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'VideoParser.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -19,7 +19,7 @@ from PySide6.QtWidgets import (QApplication, QDialog, QDoubleSpinBox, QFrame,
     QGridLayout, QHBoxLayout, QLabel, QLineEdit,
     QPlainTextEdit, QPushButton, QSizePolicy, QSpacerItem,
     QVBoxLayout, QWidget)
-from . import resources_rc
+import resources_rc
 
 class Ui_VideoParser(object):
     def setupUi(self, VideoParser):
@@ -209,14 +209,15 @@ class Ui_VideoParser(object):
 "Click the Select button to browse for a video file.", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(tooltip)
-        self.srtSelectLabel.setToolTip(QCoreApplication.translate("VideoParser", u"SRT subtitle file containing GPS telemetry and timestamp data.\n"
+        self.srtSelectLabel.setToolTip(QCoreApplication.translate("VideoParser", u"Metadata file containing GPS telemetry data.\n"
+"Supports DJI SRT subtitle files and Skydio CSV flight logs.\n"
 "Optional: Provides location information for extracted frames.\n"
-"Without SRT file, frames will have no GPS metadata.", None))
+"Without a metadata file, frames will have no GPS data.", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(whatsthis)
-        self.srtSelectLabel.setWhatsThis(QCoreApplication.translate("VideoParser", u"The SRT file contains timestamped information about the video file.  It is optional, but without it output images won't include location information.", None))
+        self.srtSelectLabel.setWhatsThis(QCoreApplication.translate("VideoParser", u"The metadata file contains timestamped GPS information for the video.  It is optional, but without it output images won't include location information.  Supports SRT (DJI) and CSV (Skydio) formats.", None))
 #endif // QT_CONFIG(whatsthis)
-        self.srtSelectLabel.setText(QCoreApplication.translate("VideoParser", u"SRT File (optional): ", None))
+        self.srtSelectLabel.setText(QCoreApplication.translate("VideoParser", u"Metadata File (optional): ", None))
 #if QT_CONFIG(tooltip)
         self.outputLabel.setToolTip(QCoreApplication.translate("VideoParser", u"Destination folder where extracted frame images will be saved.\n"
 "Each frame is saved as a separate image file with timestamp information.", None))
@@ -244,15 +245,15 @@ class Ui_VideoParser(object):
 #endif // QT_CONFIG(tooltip)
         self.videoSelectButton.setText(QCoreApplication.translate("VideoParser", u"Select", None))
 #if QT_CONFIG(tooltip)
-        self.srtSelectLine.setToolTip(QCoreApplication.translate("VideoParser", u"Path to the optional SRT subtitle file with GPS telemetry data.\n"
-"SRT files contain timestamp and location information for video frames.\n"
+        self.srtSelectLine.setToolTip(QCoreApplication.translate("VideoParser", u"Path to the optional metadata file with GPS telemetry data.\n"
+"Supports DJI SRT subtitle files and Skydio CSV flight logs.\n"
 "If provided, extracted frames will include GPS metadata (latitude, longitude, altitude).\n"
 "Can be left empty if location data is not needed.", None))
 #endif // QT_CONFIG(tooltip)
 #if QT_CONFIG(tooltip)
-        self.srtSelectButton.setToolTip(QCoreApplication.translate("VideoParser", u"Browse for optional SRT subtitle file containing GPS telemetry.\n"
-"SRT files are commonly created by DJI drones and other video recording devices.\n"
-"Opens a file selection dialog for SRT files.", None))
+        self.srtSelectButton.setToolTip(QCoreApplication.translate("VideoParser", u"Browse for optional metadata file containing GPS telemetry.\n"
+"Supports DJI SRT subtitle files and Skydio CSV flight logs.\n"
+"Opens a file selection dialog for SRT and CSV files.", None))
 #endif // QT_CONFIG(tooltip)
         self.srtSelectButton.setText(QCoreApplication.translate("VideoParser", u"Select", None))
 #if QT_CONFIG(tooltip)
@@ -276,7 +277,7 @@ class Ui_VideoParser(object):
 "\u2022 Output folder must be selected\n"
 "\u2022 Time interval must be set (default: 5 seconds)\n"
 "The process will extract frames at the specified interval and save them as images.\n"
-"If SRT file is provided, GPS metadata will be embedded in the extracted frames.", None))
+"If a metadata file (SRT or CSV) is provided, GPS metadata will be embedded in the extracted frames.", None))
 #endif // QT_CONFIG(tooltip)
         self.startButton.setText(QCoreApplication.translate("VideoParser", u"Start", None))
 #if QT_CONFIG(tooltip)

--- a/app/core/views/images/viewer/dialogs/AOIFilterDialog.py
+++ b/app/core/views/images/viewer/dialogs/AOIFilterDialog.py
@@ -1,13 +1,15 @@
-"""AOIFilterDialog - Dialog for filtering AOIs by color, pixel area, and spatial density."""
+"""AOIFilterDialog - Dialog for filtering AOIs by color, pixel area, spatial density, and image mask."""
 
+import colorsys
+import os
 from PySide6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLabel,
                                QPushButton, QGroupBox, QSlider, QSpinBox,
-                               QCheckBox, QColorDialog, QLineEdit, QDoubleSpinBox,
-                               QRadioButton, QButtonGroup, QFrame)
+                               QCheckBox, QColorDialog, QFileDialog, QLineEdit,
+                               QDoubleSpinBox, QRadioButton, QButtonGroup, QFrame,
+                               QMessageBox)
 from PySide6.QtCore import Qt
-from helpers.TranslationMixin import TranslationMixin
 from PySide6.QtGui import QColor
-import colorsys
+from helpers.TranslationMixin import TranslationMixin
 
 
 class AOIFilterDialog(TranslationMixin, QDialog):
@@ -59,6 +61,10 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         self.heatmap_service = heatmap_service
         self.heatmap_mode = current_filters.get('heatmap_mode', 'off')
         self.heatmap_threshold = current_filters.get('heatmap_threshold', 75)
+
+        # Mask filter state
+        self.mask_filter_path = current_filters.get('mask_filter_path', None)
+        self.mask_filter_mode = current_filters.get('mask_filter_mode', 'include')
 
         self.setupUi()
         self._apply_translations()
@@ -400,6 +406,62 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         heatmap_group.setLayout(heatmap_layout)
         layout.addWidget(heatmap_group)
 
+        # ===== Image Mask Filter =====
+        mask_group = QGroupBox(self.tr("Image Mask Filter"))
+        mask_layout = QVBoxLayout()
+
+        # Enable mask filter checkbox
+        self.mask_filter_enabled = QCheckBox(self.tr("Enable Image Mask Filter"))
+        self.mask_filter_enabled.setChecked(self.mask_filter_path is not None)
+        self.mask_filter_enabled.toggled.connect(self.on_mask_filter_toggled)
+        mask_layout.addWidget(self.mask_filter_enabled)
+
+        # Mask filter mode radio buttons
+        self.mask_mode_group = QButtonGroup(self)
+        self.mask_include_radio = QRadioButton(self.tr("Show Only Detections in Mask"))
+        self.mask_exclude_radio = QRadioButton(self.tr("Exclude Detections in Mask"))
+        self.mask_mode_group.addButton(self.mask_include_radio, 0)
+        self.mask_mode_group.addButton(self.mask_exclude_radio, 1)
+
+        if self.mask_filter_mode == 'exclude':
+            self.mask_exclude_radio.setChecked(True)
+        else:
+            self.mask_include_radio.setChecked(True)
+
+        mask_mode_layout = QHBoxLayout()
+        mask_mode_layout.addWidget(self.mask_include_radio)
+        mask_mode_layout.addWidget(self.mask_exclude_radio)
+        mask_mode_layout.addStretch()
+        mask_layout.addLayout(mask_mode_layout)
+
+        # File selection row
+        file_layout = QHBoxLayout()
+        self.mask_path_display = QLineEdit()
+        self.mask_path_display.setReadOnly(True)
+        self.mask_path_display.setPlaceholderText(self.tr("No mask image selected"))
+        if self.mask_filter_path:
+            self.mask_path_display.setText(os.path.basename(self.mask_filter_path))
+        file_layout.addWidget(self.mask_path_display)
+
+        self.mask_browse_button = QPushButton(self.tr("Browse..."))
+        self.mask_browse_button.clicked.connect(self.browse_mask_image)
+        file_layout.addWidget(self.mask_browse_button)
+
+        self.mask_clear_button = QPushButton(self.tr("Clear"))
+        self.mask_clear_button.clicked.connect(self.clear_mask_image)
+        file_layout.addWidget(self.mask_clear_button)
+
+        mask_layout.addLayout(file_layout)
+
+        # Info label
+        mask_info = QLabel(self.tr("White regions = areas of interest. Mask is scaled to each image's dimensions."))
+        mask_info.setStyleSheet("QLabel { color: gray; font-size: 9pt; }")
+        mask_info.setWordWrap(True)
+        mask_layout.addWidget(mask_info)
+
+        mask_group.setLayout(mask_layout)
+        layout.addWidget(mask_group)
+
         # Spacer
         layout.addStretch()
 
@@ -431,6 +493,7 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         self.on_area_filter_toggled(self.area_filter_enabled.isChecked())
         self.on_temperature_filter_toggled(self.temperature_filter_enabled.isChecked())
         self.on_heatmap_mode_changed(self.heatmap_mode_group.checkedId())
+        self.on_mask_filter_toggled(self.mask_filter_enabled.isChecked())
         self.update_color_preview()
 
     def showEvent(self, event):
@@ -517,6 +580,43 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         self.heatmap_threshold = value
         self.heatmap_threshold_label.setText(f"{value}%")
 
+    def on_mask_filter_toggled(self, checked):
+        """Enable/disable mask filter controls."""
+        self.mask_include_radio.setEnabled(checked)
+        self.mask_exclude_radio.setEnabled(checked)
+        self.mask_browse_button.setEnabled(checked)
+        self.mask_clear_button.setEnabled(checked)
+        self.mask_path_display.setEnabled(checked)
+
+    def browse_mask_image(self):
+        """Open file dialog to select a mask image."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("Select Mask Image"),
+            "",
+            self.tr("Images (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)")
+        )
+
+        if file_path:
+            from core.services.streaming.MaskManager import MaskManager
+            is_valid, error_msg, dimensions = MaskManager.validate_mask_image(file_path)
+
+            if not is_valid:
+                QMessageBox.warning(
+                    self, self.tr("Invalid Image"),
+                    error_msg or self.tr("Could not load the selected image. Please choose a valid image file.")
+                )
+                return
+
+            self.mask_filter_path = file_path
+            self.mask_path_display.setText(os.path.basename(file_path))
+
+    def clear_mask_image(self):
+        """Clear the selected mask image."""
+        self.mask_filter_path = None
+        self.mask_path_display.clear()
+        self.mask_path_display.setPlaceholderText(self.tr("No mask image selected"))
+
     def _update_heatmap_info_label(self):
         """Update the heatmap info label based on current mode."""
         mode_id = self.heatmap_mode_group.checkedId()
@@ -568,6 +668,15 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         self.heatmap_threshold_slider.setValue(75)
         self.heatmap_threshold_label.setText("75%")
         self.on_heatmap_mode_changed(0)
+
+        # Reset mask filter
+        self.mask_filter_enabled.setChecked(False)
+        self.mask_filter_path = None
+        self.mask_filter_mode = 'include'
+        self.mask_include_radio.setChecked(True)
+        self.mask_path_display.clear()
+        self.mask_path_display.setPlaceholderText(self.tr("No mask image selected"))
+        self.on_mask_filter_toggled(False)
 
     def get_filters(self):
         """Get the current filter settings.
@@ -627,6 +736,8 @@ class AOIFilterDialog(TranslationMixin, QDialog):
             'temperature_min': temp_min,
             'temperature_max': temp_max,
             'heatmap_mode': heatmap_mode,
-            'heatmap_threshold': self.heatmap_threshold
+            'heatmap_threshold': self.heatmap_threshold,
+            'mask_filter_path': self.mask_filter_path if self.mask_filter_enabled.isChecked() else None,
+            'mask_filter_mode': 'exclude' if self.mask_exclude_radio.isChecked() else 'include'
         }
         return filters

--- a/app/helpers/VideoFileHelper.py
+++ b/app/helpers/VideoFileHelper.py
@@ -3,6 +3,7 @@ VideoFileHelper.py - Utilities for handling video files with non-standard stream
 
 Detects and works around MP4 files that embed a thumbnail/cover image as the
 first video stream (e.g. Skydio X10), which causes OpenCV to grab the wrong track.
+Also provides utilities for extracting metadata from video containers.
 """
 
 import os
@@ -10,6 +11,46 @@ import subprocess
 import tempfile
 import json
 import cv2
+from datetime import datetime, timezone
+
+
+def get_video_creation_time(video_path, logger=None):
+    """Extract creation_time from MP4 container via ffprobe.
+
+    Args:
+        video_path: Path to the video file.
+        logger: Optional logger for error reporting.
+
+    Returns:
+        A timezone-aware UTC datetime, or None if extraction fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                'ffprobe', '-v', 'error',
+                '-show_entries', 'format_tags=creation_time',
+                '-of', 'json', video_path
+            ],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            if logger:
+                logger.error(f"ffprobe failed: {result.stderr}")
+            return None
+
+        data = json.loads(result.stdout)
+        creation_time_str = data.get('format', {}).get('tags', {}).get('creation_time')
+        if not creation_time_str:
+            return None
+
+        # Parse ISO 8601 UTC timestamp (e.g. "2024-02-24T19:09:57.000000Z")
+        creation_time_str = creation_time_str.replace('Z', '+00:00')
+        return datetime.fromisoformat(creation_time_str).astimezone(timezone.utc)
+
+    except Exception as e:
+        if logger:
+            logger.error(f"Error extracting video creation time: {e}")
+        return None
 
 
 def detect_thumbnail_track(cap) -> bool:

--- a/app/tests/core/services/test_video_parser_service.py
+++ b/app/tests/core/services/test_video_parser_service.py
@@ -24,7 +24,7 @@ def video_parser_service():
         service = VideoParserService(
             id=1,
             video=video_path,
-            srt=srt_path,
+            metadata_path=srt_path,
             output=output_dir,
             interval=1.0
         )

--- a/resources/views/images/VideoParser.ui
+++ b/resources/views/images/VideoParser.ui
@@ -59,15 +59,16 @@ Click the Select button to browse for a video file.</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>SRT subtitle file containing GPS telemetry and timestamp data.
+           <string>Metadata file containing GPS telemetry data.
+Supports DJI SRT subtitle files and Skydio CSV flight logs.
 Optional: Provides location information for extracted frames.
-Without SRT file, frames will have no GPS metadata.</string>
+Without a metadata file, frames will have no GPS data.</string>
           </property>
           <property name="whatsThis">
-           <string>The SRT file contains timestamped information about the video file.  It is optional, but without it output images won't include location information.</string>
+           <string>The metadata file contains timestamped GPS information for the video.  It is optional, but without it output images won't include location information.  Supports SRT (DJI) and CSV (Skydio) formats.</string>
           </property>
           <property name="text">
-           <string>SRT File (optional): </string>
+           <string>Metadata File (optional): </string>
           </property>
          </widget>
         </item>
@@ -173,8 +174,8 @@ Opens a file selection dialog for video files (MP4, AVI, MOV, etc.).</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>Path to the optional SRT subtitle file with GPS telemetry data.
-SRT files contain timestamp and location information for video frames.
+           <string>Path to the optional metadata file with GPS telemetry data.
+Supports DJI SRT subtitle files and Skydio CSV flight logs.
 If provided, extracted frames will include GPS metadata (latitude, longitude, altitude).
 Can be left empty if location data is not needed.</string>
           </property>
@@ -191,9 +192,9 @@ Can be left empty if location data is not needed.</string>
            </font>
           </property>
           <property name="toolTip">
-           <string>Browse for optional SRT subtitle file containing GPS telemetry.
-SRT files are commonly created by DJI drones and other video recording devices.
-Opens a file selection dialog for SRT files.</string>
+           <string>Browse for optional metadata file containing GPS telemetry.
+Supports DJI SRT subtitle files and Skydio CSV flight logs.
+Opens a file selection dialog for SRT and CSV files.</string>
           </property>
           <property name="text">
            <string>Select</string>
@@ -303,7 +304,7 @@ Requirements:
 • Output folder must be selected
 • Time interval must be set (default: 5 seconds)
 The process will extract frames at the specified interval and save them as images.
-If SRT file is provided, GPS metadata will be embedded in the extracted frames.</string>
+If a metadata file (SRT or CSV) is provided, GPS metadata will be embedded in the extracted frames.</string>
        </property>
        <property name="layoutDirection">
         <enum>Qt::LeftToRight</enum>


### PR DESCRIPTION
## Summary
- Adds an **Image Mask Filter** to the Results Viewer AOI filter dialog under Spatial Filters
- Users can browse for a black/white mask image and choose **include mode** (show only detections in white regions) or **exclude mode** (hide detections in white regions)
- Mask is automatically scaled to each image's dimensions with per-resolution caching
- Filter syncs to Gallery view and respects Clear All Filters

## Test plan
- [ ] Open Results Viewer with analysis results, click Filter button — verify new "Image Mask Filter" group appears under Spatial Filters
- [ ] Browse for a mask image — verify file dialog opens, file is validated, path displays
- [ ] Enable mask filter in include mode — verify only AOIs with centers in white region show
- [ ] Switch to exclude mode — verify AOIs with centers in white region are hidden
- [ ] Clear mask — verify all AOIs show again
- [ ] Test "Clear All Filters" — verify mask filter is also cleared
- [ ] Open Gallery view — verify mask filter is synced and applied there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)