### PR TITLE
feat: Add map tile source selection for PDF export settings

### DIFF
--- a/app/core/controllers/images/viewer/exports/PDFExportController.py
+++ b/app/core/controllers/images/viewer/exports/PDFExportController.py
@@ -113,6 +113,7 @@ class PDFExportController(TranslationMixin):
             organization = settings_dialog.get_organization()
             search_name = settings_dialog.get_search_name()
             include_images_without_flagged_aois = settings_dialog.get_include_images_without_flagged_aois()
+            map_tile_source = settings_dialog.get_map_tile_source()
 
             # Filter images based on user preference to check if there are any images to export
             original_images = images
@@ -183,6 +184,7 @@ class PDFExportController(TranslationMixin):
                 search_name=search_name,
                 images=filtered_images,
                 include_images_without_flagged_aois=include_images_without_flagged_aois,
+                map_tile_source=map_tile_source,
             )
 
             # Store all images for map generation

--- a/app/core/services/export/PDFSettingsService.py
+++ b/app/core/services/export/PDFSettingsService.py
@@ -35,8 +35,7 @@ class PDFSettingsService:
         """Load previously saved settings from config file.
 
         Returns:
-            dict: Dictionary with 'organization', 'search_name', and 'include_images_without_flagged_aois' keys,
-                  or empty dict if loading fails
+            dict: Dictionary with persisted PDF export settings
         """
         try:
             if os.path.exists(self.config_path):
@@ -45,21 +44,28 @@ class PDFSettingsService:
                     return {
                         'organization': settings.get('organization', ''),
                         'search_name': settings.get('search_name', ''),
-                        'include_images_without_flagged_aois': settings.get('include_images_without_flagged_aois', False)
+                        'include_images_without_flagged_aois': settings.get('include_images_without_flagged_aois', False),
+                        'map_tile_source': settings.get('map_tile_source', 'map')
                     }
         except Exception:
             # If loading fails, return empty values
             pass
 
-        return {'organization': '', 'search_name': '', 'include_images_without_flagged_aois': False}
+        return {
+            'organization': '',
+            'search_name': '',
+            'include_images_without_flagged_aois': False,
+            'map_tile_source': 'map'
+        }
 
-    def save_settings(self, organization, search_name, include_images_without_flagged_aois=False):
+    def save_settings(self, organization, search_name, include_images_without_flagged_aois=False, map_tile_source='map'):
         """Save settings to config file.
 
         Args:
             organization (str): Organization name
             search_name (str): Search name
             include_images_without_flagged_aois (bool): Whether to include images without flagged AOIs
+            map_tile_source (str): Tile source for overview map ('map' or 'satellite')
 
         Returns:
             bool: True if saved successfully, False otherwise
@@ -68,7 +74,8 @@ class PDFSettingsService:
             settings = {
                 'organization': organization.strip(),
                 'search_name': search_name.strip(),
-                'include_images_without_flagged_aois': include_images_without_flagged_aois
+                'include_images_without_flagged_aois': include_images_without_flagged_aois,
+                'map_tile_source': map_tile_source if map_tile_source in ('map', 'satellite') else 'map'
             }
             with open(self.config_path, 'w') as f:
                 json.dump(settings, f, indent=2)

--- a/app/core/services/export/PdfGeneratorService.py
+++ b/app/core/services/export/PdfGeneratorService.py
@@ -175,7 +175,7 @@ class PDFDocTemplate(BaseDocTemplate):
 class PdfGeneratorService:
     """Service for generating PDF reports from analysis results."""
 
-    def __init__(self, viewer, organization="", search_name="", images=None, include_images_without_flagged_aois=False):
+    def __init__(self, viewer, organization="", search_name="", images=None, include_images_without_flagged_aois=False, map_tile_source="map"):
         """
         Initialize the PDF generator service.
 
@@ -185,6 +185,7 @@ class PdfGeneratorService:
             search_name: Search/mission name for the report
             images: List of images to include in the PDF (if None, will use viewer.images)
             include_images_without_flagged_aois: Whether to include images without flagged AOIs
+            map_tile_source: Tile source for overview map ('map' or 'satellite')
         """
 
         self.logger = LoggerService()
@@ -192,6 +193,7 @@ class PdfGeneratorService:
         self.organization = organization if organization else "[ORGANIZATION]"
         self.search_name = search_name if search_name else "Analysis"
         self.include_images_without_flagged_aois = include_images_without_flagged_aois
+        self.map_tile_source = map_tile_source if map_tile_source in ("map", "satellite") else "map"
         self.images = images  # Store the images to use for PDF generation
         self.story = []
         self.doc = None
@@ -953,8 +955,7 @@ class PdfGeneratorService:
             np.ndarray: Tile image (256x256x3) or None
         """
         try:
-            # Use OpenStreetMap tiles (prefer 'map' for streets/trails visibility)
-            tile_source = 'map'
+            tile_source = self.map_tile_source
             cache_path = cache_dir / f"{tile_source}_{zoom}_{x_tile}_{y_tile}.png"
 
             # Check cache first
