### PR TITLE
fix: Pause video at end and simplify gallery highlight

### DIFF
--- a/app/core/controllers/streaming/StreamViewerWindow.py
+++ b/app/core/controllers/streaming/StreamViewerWindow.py
@@ -1944,14 +1944,6 @@ class StreamViewerWindow(TranslationMixin, QMainWindow):
         # Draw circle around the detection
         cv2.circle(frame, (cx, cy), radius, highlight_color, thickness)
 
-        # Draw a second outer circle for better visibility
-        cv2.circle(frame, (cx, cy), radius + 8, highlight_color, 2)
-
-        # Draw crosshair at centroid for precise location
-        crosshair_size = 20
-        cv2.line(frame, (cx - crosshair_size, cy), (cx + crosshair_size, cy), highlight_color, 3)
-        cv2.line(frame, (cx, cy - crosshair_size), (cx, cy + crosshair_size), highlight_color, 3)
-
         return frame
 
     def _clear_gallery_highlight(self):

--- a/app/core/services/streaming/RTMPStreamService.py
+++ b/app/core/services/streaming/RTMPStreamService.py
@@ -424,8 +424,20 @@ class RTMPStreamService(QThread):
                 if not ret or frame is None:
                     consecutive_errors += 1
                     if consecutive_errors >= max_consecutive_errors:
-                        self.logger.error(f"Failed to read {consecutive_errors} consecutive frames, stopping")
-                        break
+                        if self._is_file:
+                            # End of video file - pause at end instead of disconnecting
+                            with self._playback_lock:
+                                self._is_playing = False
+                                last_frame = max(0, self._total_frames - 1)
+                                self._cap.set(cv2.CAP_PROP_POS_FRAMES, last_frame)
+                                self._current_frame_pos = last_frame
+                            self.videoPositionChanged.emit(self._total_duration, self._total_duration)
+                            self.streamStatsChanged.emit({'is_playing': False})
+                            consecutive_errors = 0
+                            continue
+                        else:
+                            self.logger.error(f"Failed to read {consecutive_errors} consecutive frames, stopping")
+                            break
                     else:
                         self.logger.warning(f"Failed to read frame ({consecutive_errors}/{max_consecutive_errors})")
                         time.sleep(0.1)  # Small delay before retry


### PR DESCRIPTION
## Summary
- When a video file reaches the end in streaming analysis mode, the player now **pauses on the last frame** instead of disconnecting the stream. Users can review the final frame and seek back without losing the session.
- Gallery thumbnail highlight overlay now draws **only a simple circle** around the detection, removing the crosshair lines and outer ring that were obscuring the identified object.

## Test plan
- [ ] Open a video file in streaming analysis mode and let it play to the end - verify it pauses on the last frame rather than disconnecting
- [ ] After pause at end, verify playback controls still work (seek back, press play)
- [ ] Click a gallery thumbnail and verify the highlight shows only a circle with no crosshair