### PR TITLE
fix: Add image algorithm hiddenimports to PyInstaller spec

### DIFF
--- a/app.spec
+++ b/app.spec
@@ -40,6 +40,16 @@ if platform.system() == 'Windows':
                 hiddenimports=[
                     'shapely',
                     'shapely.geometry',
+                    # Image algorithm services (dynamically loaded via importlib in AnalyzeService)
+                    'algorithms.images.ColorRange.services.ColorRangeService',
+                    'algorithms.images.HSVColorRange.services.HSVColorRangeService',
+                    'algorithms.images.MatchedFilter.services.MatchedFilterService',
+                    'algorithms.images.RXAnomaly.services.RXAnomalyService',
+                    'algorithms.images.MRMap.services.MRMapService',
+                    'algorithms.images.ThermalRange.services.ThermalRangeService',
+                    'algorithms.images.ThermalAnomaly.services.ThermalAnomalyService',
+                    'algorithms.images.ThermalResidualAnomaly.services.ThermalResidualAnomalyService',
+                    'algorithms.images.AIPersonDetector.services.AIPersonDetectorService',
                     # Streaming algorithms modules
                     'algorithms.streaming',
                     'algorithms.streaming.MotionDetection',
@@ -95,6 +105,16 @@ elif platform.system() == 'Darwin':
                     hiddenimports=[
                         'shapely',
                         'shapely.geometry',
+                        # Image algorithm services (dynamically loaded via importlib in AnalyzeService)
+                        'algorithms.images.ColorRange.services.ColorRangeService',
+                        'algorithms.images.HSVColorRange.services.HSVColorRangeService',
+                        'algorithms.images.MatchedFilter.services.MatchedFilterService',
+                        'algorithms.images.RXAnomaly.services.RXAnomalyService',
+                        'algorithms.images.MRMap.services.MRMapService',
+                        'algorithms.images.ThermalRange.services.ThermalRangeService',
+                        'algorithms.images.ThermalAnomaly.services.ThermalAnomalyService',
+                        'algorithms.images.ThermalResidualAnomaly.services.ThermalResidualAnomalyService',
+                        'algorithms.images.AIPersonDetector.services.AIPersonDetectorService',
                         # Streaming algorithms modules
                         'algorithms.streaming',
                         'algorithms.streaming.MotionDetection',


### PR DESCRIPTION
## Summary
- Adds all 9 image algorithm service modules as `hiddenimports` in `app.spec` (both Windows and Darwin)
- The refactor in commit `5f84a2e` replaced static imports of image algorithm services in `AnalyzeService.py` with dynamic `importlib.import_module()` loading. PyInstaller can't trace dynamic imports, so the algorithm modules were no longer bundled in compiled builds.
- This caused "Unknown algorithm service" errors (e.g., `MRMapService`, `HSVColorRangeService`) for every image processed in the compiled app.

## Test plan
- [x] Built macOS `.app` bundle with `python setup.py bdist_app` — build succeeds
- [ ] Run compiled app and process images with each algorithm (MRMap, HSVColorRange, ColorRange, MatchedFilter, RXAnomaly, AIPersonDetector)
- [ ] Verify no "Unknown algorithm service" errors appear
- [ ] Build and test on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)