### PR TITLE
feat: Gallery mode left/right arrow key AOI navigation

### DIFF
--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -690,9 +690,15 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
                 return
 
         if e.key() == Qt.Key_Right:
-            self._nextImageButton_clicked()
+            if self.gallery_mode and hasattr(self, 'gallery_controller'):
+                self.gallery_controller.navigate_gallery_aoi(1)
+            else:
+                self._nextImageButton_clicked()
         if e.key() == Qt.Key_Left:
-            self._previousImageButton_clicked()
+            if self.gallery_mode and hasattr(self, 'gallery_controller'):
+                self.gallery_controller.navigate_gallery_aoi(-1)
+            else:
+                self._previousImageButton_clicked()
         if e.key() == Qt.Key_Down or e.key() == Qt.Key_P:
             self._hide_image_change(True)
         if e.key() == Qt.Key_Up or e.key() == Qt.Key_U:

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -789,6 +789,35 @@ class GalleryController:
             self.logger.error(f"Error handling AOI click: {e}")
             self.logger.error(traceback.format_exc())
 
+    def navigate_gallery_aoi(self, direction):
+        """Navigate to the next or previous AOI in the gallery.
+
+        Args:
+            direction: 1 for next (right), -1 for previous (left)
+        """
+        row_count = self.model.rowCount()
+        if row_count == 0:
+            return
+
+        current_index = self.ui_component.gallery_view.currentIndex()
+        if not current_index.isValid():
+            target_row = 0 if direction == 1 else row_count - 1
+        else:
+            target_row = (current_index.row() + direction) % row_count
+
+        self._select_and_activate_aoi(target_row)
+
+    def _select_and_activate_aoi(self, row):
+        """Select an AOI by row index and trigger click behavior."""
+        index = self.model.index(row, 0)
+        self.ui_component.gallery_view.setCurrentIndex(index)
+        self.ui_component.gallery_view.scrollTo(index)
+
+        aoi_info = self.model.get_aoi_info(index)
+        if aoi_info:
+            image_idx, aoi_idx, aoi_data = aoi_info
+            self.on_aoi_clicked(image_idx, aoi_idx, aoi_data)
+
     def _zoom_to_aoi(self, aoi_data):
         """Zoom to an AOI in the image viewer and highlight it."""
         try:

--- a/app/core/controllers/images/viewer/gallery/GalleryUIComponent.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryUIComponent.py
@@ -231,11 +231,9 @@ class GalleryUIComponent(TranslationMixin, QObject):
         original_keyPressEvent = self.gallery_view.keyPressEvent
 
         def keyPressEvent(event):
-            if event.key() == Qt.Key_F and event.modifiers() == Qt.NoModifier:
-                # Forward F key to parent window's keyPressEvent
-                if self.gallery_view.window():
-                    self.gallery_view.window().keyPressEvent(event)
-                return
+            # Arrow keys and F key are handled in eventFilter (which reliably
+            # intercepts before the C++ QListView::keyPressEvent runs).
+            # This fallback only handles keys not caught by the event filter.
             original_keyPressEvent(event)
         self.gallery_view.keyPressEvent = keyPressEvent
 
@@ -485,6 +483,22 @@ class GalleryUIComponent(TranslationMixin, QObject):
     def eventFilter(self, obj, event):
         """Watch for the first time the view/viewport has a valid size, handle flag button clicks, and keyboard events."""
         try:
+            # Intercept arrow keys on the gallery view to navigate AOIs
+            # Note: no modifier check for arrows (Mac reports KeypadModifier
+            # for arrow keys), matching Viewer.keyPressEvent behaviour
+            if (obj is self.gallery_view and
+                    event.type() == QEvent.KeyPress):
+                if event.key() == Qt.Key_Right:
+                    self.gallery_controller.navigate_gallery_aoi(1)
+                    return True
+                if event.key() == Qt.Key_Left:
+                    self.gallery_controller.navigate_gallery_aoi(-1)
+                    return True
+                if event.key() == Qt.Key_F:
+                    if self.gallery_view.window():
+                        self.gallery_view.window().keyPressEvent(event)
+                    return True
+
             # Handle mouse clicks on flag button
             if (obj == self.gallery_view.viewport() and
                     event.type() == QEvent.MouseButtonPress and


### PR DESCRIPTION
## Summary
- Left/right arrow keys now navigate sequentially between AOIs in gallery mode, moving the selection highlight and loading/zooming to each AOI
- Navigation wraps around at boundaries (last→first, first→last)
- When not in gallery mode, arrow keys continue to navigate between images as before
- Key interception uses `eventFilter` on the gallery QListView (avoids Mac `KeypadModifier` issue with arrow keys)

Closes #96

## Test plan
- [ ] Open results with multiple images containing AOIs
- [ ] Press G to enter gallery mode
- [ ] Click any AOI to select it
- [ ] Press right arrow → next AOI highlights, image loads and zooms to it
- [ ] Press left arrow → previous AOI highlights, image loads and zooms
- [ ] Navigate past last AOI → wraps to first
- [ ] Navigate before first AOI → wraps to last
- [ ] Click on the main image, then press right → gallery navigation still works
- [ ] Press G to exit gallery mode → left/right arrows navigate between images again

🤖 Generated with [Claude Code](https://claude.com/claude-code)