### PR TITLE
fix: Resolve macOS combobox dropdown positioning and truncation

### DIFF
--- a/app/algorithms/AlgorithmController.py
+++ b/app/algorithms/AlgorithmController.py
@@ -1,3 +1,8 @@
+import sys
+
+from PySide6.QtWidgets import QComboBox, QListView
+
+
 class AlgorithmController:
     """Base class for algorithm controllers that manages algorithm options and validation.
 
@@ -50,3 +55,19 @@ class AlgorithmController:
             NotImplementedError: Must be implemented by subclasses.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def fixComboBoxForMacOS(combo):
+        """Fix combobox dropdown positioning and truncation on macOS.
+
+        Sets size-adjust policy on all platforms and forces Qt's own list-style
+        popup on macOS instead of the native Cocoa menu-style popup.
+
+        Args:
+            combo: QComboBox instance to fix.
+        """
+        combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+        if sys.platform == 'darwin':
+            combo.setView(QListView())
+            combo.setStyleSheet("QComboBox { combobox-popup: 0; }")
+            combo.view().setMinimumWidth(combo.minimumSizeHint().width())

--- a/app/algorithms/images/MRMap/controllers/MRMapController.py
+++ b/app/algorithms/images/MRMap/controllers/MRMapController.py
@@ -21,6 +21,8 @@ class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
         AlgorithmController.__init__(self, config)
         self.setupUi(self)
         self._init_combo_data()
+        self.fixComboBoxForMacOS(self.colorspaceComboBox)
+        self.fixComboBoxForMacOS(self.segmentsComboBox)
         self.thresholdSlider.valueChanged.connect(self.updatethreshold)
 
     def _init_combo_data(self):

--- a/app/algorithms/images/RXAnomaly/controllers/RXAnomalyController.py
+++ b/app/algorithms/images/RXAnomaly/controllers/RXAnomalyController.py
@@ -21,6 +21,7 @@ class RXAnomalyController(QWidget, Ui_RXAnomaly, AlgorithmController):
         AlgorithmController.__init__(self, config)
         self.setupUi(self)
         self._init_segments_combo_data()
+        self.fixComboBoxForMacOS(self.segmentsComboBox)
         self.sensitivitySlider.valueChanged.connect(self.update_sensitivity)
 
     def _init_segments_combo_data(self):


### PR DESCRIPTION
## Summary
- Fixes macOS combobox dropdowns appearing **over** the widget instead of below, and item text being truncated
- Adds `combobox-popup: 0` stylesheet which forces Qt's own list-style popup instead of the native Cocoa menu-style popup
- Centralizes the fix as a `fixComboBoxForMacOS` static method on `AlgorithmController` so all algorithm controllers can reuse it
- Applies the fix to both **MRMap** (`colorspaceComboBox`, `segmentsComboBox`) and **RX Anomaly** (`segmentsComboBox`)

Supersedes #99

Closes #92

## Test plan
- [ ] On macOS: open MRMap, verify Color Space and Segments dropdowns appear **below** the combobox with full untruncated labels
- [ ] On macOS: open RX Anomaly, verify Segments dropdown appears below the combobox with full untruncated labels
- [ ] On Windows/Linux: verify no change in combobox behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)