@@ -963,8 +964,11 @@ class PdfGeneratorService:
                 if tile_img is not None and tile_img.shape[0] == 256 and tile_img.shape[1] == 256:
                     return tile_img
 
-            # Download tile
-            url = f"https://tile.openstreetmap.org/{zoom}/{x_tile}/{y_tile}.png"
+            # Download tile from selected source
+            if tile_source == 'satellite':
+                url = f"https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{zoom}/{y_tile}/{x_tile}"
+            else:
+                url = f"https://tile.openstreetmap.org/{zoom}/{x_tile}/{y_tile}.png"
 
             # Use requests with timeout
             headers = {'User-Agent': 'ADIAT/1.0'}

--- a/app/core/views/images/viewer/dialogs/PDFExportDialog.py
+++ b/app/core/views/images/viewer/dialogs/PDFExportDialog.py
@@ -1,6 +1,6 @@
 """PDFExportDialog - Pure UI dialog for collecting PDF export settings."""
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QFormLayout, QCheckBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QFormLayout, QCheckBox, QComboBox
 from PySide6.QtCore import Qt
 from helpers.TranslationMixin import TranslationMixin
 
@@ -64,6 +64,17 @@ class PDFExportDialog(TranslationMixin, QDialog):
         ))
         layout.addWidget(self.include_images_without_flagged_aois)
 
+        # Map tile source for overview map
+        map_tiles_layout = QHBoxLayout()
+        map_tiles_label = QLabel(self.tr("Map Tiles:"))
+        self.map_tile_source_combo = QComboBox()
+        self.map_tile_source_combo.addItem(self.tr("Map"), "map")
+        self.map_tile_source_combo.addItem(self.tr("Satellite"), "satellite")
+        self.map_tile_source_combo.setToolTip(self.tr("Choose the background tiles for the PDF overview map."))
+        map_tiles_layout.addWidget(map_tiles_label)
+        map_tiles_layout.addWidget(self.map_tile_source_combo)
+        layout.addLayout(map_tiles_layout)
+
         # Buttons
         button_layout = QHBoxLayout()
         self.ok_button = QPushButton(self.tr("OK"))
@@ -104,13 +115,15 @@ class PDFExportDialog(TranslationMixin, QDialog):
         self.organization_input.setText(settings.get('organization', ''))
         self.search_name_input.setText(settings.get('search_name', ''))
         self.include_images_without_flagged_aois.setChecked(settings.get('include_images_without_flagged_aois', False))
+        self._set_map_tile_source(settings.get('map_tile_source', 'map'))
 
     def save_settings(self):
         """Save current settings to config file."""
         self.settings_service.save_settings(
             self.organization_input.text(),
             self.search_name_input.text(),
-            self.include_images_without_flagged_aois.isChecked()
+            self.include_images_without_flagged_aois.isChecked(),
+            self.get_map_tile_source()
         )
 
     def get_organization(self):
@@ -136,3 +149,20 @@ class PDFExportDialog(TranslationMixin, QDialog):
             bool: True if images without flagged AOIs should be included
         """
         return self.include_images_without_flagged_aois.isChecked()
+
+    def get_map_tile_source(self):
+        """Get selected tile source for overview map.
+
+        Returns:
+            str: 'map' or 'satellite'
+        """
+        source = self.map_tile_source_combo.currentData()
+        return source if source in ("map", "satellite") else "map"
+
+    def _set_map_tile_source(self, source):
+        """Set selected tile source in the combobox."""
+        target = source if source in ("map", "satellite") else "map"
+        for i in range(self.map_tile_source_combo.count()):
+            if self.map_tile_source_combo.itemData(i) == target:
+                self.map_tile_source_combo.setCurrentIndex(i)
+                return

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -6478,6 +6478,26 @@ Please flag at least one AOI, or check &apos;Include images without flagged AOIs
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="69"/>
+        <source>Map Tiles:</source>
+        <translation>Map Tiles:</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="71"/>
+        <source>Map</source>
+        <translation>Map</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="72"/>
+        <source>Satellite</source>
+        <translation>Satellite</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="73"/>
+        <source>Choose the background tiles for the PDF overview map.</source>
+        <translation>Choose the background tiles for the PDF overview map.</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="69"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -6482,6 +6482,26 @@ Contrassegna almeno una AOI oppure seleziona &apos;Includi immagini senza AOI co
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="69"/>
+        <source>Map Tiles:</source>
+        <translation>Tile mappa:</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="71"/>
+        <source>Map</source>
+        <translation>Mappa</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="72"/>
+        <source>Satellite</source>
+        <translation>Satellite</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="73"/>
+        <source>Choose the background tiles for the PDF overview map.</source>
+        <translation>Scegli le tile di sfondo per la mappa panoramica del PDF.</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="69"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>


### PR DESCRIPTION
- Introduced a new dropdown in the PDF export dialog to select between 'Map' and 'Satellite' tile sources for the overview map.
- Updated PDF export settings to include the selected map tile source.
- Modified PDF generation service to utilize the chosen tile source when downloading map tiles.
- Enhanced settings loading and saving to accommodate the new map tile source option.