### PR TITLE
feat: Restore Wingtra CSV loader and fix heatmap filter availability

### DIFF
--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -26,6 +26,7 @@ from core.controllers.images.viewer.exports.CalTopoExportController import CalTo
 from core.controllers.images.viewer.exports.ZipExportController import ZipExportController
 from core.controllers.images.viewer.exports.PDFExportController import PDFExportController
 from core.controllers.images.viewer.AltitudeController import AltitudeController
+from core.controllers.images.viewer.WingtraDataController import WingtraDataController
 from core.controllers.images.viewer.image.ImageLoadController import ImageLoadController
 from core.controllers.images.viewer.PixelInfoController import PixelInfoController
 from core.controllers.images.viewer.ThermalDataController import ThermalDataController
@@ -176,6 +177,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self.pixel_info_controller = PixelInfoController(self)
         self.image_load_controller = ImageLoadController(self)
         self.altitude_controller = AltitudeController(self)
+        self.wingtra_controller = WingtraDataController(self)
 
         # Initialize services
         self.cache_path_service = CachePathService()
@@ -790,6 +792,9 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             # Track AOI in neighboring images with 'Z' key
             if hasattr(self, 'neighbor_tracking_controller'):
                 self.neighbor_tracking_controller.track_selected_aoi()
+        if e.key() == Qt.Key_W and e.modifiers() == Qt.ShiftModifier:
+            # Load Wingtra CSV flight log with 'Shift+W' key
+            self.wingtra_controller.prompt_and_load_csv()
 
     def _backfill_image_dimensions_if_needed(self):
         """Check if image dimensions are missing and offer to backfill from image files."""

