### PR TITLE
fix: Resolve macOS combobox dropdown positioning and label truncation in MRMap

### DIFF
--- a/app/algorithms/images/MRMap/controllers/MRMapController.py
+++ b/app/algorithms/images/MRMap/controllers/MRMapController.py
@@ -1,7 +1,9 @@
+import sys
+
 from algorithms.AlgorithmController import AlgorithmController
 from algorithms.images.MRMap.views.MRMap_ui import Ui_MRMap
 
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QComboBox, QListView, QWidget
 
 
 class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
@@ -21,7 +23,15 @@ class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
         AlgorithmController.__init__(self, config)
         self.setupUi(self)
         self._init_combo_data()
+        self._fixComboBoxForMacOS(self.colorspaceComboBox)
+        self._fixComboBoxForMacOS(self.segmentsComboBox)
         self.thresholdSlider.valueChanged.connect(self.updatethreshold)
+
+    def _fixComboBoxForMacOS(self, combo):
+        """Force non-native dropdown rendering on macOS to fix popup positioning and padding."""
+        combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        if sys.platform == 'darwin':
+            combo.setView(QListView())
 
     def _init_combo_data(self):
         """Attach stable option keys so translated labels do not affect config values."""


### PR DESCRIPTION
## Summary
- Fixes MRMap color space and segments combobox dropdowns on macOS appearing to the left/on top of the control with extra left padding and truncated labels
- On macOS, forces non-native `QListView` rendering instead of native `NSPopUpButton` to get standard dropdown behavior
- Sets `AdjustToContents` size policy on all platforms so comboboxes auto-size to their labels

Closes #92

## Test plan
- [ ] On macOS at 1920x1080: verify Color Space dropdown appears below the combobox, labels (LAB/RGB/HSV) display fully without truncation or extra left padding
- [ ] On macOS: verify Segments dropdown also renders correctly
- [ ] On Windows/Linux: verify no change in combobox behavior