--- a/app/core/controllers/images/viewer/WingtraDataController.py
+++ b/app/core/controllers/images/viewer/WingtraDataController.py
@@ -1,0 +1,460 @@
+"""
+WingtraDataController - Handles Wingtra CSV data loading and session management.
+
+Manages CSV parsing, image matching, per-image AGL computation via terrain
+elevation, and provides override values for orientation and GSD calculations.
+"""
+
+import csv
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Optional, List, Tuple
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox, QDialog
+
+from core.services.LoggerService import LoggerService
+from core.services.terrain.TerrainService import TerrainService
+from core.views.images.viewer.dialogs.WingtraDataDialog import WingtraDataDialog
+
+
+METERS_TO_FEET = 3.28084
+
+
+@dataclass
+class WingtraImageData:
+    """Wingtra orientation and position data for a single image."""
+    image_name: str
+    latitude: float
+    longitude: float
+    altitude_asl: float  # meters (above sea level, from CSV)
+    omega: float         # roll (degrees)
+    phi: float           # pitch (degrees)
+    kappa: float         # yaw (degrees)
+    accuracy_h: float
+    accuracy_v: float
+    altitude_agl: Optional[float] = field(default=None)  # meters (computed)
+
+
+class WingtraDataController:
+    """Controller for managing Wingtra CSV data overrides."""
+
+    REQUIRED_COLUMNS = [
+        'image', 'latitude', 'longitude', 'altitude',
+        'omega', 'phi', 'kappa'
+    ]
+
+    # Alternate column name mappings (case-insensitive, supports partial matches)
+    # Wingtra format: "# image name", "latitude [decimal degrees]", etc.
+    COLUMN_ALIASES = {
+        'image': ['# image name', 'image name', 'image', 'image_name', 'filename', 'name', 'file'],
+        'latitude': ['latitude [decimal degrees]', 'latitude', 'lat'],
+        'longitude': ['longitude [decimal degrees]', 'longitude', 'lon', 'long'],
+        'altitude': ['altitude [meter]', 'altitude [meters]', 'altitude', 'altitude_asl', 'alt', 'elevation'],
+        'omega': ['omega [degrees]', 'omega [degree]', 'omega', 'roll'],
+        'phi': ['phi [degrees]', 'phi [degree]', 'phi', 'pitch'],
+        'kappa': ['kappa [degrees]', 'kappa [degree]', 'kappa', 'yaw', 'heading'],
+        'accuracy_h': ['accuracy horizontal [meter]', 'accuracy horizontal [meters]',
+                       'accuracy_h', 'accuracy_horizontal', 'h_accuracy', 'horizontal_accuracy'],
+        'accuracy_v': ['accuracy vertical [meter]', 'accuracy vertical [meters]',
+                       'accuracy_v', 'accuracy_vertical', 'v_accuracy', 'vertical_accuracy']
+    }
+
+    def __init__(self, parent_viewer):
+        """Initialize the Wingtra data controller."""
+        self.parent = parent_viewer
+        self.logger = LoggerService()
+
+        # Session-only storage (not persisted to XML)
+        self.image_data: Dict[str, WingtraImageData] = {}
+        self.csv_path: Optional[str] = None
+        self.is_active: bool = False  # True when Wingtra data is loaded
+        self._terrain_service: Optional[TerrainService] = None
+
+    def _get_terrain_service(self) -> Optional[TerrainService]:
+        """Lazily initialize terrain service."""
+        if self._terrain_service is None:
+            try:
+                self._terrain_service = TerrainService()
+            except Exception as e:
+                self.logger.warning(f"Could not initialize terrain service: {e}")
+        return self._terrain_service
+
+    def _compute_agl_for_images(self, image_data: Dict[str, WingtraImageData]) -> int:
+        """Compute per-image AGL using terrain elevation lookup.
+
+        For each image, AGL = ASL altitude (from CSV) - ground elevation.
+        Uses the geoid to convert between ellipsoidal (GPS/CSV) and
+        orthometric (terrain) heights when available.
+
+        Args:
+            image_data: Dict of image name -> WingtraImageData
+
+        Returns:
+            Number of images where AGL was computed successfully.
+        """
+        terrain = self._get_terrain_service()
+        if terrain is None:
+            return 0
+
+        computed = 0
+        for data in image_data.values():
+            result = terrain.get_elevation(data.latitude, data.longitude)
+            if result.source == 'terrain' and result.elevation_m is not None:
+                # CSV altitude is typically ellipsoidal (WGS84).
+                # Terrain elevation is orthometric (EGM96).
+                # Convert CSV altitude to orthometric for a proper AGL.
+                asl_orthometric = data.altitude_asl
+                if result.geoid_undulation_m is not None:
+                    asl_orthometric = data.altitude_asl - result.geoid_undulation_m
+
+                data.altitude_agl = max(1.0, asl_orthometric - result.elevation_m)
+                computed += 1
+
+        return computed
+
+    def _get_distance_unit(self) -> str:
+        """Get user's preferred distance unit."""
+        if hasattr(self.parent, 'settings_service'):
+            unit = self.parent.settings_service.get_setting('DistanceUnit', 'Feet')
+            if unit in ('Meters', 'm'):
+                return 'm'
+        return 'ft'
+
+    def prompt_and_load_csv(self):
+        """Show file dialog and load Wingtra CSV data."""
+        # Get initial directory from settings if available
+        initial_dir = ""
+        if hasattr(self.parent, 'settings_service'):
+            initial_dir = self.parent.settings_service.get_setting('LastWingtraFolder', '')
+            if initial_dir and not os.path.exists(initial_dir):
+                initial_dir = ""
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            self.parent,
+            "Select Wingtra CSV File",
+            initial_dir,
+            "CSV files (*.csv);;All files (*.*)"
+        )
+
+        if not file_path:
+            return  # User cancelled
+
+        # Save directory for next time
+        if hasattr(self.parent, 'settings_service'):
+            self.parent.settings_service.set_setting('LastWingtraFolder', os.path.dirname(file_path))
+
+        # Parse and validate CSV
+        parsed_data, errors = self._parse_csv(file_path)
+
+        if errors:
+            self._show_parse_errors(errors)
+            return
+
+        if not parsed_data:
+            QMessageBox.warning(
+                self.parent,
+                "Empty CSV",
+                "The CSV file contains no valid data rows."
+            )
+            return
+
+        # Match to current result images
+        matched, unmatched_csv, unmatched_images = self._match_images(parsed_data)
+
+        if not matched:
+            self._show_no_matches_error(unmatched_csv, unmatched_images)
+            return
+
+        # Compute per-image AGL from terrain elevation
+        agl_count = self._compute_agl_for_images(matched)
+
+        # Show match summary dialog
+        dialog = WingtraDataDialog(
+            self.parent,
+            matched_count=len(matched),
+            unmatched_csv_count=len(unmatched_csv),
+            unmatched_images_count=len(unmatched_images),
+            agl_computed_count=agl_count,
+            distance_unit=self._get_distance_unit()
+        )
+
+        if dialog.exec() != QDialog.Accepted:
+            return  # User cancelled
+
+        # Store the data
+        self.image_data = matched
+        self.csv_path = file_path
+        self.is_active = True
+
+        # Inject bearing and AGL into image dicts so all consumers pick them up
+        self._inject_into_image_dicts(matched)
+
+        # Show success toast
+        if hasattr(self.parent, 'status_controller'):
+            msg = f"Wingtra data loaded: {len(matched)} images matched"
+            if agl_count > 0:
+                msg += f", {agl_count} AGL computed"
+            self.parent.status_controller.show_toast(msg, 3000, color="#00C853")
+
+        # Reload current image to apply overrides
+        if hasattr(self.parent, 'image_load_controller'):
+            self.parent.image_load_controller.load_image()
+
+    def _parse_csv(self, file_path: str) -> Tuple[Dict[str, WingtraImageData], List[str]]:
+        """
+        Parse Wingtra CSV file.
+
+        Returns:
+            tuple: (parsed_data dict keyed by filename, error_list)
+        """
+        parsed_data = {}
+        errors = []
+
+        try:
+            with open(file_path, 'r', newline='', encoding='utf-8-sig') as f:
+                reader = csv.DictReader(f)
+
+                # Validate columns exist
+                if not reader.fieldnames:
+                    errors.append("CSV file has no header row")
+                    return {}, errors
+
+                # Map actual column names to expected names
+                column_map = self._build_column_map(reader.fieldnames)
+
+                missing = [col for col in self.REQUIRED_COLUMNS if col not in column_map]
+                if missing:
+                    errors.append(f"Missing required columns: {', '.join(missing)}")
+                    return {}, errors
+
+                # Parse rows
+                for row_num, row in enumerate(reader, start=2):
+                    try:
+                        image_name = row[column_map['image']].strip()
+                        if not image_name:
+                            continue
+
+                        # Get accuracy values (optional)
+                        accuracy_h = 0.0
+                        accuracy_v = 0.0
+                        if 'accuracy_h' in column_map:
+                            try:
+                                accuracy_h = float(row[column_map['accuracy_h']])
+                            except (ValueError, KeyError):
+                                pass
+                        if 'accuracy_v' in column_map:
+                            try:
+                                accuracy_v = float(row[column_map['accuracy_v']])
+                            except (ValueError, KeyError):
+                                pass
+
+                        data = WingtraImageData(
+                            image_name=image_name,
+                            latitude=float(row[column_map['latitude']]),
+                            longitude=float(row[column_map['longitude']]),
+                            altitude_asl=float(row[column_map['altitude']]),
+                            omega=float(row[column_map['omega']]),
+                            phi=float(row[column_map['phi']]),
+                            kappa=float(row[column_map['kappa']]),
+                            accuracy_h=accuracy_h,
+                            accuracy_v=accuracy_v
+                        )
+                        parsed_data[image_name] = data
+
+                    except (ValueError, KeyError) as e:
+                        errors.append(f"Row {row_num}: {str(e)}")
+
+        except FileNotFoundError:
+            errors.append(f"File not found: {file_path}")
+        except Exception as e:
+            errors.append(f"Error reading CSV: {str(e)}")
+
+        return parsed_data, errors
+
+    def _build_column_map(self, fieldnames: List[str]) -> Dict[str, str]:
+        """Build mapping from expected column names to actual CSV headers."""
+        column_map = {}
+        lower_fields = {f.lower().strip(): f for f in fieldnames}
+
+        for expected, aliases in self.COLUMN_ALIASES.items():
+            for alias in aliases:
+                if alias.lower() in lower_fields:
+                    column_map[expected] = lower_fields[alias.lower()]
+                    break
+
+        return column_map
+
+    def _match_images(self, parsed_data: Dict[str, WingtraImageData]) -> Tuple[Dict[str, WingtraImageData], List[str], List[str]]:
+        """
+        Match CSV image names to result images.
+
+        Returns:
+            tuple: (matched_dict keyed by result image name, unmatched_csv_names, unmatched_image_names)
+        """
+        matched = {}
+
+        # Get result image names
+        result_names = set()
+        result_name_map = {}  # lowercase -> original name
+        for img in self.parent.images:
+            name = img.get('name', '')
+            if name:
+                result_names.add(name)
+                result_name_map[name.lower()] = name
+
+        # Match CSV entries to result images
+        matched_csv_names = set()
+        for csv_name, data in parsed_data.items():
+            # Try exact match first
+            if csv_name in result_names:
+                matched[csv_name] = data
+                matched_csv_names.add(csv_name)
+            else:
+                # Try case-insensitive match
+                csv_lower = csv_name.lower()
+                if csv_lower in result_name_map:
+                    result_name = result_name_map[csv_lower]
+                    matched[result_name] = data
+                    matched_csv_names.add(csv_name)
+
+        # Find unmatched
+        unmatched_csv = [name for name in parsed_data.keys() if name not in matched_csv_names]
+        matched_result_names = set(matched.keys())
+        unmatched_images = [name for name in result_names if name not in matched_result_names]
+
+        return matched, unmatched_csv, unmatched_images
+
+    def _show_parse_errors(self, errors: List[str]):
+        """Show CSV parsing errors to user."""
+        error_text = "\n".join(errors[:10])
+        if len(errors) > 10:
+            error_text += f"\n... and {len(errors) - 10} more errors"
+
+        QMessageBox.critical(
+            self.parent,
+            "CSV Parse Error",
+            f"Failed to parse Wingtra CSV:\n\n{error_text}"
+        )
+
+    def _show_no_matches_error(self, unmatched_csv: List[str], unmatched_images: List[str]):
+        """Show error when no images match."""
+        # Show a few example names to help debugging
+        csv_examples = unmatched_csv[:3] if unmatched_csv else []
+        img_examples = list(unmatched_images)[:3] if unmatched_images else []
+
+        msg = (
+            f"No images in the CSV match the current results.\n\n"
+            f"CSV images: {len(unmatched_csv)}\n"
+            f"Result images: {len(unmatched_images)}\n\n"
+        )
+
+        if csv_examples:
+            msg += f"CSV examples: {', '.join(csv_examples)}\n"
+        if img_examples:
+            msg += f"Result examples: {', '.join(img_examples)}\n"
+
+        msg += "\nEnsure image filenames in the CSV match exactly."
+
+        QMessageBox.warning(
+            self.parent,
+            "No Matching Images",
+            msg
+        )
+
+    def _inject_into_image_dicts(self, matched: Dict[str, WingtraImageData]):
+        """Inject bearing and per-image AGL into self.parent.images dicts and gps_data.
+
+        This ensures all consumers (R-key rotation, GPS map, KML export,
+        coverage extent) automatically get the Wingtra orientation data
+        through the standard image['bearing'] path.
+        """
+        # Build lookup from image name -> image dict for quick access
+        for image in self.parent.images:
+            name = image.get('name', '')
+            data = matched.get(name)
+            if data is None:
+                continue
+
+            # Convert kappa (CCW, photogrammetric) to bearing (CW, geographic)
+            bearing = (-data.kappa) % 360
+            image['bearing'] = bearing
+
+            if data.altitude_agl is not None:
+                image['wingtra_agl_ft'] = data.altitude_agl * METERS_TO_FEET
+
+        # Also update gps_data entries (separate list used by GPS map)
+        if hasattr(self.parent, 'gps_map_controller'):
+            for entry in self.parent.gps_map_controller.gps_data:
+                idx = entry.get('index')
+                if idx is not None and 0 <= idx < len(self.parent.images):
+                    img = self.parent.images[idx]
+                    bearing = img.get('bearing')
+                    if bearing is not None:
+                        entry['bearing'] = bearing
+                    agl = img.get('wingtra_agl_ft')
+                    if agl is not None:
+                        entry['wingtra_agl_ft'] = agl
+
+    # Override getters for ImageService integration
+    def get_wingtra_data(self, image_name: str) -> Optional[WingtraImageData]:
+        """Get Wingtra data for a specific image."""
+        if not self.is_active:
+            return None
+        return self.image_data.get(image_name)
+
+    def get_camera_yaw(self, image_name: str) -> Optional[float]:
+        """Get camera yaw as geographic bearing (CW from North)."""
+        data = self.get_wingtra_data(image_name)
+        if data:
+            # Convert kappa (CCW, photogrammetric) to bearing (CW, geographic)
+            return (-data.kappa) % 360
+        return None
+
+    def get_camera_pitch(self, image_name: str) -> Optional[float]:
+        """Get camera pitch (phi) for image.
+
+        Converts from Wingtra convention (0 = nadir) to standard
+        photogrammetry convention (-90 = nadir, 0 = horizontal).
+        """
+        data = self.get_wingtra_data(image_name)
+        if data:
+            return data.phi - 90.0
+        return None
+
+    def get_gimbal_roll(self, image_name: str) -> Optional[float]:
+        """Get gimbal roll (omega) for image."""
+        data = self.get_wingtra_data(image_name)
+        if data:
+            return data.omega
+        return None
+
+    def get_altitude_agl_ft(self, image_name: str) -> Optional[float]:
+        """Get per-image AGL altitude in feet, computed from terrain elevation.
+
+        Args:
+            image_name: Image filename.
+
+        Returns:
+            AGL altitude in feet, or None if not computed.
+        """
+        data = self.get_wingtra_data(image_name)
+        if data and data.altitude_agl is not None:
+            return data.altitude_agl * METERS_TO_FEET
+        return None
+
+    def clear_data(self):
+        """Clear all Wingtra data and deactivate overrides."""
+        # Remove injected values from image dicts
+        for image in self.parent.images:
+            image.pop('bearing', None)
+            image.pop('wingtra_agl_ft', None)
+
+        # Clear gps_data bearings and AGL
+        if hasattr(self.parent, 'gps_map_controller'):
+            for entry in self.parent.gps_map_controller.gps_data:
+                entry['bearing'] = None
+                entry.pop('wingtra_agl_ft', None)
+
+        self.image_data = {}
+        self.csv_path = None
+        self.is_active = False

--- a/app/core/controllers/images/viewer/aoi/AOIController.py
+++ b/app/core/controllers/images/viewer/aoi/AOIController.py
@@ -1378,7 +1378,10 @@ class AOIController(TranslationMixin):
         if hasattr(self.parent, 'gallery_controller'):
             gc = self.parent.gallery_controller
             heatmap_service = gc.heatmap_service
-            heatmap_available = heatmap_service.is_valid()
+            # Ensure heatmap is computed even if gallery mode hasn't been entered yet
+            if not heatmap_service.is_valid() and self.parent.images:
+                heatmap_service.compute_heatmap(self.parent.images)
+            heatmap_available = heatmap_service.has_data()
 
         dialog = AOIFilterDialog(self.parent, current_filters, temperature_unit, is_thermal,
                                  heatmap_available=heatmap_available, heatmap_service=heatmap_service)

--- a/app/core/services/HeatmapService.py
+++ b/app/core/services/HeatmapService.py
@@ -100,6 +100,19 @@ class HeatmapService:
         """
         return self._grid is not None
 
+    def has_data(self):
+        """Check whether the heatmap has meaningful density data.
+
+        Returns True only if the grid was computed and at least some AOIs
+        had valid dimensions and positions. Returns False if never computed
+        or if all AOIs were skipped due to missing dimensions/centers.
+        """
+        if self._grid is None:
+            return False
+        if self._totalAois == 0:
+            return False
+        return self._skippedAois < self._totalAois
+
     def invalidate(self):
         """Clear the cached heatmap grid."""
         self._grid = None

--- a/app/core/views/images/viewer/dialogs/AOIFilterDialog.py
+++ b/app/core/views/images/viewer/dialogs/AOIFilterDialog.py
@@ -632,7 +632,7 @@ class AOIFilterDialog(TranslationMixin, QDialog):
 
     def open_heatmap_viewer(self):
         """Open the heatmap viewer dialog."""
-        if self.heatmap_service is None or not self.heatmap_service.is_valid():
+        if self.heatmap_service is None or not self.heatmap_service.has_data():
             from PySide6.QtWidgets import QMessageBox
             QMessageBox.information(self, self.tr("Heatmap"),
                                     self.tr("No heatmap data available. Ensure image dimensions are present in the dataset."))

--- a/app/core/views/images/viewer/dialogs/WingtraDataDialog.py
+++ b/app/core/views/images/viewer/dialogs/WingtraDataDialog.py
@@ -1,0 +1,112 @@
+"""
+WingtraDataDialog - Dialog showing Wingtra CSV import summary.
+
+Shown after CSV is parsed, images matched, and AGL computed from terrain.
+"""
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel,
+    QPushButton, QGroupBox
+)
+from PySide6.QtCore import Qt
+
+
+class WingtraDataDialog(QDialog):
+    """Dialog showing Wingtra CSV import summary and confirmation."""
+
+    def __init__(self, parent, matched_count: int, unmatched_csv_count: int,
+                 unmatched_images_count: int, agl_computed_count: int = 0,
+                 distance_unit: str = 'ft'):
+        """
+        Initialize the dialog.
+
+        Args:
+            parent: Parent widget
+            matched_count: Number of successfully matched images
+            unmatched_csv_count: Number of CSV entries without matching images
+            unmatched_images_count: Number of result images without CSV data
+            agl_computed_count: Number of images with terrain-derived AGL
+            distance_unit: User's preferred distance unit ('ft' or 'm')
+        """
+        super().__init__(parent)
+        self.distance_unit = distance_unit
+        self.matched_count = matched_count
+        self.unmatched_csv_count = unmatched_csv_count
+        self.unmatched_images_count = unmatched_images_count
+        self.agl_computed_count = agl_computed_count
+
+        self._setup_ui()
+
+    def _setup_ui(self):
+        """Set up the dialog UI."""
+        self.setWindowTitle("Wingtra Data Import")
+        self.setModal(True)
+        self.setMinimumWidth(450)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(15)
+        layout.setContentsMargins(20, 20, 20, 20)
+
+        # Summary section
+        summary_group = QGroupBox("Import Summary")
+        summary_layout = QVBoxLayout(summary_group)
+
+        summary_text = (
+            f"<b>Matched images:</b> {self.matched_count}<br>"
+            f"<b>CSV entries without match:</b> {self.unmatched_csv_count}<br>"
+            f"<b>Result images without CSV data:</b> {self.unmatched_images_count}"
+        )
+
+        summary_label = QLabel(summary_text)
+        summary_label.setTextFormat(Qt.RichText)
+        summary_layout.addWidget(summary_label)
+        layout.addWidget(summary_group)
+
+        # Terrain / AGL section
+        terrain_group = QGroupBox("Altitude & GSD")
+        terrain_layout = QVBoxLayout(terrain_group)
+
+        if self.agl_computed_count > 0:
+            terrain_text = (
+                f"<b>AGL computed from terrain:</b> {self.agl_computed_count} of {self.matched_count} images<br>"
+                f"<br>"
+                f"Per-image AGL is derived from the CSV altitude (ASL) minus "
+                f"terrain elevation at each GPS location. GSD will be calculated "
+                f"automatically using the camera sensor data and focal length."
+            )
+        else:
+            terrain_text = (
+                "<b>Terrain data unavailable</b> - AGL could not be computed.<br>"
+                "<br>"
+                "Orientation (yaw/pitch/roll) will still be applied from the CSV. "
+                "GSD and altitude displays require terrain data or a manual "
+                "altitude override (Shift+O) after import."
+            )
+
+        terrain_label = QLabel(terrain_text)
+        terrain_label.setTextFormat(Qt.RichText)
+        terrain_label.setWordWrap(True)
+        terrain_layout.addWidget(terrain_label)
+        layout.addWidget(terrain_group)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.reject)
+        button_layout.addWidget(self.cancel_button)
+
+        self.ok_button = QPushButton("Apply Wingtra Data")
+        self.ok_button.setDefault(True)
+        self.ok_button.clicked.connect(self.accept)
+        button_layout.addWidget(self.ok_button)
+
+        layout.addLayout(button_layout)
+
+    def showEvent(self, event):
+        """Override showEvent to ensure dialog receives focus on macOS."""
+        super().showEvent(event)
+        self.activateWindow()
+        self.raise_()

--- a/scripts/wingtra_csv_to_exif.py
+++ b/scripts/wingtra_csv_to_exif.py
@@ -1,0 +1,359 @@
+"""
+wingtra_csv_to_exif.py - Embed Wingtra CSV orientation data into image EXIF/XMP metadata.
+
+Reads a Wingtra geotags CSV file and writes DJI-compatible XMP tags into matching
+image files so that ADIAT can read them without loading a CSV at runtime.
+
+Usage:
+    python wingtra_csv_to_exif.py <csv_file> <image_directory> [--output-dir <dir>] [--agl <meters>] [--terrain-agl]
+
+Arguments:
+    csv_file         Path to Wingtra geotags CSV file
+    image_directory  Directory containing Wingtra image files
+    --output-dir     Write modified images to this directory instead of modifying originals
+    --agl            Above-ground-level altitude in meters (written as RelativeAltitude)
+    --terrain-agl    Compute per-image AGL from terrain elevation data
+"""
+
+import argparse
+import csv
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class WingtraImageData:
+    """Parsed orientation and position data for a single Wingtra image."""
+    image_name: str
+    latitude: float
+    longitude: float
+    altitude_asl: float  # meters
+    omega: float         # roll (degrees)
+    phi: float           # pitch (degrees)
+    kappa: float         # yaw (degrees)
+    accuracy_h: float
+    accuracy_v: float
+
+
+# Column name aliases matching WingtraDataController conventions
+COLUMN_ALIASES = {
+    'image': ['# image name', 'image name', 'image', 'image_name', 'filename', 'name', 'file'],
+    'latitude': ['latitude [decimal degrees]', 'latitude', 'lat'],
+    'longitude': ['longitude [decimal degrees]', 'longitude', 'lon', 'long'],
+    'altitude': ['altitude [meter]', 'altitude [meters]', 'altitude', 'altitude_asl', 'alt', 'elevation'],
+    'omega': ['omega [degrees]', 'omega [degree]', 'omega', 'roll'],
+    'phi': ['phi [degrees]', 'phi [degree]', 'phi', 'pitch'],
+    'kappa': ['kappa [degrees]', 'kappa [degree]', 'kappa', 'yaw', 'heading'],
+    'accuracy_h': ['accuracy horizontal [meter]', 'accuracy horizontal [meters]',
+                   'accuracy_h', 'accuracy_horizontal', 'h_accuracy', 'horizontal_accuracy'],
+    'accuracy_v': ['accuracy vertical [meter]', 'accuracy vertical [meters]',
+                   'accuracy_v', 'accuracy_vertical', 'v_accuracy', 'vertical_accuracy']
+}
+
+REQUIRED_COLUMNS = ['image', 'latitude', 'longitude', 'altitude', 'omega', 'phi', 'kappa']
+
+
+def find_exiftool():
+    """Locate exiftool executable."""
+    # Check if bundled with ADIAT
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    app_root = os.path.dirname(script_dir)
+    bundled = os.path.join(app_root, 'app', 'external', 'exiftool.exe')
+    if os.path.exists(bundled):
+        return bundled
+
+    # Check PATH
+    try:
+        result = subprocess.run(['exiftool', '-ver'], capture_output=True, text=True)
+        if result.returncode == 0:
+            return 'exiftool'
+    except FileNotFoundError:
+        pass
+
+    return None
+
+
+def build_column_map(fieldnames):
+    """Map actual CSV column headers to expected column names."""
+    column_map = {}
+    lower_fields = {f.lower().strip(): f for f in fieldnames}
+
+    for expected, aliases in COLUMN_ALIASES.items():
+        for alias in aliases:
+            if alias.lower() in lower_fields:
+                column_map[expected] = lower_fields[alias.lower()]
+                break
+
+    return column_map
+
+
+def parse_csv(csv_path):
+    """Parse Wingtra geotags CSV file.
+
+    Returns:
+        tuple: (dict of image_name -> WingtraImageData, list of errors)
+    """
+    parsed = {}
+    errors = []
+
+    try:
+        with open(csv_path, 'r', newline='', encoding='utf-8-sig') as f:
+            reader = csv.DictReader(f)
+
+            if not reader.fieldnames:
+                return {}, ["CSV file has no header row"]
+
+            column_map = build_column_map(reader.fieldnames)
+            missing = [col for col in REQUIRED_COLUMNS if col not in column_map]
+            if missing:
+                return {}, [f"Missing required columns: {', '.join(missing)}"]
+
+            for row_num, row in enumerate(reader, start=2):
+                try:
+                    image_name = row[column_map['image']].strip()
+                    if not image_name:
+                        continue
+
+                    accuracy_h = 0.0
+                    accuracy_v = 0.0
+                    if 'accuracy_h' in column_map:
+                        try:
+                            accuracy_h = float(row[column_map['accuracy_h']])
+                        except (ValueError, KeyError):
+                            pass
+                    if 'accuracy_v' in column_map:
+                        try:
+                            accuracy_v = float(row[column_map['accuracy_v']])
+                        except (ValueError, KeyError):
+                            pass
+
+                    data = WingtraImageData(
+                        image_name=image_name,
+                        latitude=float(row[column_map['latitude']]),
+                        longitude=float(row[column_map['longitude']]),
+                        altitude_asl=float(row[column_map['altitude']]),
+                        omega=float(row[column_map['omega']]),
+                        phi=float(row[column_map['phi']]),
+                        kappa=float(row[column_map['kappa']]),
+                        accuracy_h=accuracy_h,
+                        accuracy_v=accuracy_v
+                    )
+                    parsed[image_name] = data
+                except (ValueError, KeyError) as e:
+                    errors.append(f"Row {row_num}: {e}")
+
+    except FileNotFoundError:
+        errors.append(f"File not found: {csv_path}")
+    except Exception as e:
+        errors.append(f"Error reading CSV: {e}")
+
+    return parsed, errors
+
+
+def normalize_yaw(kappa):
+    """Convert photogrammetric kappa (CCW) to geographic bearing (CW from North).
+
+    Kappa: 0=North, positive=CCW (photogrammetric right-hand rule)
+    Bearing: 0=North, positive=CW (geographic/DJI convention)
+    """
+    yaw = (-kappa) % 360
+    return yaw
+
+
+def convert_pitch(phi):
+    """Convert Wingtra phi (0=nadir) to DJI convention (-90=nadir).
+
+    Wingtra: 0 degrees = camera pointing straight down (nadir)
+    DJI: -90 degrees = camera pointing straight down (nadir)
+    """
+    return phi - 90.0
+
+
+def write_tags(exiftool_path, image_path, data, agl_meters=None):
+    """Write DJI-compatible XMP and EXIF tags to an image using exiftool.
+
+    Args:
+        exiftool_path: Path to exiftool executable.
+        image_path: Path to image file.
+        data: WingtraImageData for this image.
+        agl_meters: Optional above-ground-level altitude in meters.
+
+    Returns:
+        bool: True if successful.
+    """
+    yaw = normalize_yaw(data.kappa)
+    pitch = convert_pitch(data.phi)
+    roll = data.omega
+
+    args = [
+        exiftool_path,
+        '-overwrite_original',
+        # DJI XMP orientation tags
+        f'-XMP-drone-dji:GimbalYawDegree={yaw:.2f}',
+        f'-XMP-drone-dji:GimbalPitchDegree={pitch:.2f}',
+        f'-XMP-drone-dji:GimbalRollDegree={roll:.2f}',
+        f'-XMP-drone-dji:FlightYawDegree={yaw:.2f}',
+        f'-XMP-drone-dji:FlightPitchDegree={pitch:.2f}',
+        f'-XMP-drone-dji:FlightRollDegree={roll:.2f}',
+        f'-XMP-drone-dji:AbsoluteAltitude={data.altitude_asl:.2f}',
+        # Update GPS from post-processed CSV values
+        f'-GPSLatitude={abs(data.latitude):.10f}',
+        f'-GPSLatitudeRef={"N" if data.latitude >= 0 else "S"}',
+        f'-GPSLongitude={abs(data.longitude):.10f}',
+        f'-GPSLongitudeRef={"E" if data.longitude >= 0 else "W"}',
+        f'-GPSAltitude={data.altitude_asl:.2f}',
+        f'-GPSAltitudeRef=0',
+        # Set Make to DJI so ADIAT recognizes the XMP namespace
+        '-Make=DJI',
+    ]
+
+    if agl_meters is not None:
+        args.append(f'-XMP-drone-dji:RelativeAltitude={agl_meters:.2f}')
+
+    args.append(image_path)
+
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  ERROR: {result.stderr.strip()}")
+        return False
+    return True
+
+
+def compute_terrain_agl(parsed_data):
+    """Compute per-image AGL using terrain elevation lookup.
+
+    For each image: AGL = ASL altitude - geoid undulation - terrain elevation
+    Same logic as WingtraDataController._compute_agl_for_images().
+
+    Returns:
+        dict of image_name -> agl_meters
+    """
+    # Add app directory to path for TerrainService import
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    app_dir = os.path.join(script_dir, '..', 'app')
+    if app_dir not in sys.path:
+        sys.path.insert(0, app_dir)
+
+    from core.services.terrain.TerrainService import TerrainService
+
+    terrain = TerrainService()
+    agls = {}
+
+    for name, data in parsed_data.items():
+        result = terrain.get_elevation(data.latitude, data.longitude)
+        if result.source == 'terrain' and result.elevation_m is not None:
+            asl_orthometric = data.altitude_asl
+            if result.geoid_undulation_m is not None:
+                asl_orthometric -= result.geoid_undulation_m
+            agls[name] = max(1.0, asl_orthometric - result.elevation_m)
+
+    return agls
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Embed Wingtra CSV orientation data into image EXIF/XMP metadata.'
+    )
+    parser.add_argument('csv_file', help='Path to Wingtra geotags CSV file')
+    parser.add_argument('image_directory', help='Directory containing Wingtra image files')
+    parser.add_argument('--output-dir', help='Write modified images here instead of modifying originals')
+    parser.add_argument('--agl', type=float, help='Above-ground-level altitude in meters (RelativeAltitude)')
+    parser.add_argument('--terrain-agl', action='store_true',
+                        help='Compute per-image AGL from terrain elevation data')
+    args = parser.parse_args()
+
+    # Validate inputs
+    if not os.path.isfile(args.csv_file):
+        print(f"Error: CSV file not found: {args.csv_file}")
+        sys.exit(1)
+    if not os.path.isdir(args.image_directory):
+        print(f"Error: Image directory not found: {args.image_directory}")
+        sys.exit(1)
+
+    # Find exiftool
+    exiftool_path = find_exiftool()
+    if not exiftool_path:
+        print("Error: exiftool not found. Install exiftool or ensure it's in the ADIAT external directory.")
+        sys.exit(1)
+    print(f"Using exiftool: {exiftool_path}")
+
+    # Parse CSV
+    print(f"Parsing CSV: {args.csv_file}")
+    parsed, errors = parse_csv(args.csv_file)
+    if errors:
+        print(f"CSV parse errors:")
+        for err in errors[:10]:
+            print(f"  {err}")
+        if not parsed:
+            sys.exit(1)
+    print(f"  Parsed {len(parsed)} image entries from CSV")
+
+    # Compute per-image terrain AGL if requested
+    terrain_agls = {}
+    if args.terrain_agl:
+        print("Computing per-image terrain AGL...")
+        terrain_agls = compute_terrain_agl(parsed)
+        print(f"  Computed AGL for {len(terrain_agls)}/{len(parsed)} images")
+
+    # Find matching images in directory
+    image_files = {}
+    for f in os.listdir(args.image_directory):
+        if f.lower().endswith(('.jpg', '.jpeg', '.tif', '.tiff', '.png')):
+            image_files[f] = os.path.join(args.image_directory, f)
+            image_files[f.lower()] = os.path.join(args.image_directory, f)
+
+    matched = 0
+    unmatched = 0
+    failed = 0
+
+    # Set up output directory if specified
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        print(f"Output directory: {args.output_dir}")
+
+    print(f"\nProcessing images...")
+    for image_name, data in parsed.items():
+        # Try exact match, then case-insensitive
+        src_path = image_files.get(image_name) or image_files.get(image_name.lower())
+        if not src_path:
+            unmatched += 1
+            continue
+
+        # Determine target path
+        if args.output_dir:
+            target_path = os.path.join(args.output_dir, os.path.basename(src_path))
+            shutil.copy2(src_path, target_path)
+        else:
+            target_path = src_path
+
+        # Determine AGL: --agl overrides terrain-agl per-image values
+        if args.agl is not None:
+            agl = args.agl
+        else:
+            agl = terrain_agls.get(image_name)
+
+        yaw = normalize_yaw(data.kappa)
+        pitch = convert_pitch(data.phi)
+        agl_str = f" agl={agl:.1f}m" if agl is not None else ""
+        print(f"  {image_name}: yaw={yaw:.1f}° pitch={pitch:.1f}° alt={data.altitude_asl:.1f}m{agl_str}")
+
+        if write_tags(exiftool_path, target_path, data, agl):
+            matched += 1
+        else:
+            failed += 1
+
+    # Summary
+    print(f"\nSummary:")
+    print(f"  Modified: {matched}")
+    print(f"  Not found in directory: {unmatched}")
+    if failed:
+        print(f"  Failed: {failed}")
+    print(f"  Total CSV entries: {len(parsed)}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- **Restore Wingtra CSV loader**: `WingtraDataController`, `WingtraDataDialog`, and `wingtra_csv_to_exif.py` were accidentally removed during the PR #85 → #86 cleanup. Restores all three files and wires up the **Shift+W** shortcut in the Results Viewer to load Wingtra flight log CSV data (parses CSV, matches images, computes per-image AGL from terrain, injects bearing and altitude into all consumers).
- **Fix heatmap filter availability**: The heatmap filter showed "Heatmap filtering unavailable (image dimensions not in dataset)" until gallery mode was entered, because `compute_heatmap()` was only called from `load_all_aois()` inside gallery mode. Now the heatmap is computed on demand when the AOI filter dialog opens. Added `has_data()` to `HeatmapService` to correctly distinguish "never computed" from "dimensions genuinely missing".

## Test plan
- [ ] Load a results file with AOIs, open AOI filter dialog without entering gallery mode — verify heatmap section is enabled (no red error)
- [ ] Load a results file without image dimensions — verify the red error message still correctly appears
- [ ] Enter gallery mode, re-open filter — verify heatmap still works
- [ ] Press Shift+W in Results Viewer, select a Wingtra CSV — verify import dialog shows match summary
- [ ] After Wingtra CSV import, verify GPS map FOV boxes use correct bearing and AGL