### PR TITLE
fix: Viewer shortcut, GPS map, and gallery comment improvements

### DIFF
--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -852,9 +852,24 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             # Upscale currently visible portion with 'E' key
             self._open_upscale_dialog()
         if e.key() == Qt.Key_Z and e.modifiers() == Qt.NoModifier:
-            # Track AOI in neighboring images with 'Z' key
+            # Track AOI in neighboring images with 'Z' key. In gallery mode
+            # the selection lives in the gallery model, which may span images,
+            # so resolve it there and pass explicit indices to the tracker.
             if hasattr(self, 'neighbor_tracking_controller'):
-                self.neighbor_tracking_controller.track_selected_aoi()
+                if (hasattr(self, 'gallery_mode') and self.gallery_mode and
+                        hasattr(self, 'gallery_controller') and self.gallery_controller):
+                    ui_component = self.gallery_controller.ui_component
+                    if ui_component and ui_component.gallery_view:
+                        current_index = ui_component.gallery_view.currentIndex()
+                        if current_index.isValid():
+                            aoi_info = self.gallery_controller.model.get_aoi_info(current_index)
+                            if aoi_info:
+                                image_idx, aoi_idx, _ = aoi_info
+                                self.neighbor_tracking_controller.track_selected_aoi(
+                                    image_idx=image_idx, aoi_idx=aoi_idx
+                                )
+                else:
+                    self.neighbor_tracking_controller.track_selected_aoi()
         if e.key() == Qt.Key_W and e.modifiers() == Qt.ShiftModifier:
             # Load Wingtra CSV flight log with 'Shift+W' key
             self.wingtra_controller.prompt_and_load_csv()

--- a/app/core/controllers/images/viewer/aoi/AOIController.py
+++ b/app/core/controllers/images/viewer/aoi/AOIController.py
@@ -7,7 +7,6 @@ UI manipulation is handled by AOIUIComponent.
 
 import colorsys
 import cv2
-import fnmatch
 import json
 import math
 import numpy as np
@@ -410,17 +409,26 @@ class AOIController(TranslationMixin):
                         except Exception:
                             pass
 
-    def edit_aoi_comment(self, aoi_index):
+    def edit_aoi_comment(self, aoi_index, image_idx=None):
         """Open dialog to edit the comment for an AOI.
 
         Args:
             aoi_index (int): Index of the AOI to edit comment for
+            image_idx (int, optional): Index of the AOI's parent image. If
+                None, the currently displayed image is used. Gallery mode
+                passes this explicitly because the selected AOI may live on
+                a different image than the one on screen.
         """
         if aoi_index < 0:
             return
 
-        # Get current image and AOI
-        image = self.parent.images[self.parent.current_image]
+        if image_idx is None:
+            image_idx = self.parent.current_image
+
+        if image_idx < 0 or image_idx >= len(self.parent.images):
+            return
+
+        image = self.parent.images[image_idx]
         if 'areas_of_interest' not in image or aoi_index >= len(image['areas_of_interest']):
             return
 
@@ -433,11 +441,20 @@ class AOIController(TranslationMixin):
         if dialog.exec():
             # User clicked OK - save the comment
             new_comment = dialog.get_comment()
-            self.save_aoi_comment_to_xml(self.parent.current_image, aoi_index, new_comment)
+            self.save_aoi_comment_to_xml(image_idx, aoi_index, new_comment)
 
-            # Refresh the AOI display to update the icon (UI component handles this)
-            if self.ui_component:
+            # Refresh the single-image AOI display if the edit was for the
+            # currently displayed image.
+            if image_idx == self.parent.current_image and self.ui_component:
                 self.ui_component.refresh_aoi_display()
+
+            # Refresh the gallery view if it exists so the comment icon
+            # state updates immediately.
+            if hasattr(self.parent, 'gallery_controller') and self.parent.gallery_controller:
+                try:
+                    self.parent.gallery_controller.refresh_gallery()
+                except Exception:
+                    pass
 
             # Show confirmation toast
             if hasattr(self.parent, 'status_controller'):
@@ -500,7 +517,7 @@ class AOIController(TranslationMixin):
                         current_gps_index
                     )
 
-    def show_aoi_context_menu(self, pos, label_widget, center, pixel_area, avg_info=None, aoi_index=None):
+    def show_aoi_context_menu(self, pos, label_widget, center, pixel_area, avg_info=None, aoi_index=None, image_idx=None):
         """Show context menu for AOI coordinate label with copy option.
 
         Args:
@@ -510,6 +527,8 @@ class AOIController(TranslationMixin):
             pixel_area: The area of the AOI in pixels
             avg_info: Average color/temperature information string
             aoi_index: Index of the AOI
+            image_idx: Optional parent-image index for gallery mode. None means
+                the copy will target the currently displayed image.
         """
         menu = QMenu(label_widget)
 
@@ -532,7 +551,9 @@ class AOIController(TranslationMixin):
 
         # Add copy action
         copy_action = menu.addAction(self.tr("Copy Data"))
-        copy_action.triggered.connect(lambda: self.copy_aoi_data(center, pixel_area, avg_info, aoi_index))
+        copy_action.triggered.connect(
+            lambda: self.copy_aoi_data(center, pixel_area, avg_info, aoi_index, image_idx=image_idx)
+        )
 
         # Get the current cursor position (global coordinates)
         global_pos = QCursor.pos()
@@ -540,7 +561,7 @@ class AOIController(TranslationMixin):
         # Show menu at cursor position
         menu.exec(global_pos)
 
-    def copy_aoi_data(self, center, pixel_area, avg_info=None, aoi_index=None):
+    def copy_aoi_data(self, center, pixel_area, avg_info=None, aoi_index=None, image_idx=None):
         """Copy AOI data to clipboard including image name, coordinates, and GPS.
 
         Args:
@@ -548,13 +569,38 @@ class AOIController(TranslationMixin):
             pixel_area: The area of the AOI in pixels
             avg_info: Average color/temperature information string
             aoi_index: Index of the AOI
+            image_idx: Optional parent-image index. If None, uses the currently
+                displayed image. Gallery mode passes this explicitly so AOIs
+                from images other than the one on screen can be copied.
         """
-        # Get current image information
-        image = self.parent.images[self.parent.current_image]
+        if image_idx is None:
+            image_idx = self.parent.current_image
+
+        if image_idx < 0 or image_idx >= len(self.parent.images):
+            return
+
+        # Get image information
+        image = self.parent.images[image_idx]
         image_name = image.get('name', 'Unknown')
 
-        # Get image GPS coordinates if available
-        image_gps_coords = self.parent.messages.get('GPS Coordinates', 'N/A')
+        # Get image GPS coordinates. For the currently displayed image the
+        # viewer already has a formatted string cached in self.parent.messages;
+        # for any other image we compute it from EXIF so gallery copies produce
+        # the same output.
+        if image_idx == self.parent.current_image:
+            image_gps_coords = self.parent.messages.get('GPS Coordinates', 'N/A')
+        else:
+            image_gps_coords = 'N/A'
+            try:
+                img_service = AOIService(image).image_service
+                gps_exif = LocationInfo.get_gps(exif_data=img_service.exif_data)
+                if gps_exif:
+                    position_format = getattr(self.parent, 'position_format', 'Decimal Degrees')
+                    image_gps_coords = LocationInfo.format_coordinates(
+                        gps_exif['latitude'], gps_exif['longitude'], position_format
+                    )
+            except Exception as e:
+                self.logger.error(f"Error reading image GPS for clipboard copy: {e}")
 
         # Get user comment if available
         user_comment = ""
@@ -564,7 +610,7 @@ class AOIController(TranslationMixin):
                 user_comment = aoi.get('user_comment', '')
 
         # Calculate AOI GPS coordinates with metadata
-        gps_result = self.calculate_aoi_gps(aoi_index, return_metadata=True)
+        gps_result = self.calculate_aoi_gps(aoi_index, return_metadata=True, image_idx=image_idx)
 
         if gps_result:
             aoi_gps_coords = gps_result['coords_text']
@@ -607,12 +653,14 @@ class AOIController(TranslationMixin):
         if hasattr(self.parent, 'status_controller'):
             self.parent.status_controller.show_toast(self.tr("AOI data copied"), 2000, color="#00C853")
 
-    def calculate_aoi_gps(self, aoi_index, return_metadata=False):
+    def calculate_aoi_gps(self, aoi_index, return_metadata=False, image_idx=None):
         """Calculate GPS coordinates for a specific AOI.
 
         Args:
             aoi_index: Index of the AOI
             return_metadata: If True, return dict with coordinates and elevation source info
+            image_idx: Optional parent-image index. If None, uses the currently
+                displayed image. Gallery mode passes this explicitly.
 
         Returns:
             If return_metadata=False: String with formatted GPS coordinates or "N/A"
@@ -622,8 +670,13 @@ class AOIController(TranslationMixin):
             if aoi_index is None or aoi_index < 0:
                 return "N/A" if not return_metadata else None
 
-            # Get current image and AOI
-            image = self.parent.images[self.parent.current_image]
+            if image_idx is None:
+                image_idx = self.parent.current_image
+
+            if image_idx < 0 or image_idx >= len(self.parent.images):
+                return "N/A" if not return_metadata else None
+
+            image = self.parent.images[image_idx]
             if 'areas_of_interest' not in image or aoi_index >= len(image['areas_of_interest']):
                 return "N/A" if not return_metadata else None
 
@@ -977,12 +1030,15 @@ class AOIController(TranslationMixin):
             if self.filter_area_max is not None and area > self.filter_area_max:
                 continue
 
-            # Apply comment filter
+            # Apply comment filter — case-insensitive substring match.
+            # Any '*' characters are stripped so saved wildcard patterns from
+            # earlier versions (e.g. "*blue*", "crack*") keep working.
             if self.filter_comment_pattern is not None:
                 comment = aoi.get('user_comment', '').strip()
                 if not comment:
                     continue
-                if not fnmatch.fnmatch(comment.lower(), self.filter_comment_pattern.lower()):
+                needle = self.filter_comment_pattern.replace('*', '').lower()
+                if needle and needle not in comment.lower():
                     continue
 
             # Apply temperature filter (in Celsius)

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -6,7 +6,6 @@ for displaying AOIs from all loaded images.
 """
 
 import colorsys
-import fnmatch
 import math
 import numpy as np
 import os
@@ -402,14 +401,16 @@ class GalleryController:
                 if not aoi.get('flagged', False):
                     continue
 
-            # Apply comment filter
+            # Apply comment filter — case-insensitive substring match. Any
+            # '*' characters are stripped so saved wildcard patterns from
+            # earlier versions (e.g. "*blue*", "crack*") keep working.
             if self.filter_comment_pattern is not None:
                 comment = aoi.get('user_comment', '').strip()
                 # Skip AOIs with empty comments when filter is active
                 if not comment:
                     continue
-                # Case-insensitive wildcard matching
-                if not fnmatch.fnmatch(comment.lower(), self.filter_comment_pattern.lower()):
+                needle = self.filter_comment_pattern.replace('*', '').lower()
+                if needle and needle not in comment.lower():
                     continue
 
             # Apply color filter

--- a/app/core/controllers/images/viewer/gallery/GalleryUIComponent.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryUIComponent.py
@@ -36,6 +36,11 @@ class AOIGalleryDelegate(QStyledItemDelegate):
         # Create location icon
         self.location_icon = qta.icon('fa6s.location-dot', color='#4CAF50').pixmap(16, 16)
 
+        # Create comment icons — gold when an AOI has a comment, gray otherwise,
+        # matching the single-image view's color convention.
+        self.comment_icon_active = qta.icon('fa6s.comment', color='#FFD700').pixmap(16, 16)
+        self.comment_icon_inactive = qta.icon('fa6s.comment', color='#808080').pixmap(16, 16)
+
     def sizeHint(self, option, index):
         """Return the size hint for each item."""
         # Return cached size hint for consistency and performance
@@ -92,35 +97,20 @@ class AOIGalleryDelegate(QStyledItemDelegate):
             painter.setPen(QPen(QColor(100, 100, 100), 1))
             painter.drawRect(thumbnail_rect)
 
-            # Draw flag icon first (to the left of location)
+            # Draw bottom-right icon cluster: flag | comment | location.
+            # Positions are reflowed from the original flag/location pair so
+            # the new comment icon can slot between them without overlap.
+            icon_y = thumbnail_rect.bottom() - 20
+
             flagged = aoi_data.get('flagged', False)
             flag_icon = self.flag_icon_active if flagged else self.flag_icon_inactive
-            flag_x = thumbnail_rect.right() - 40
-            flag_y = thumbnail_rect.bottom() - 20
-            painter.drawPixmap(flag_x, flag_y, flag_icon)
+            painter.drawPixmap(thumbnail_rect.right() - 60, icon_y, flag_icon)
 
-            # Draw location icon in bottom-right corner - at the end
-            location_x = thumbnail_rect.right() - 20
-            location_y = thumbnail_rect.bottom() - 20
-            painter.drawPixmap(location_x, location_y, self.location_icon)
+            has_comment = bool(aoi_data.get('user_comment', '').strip())
+            comment_icon = self.comment_icon_active if has_comment else self.comment_icon_inactive
+            painter.drawPixmap(thumbnail_rect.right() - 40, icon_y, comment_icon)
 
-            # Draw comment indicator in top-left corner
-            comment = aoi_data.get('user_comment', '').strip()
-            if comment:
-                # Use similar icon approach for comments
-                comment_x = thumbnail_rect.left() + 5
-                comment_y = thumbnail_rect.top() + 5
-                # Draw a simple colored circle to indicate comment
-                painter.setBrush(QColor(255, 215, 0))  # Gold color for comments
-                painter.setPen(QPen(QColor(255, 255, 255), 1))
-                painter.drawEllipse(comment_x, comment_y, 16, 16)
-                # Draw text indicator
-                painter.setPen(QPen(QColor(0, 0, 0), 2))
-                font = painter.font()
-                font.setPointSize(8)
-                font.setBold(True)
-                painter.setFont(font)
-                painter.drawText(QRect(comment_x, comment_y, 16, 16), Qt.AlignCenter, "C")
+            painter.drawPixmap(thumbnail_rect.right() - 20, icon_y, self.location_icon)
 
             # Draw color swatch indicator (bottom-left corner of thumbnail)
             color_info = user_data.get('color_info')
@@ -494,15 +484,28 @@ class GalleryUIComponent(TranslationMixin, QObject):
                 if event.key() == Qt.Key_Left:
                     self.gallery_controller.navigate_gallery_aoi(-1)
                     return True
-                if event.key() == Qt.Key_F:
-                    if self.gallery_view.window():
-                        self.gallery_view.window().keyPressEvent(event)
+                # Forward global Viewer shortcuts to the parent window so they
+                # fire even when the gallery has keyboard focus. Without this,
+                # QAbstractItemView's keyboard-search feature swallows letter
+                # keys before Viewer.keyPressEvent sees them.
+                global_shortcut_keys = {
+                    Qt.Key_F, Qt.Key_G, Qt.Key_Z, Qt.Key_C, Qt.Key_R,
+                    Qt.Key_H, Qt.Key_M, Qt.Key_E, Qt.Key_W, Qt.Key_O,
+                    Qt.Key_I,
+                }
+                if event.key() in global_shortcut_keys:
+                    window = self.gallery_view.window()
+                    if window is not None:
+                        window.keyPressEvent(event)
                     return True
 
-            # Handle mouse clicks on flag button
+            # Handle mouse clicks on the thumbnail's interactive icons and
+            # right-click copy. Both left- and right-click are handled from a
+            # single branch so the hit-testing and thumbnail-rect calculation
+            # are not duplicated.
             if (obj == self.gallery_view.viewport() and
                     event.type() == QEvent.MouseButtonPress and
-                    event.button() == Qt.LeftButton):
+                    event.button() in (Qt.LeftButton, Qt.RightButton)):
                 # Get the item at the click position
                 index = self.gallery_view.indexAt(event.pos())
                 if index.isValid():
@@ -521,6 +524,7 @@ class GalleryUIComponent(TranslationMixin, QObject):
                         if user_data:
                             image_idx = user_data.get('image_idx')
                             aoi_idx = user_data.get('aoi_idx')
+                            aoi_data = user_data.get('aoi_data', {}) or {}
 
                             if image_idx is not None and aoi_idx is not None:
                                 # Calculate thumbnail rect
@@ -533,8 +537,35 @@ class GalleryUIComponent(TranslationMixin, QObject):
                                     thumbnail_size.height()
                                 )
 
-                                # Check if click is on flag button (to the left of location, 16x16 icon)
-                                flag_rect = QRect(thumbnail_rect.right() - 40, thumbnail_rect.bottom() - 20, 16, 16)
+                                aoi_controller = None
+                                if hasattr(delegate.gallery_controller.parent, 'aoi_controller'):
+                                    aoi_controller = delegate.gallery_controller.parent.aoi_controller
+
+                                # Right-click on the thumbnail copies AOI data
+                                # via the same context menu used by single-image view.
+                                if event.button() == Qt.RightButton:
+                                    if thumbnail_rect.contains(event.pos()):
+                                        if self.gallery_view.currentIndex() != index:
+                                            self.gallery_view.setCurrentIndex(index)
+                                        if aoi_controller:
+                                            aoi_controller.show_aoi_context_menu(
+                                                event.pos(),
+                                                self.gallery_view,
+                                                aoi_data.get('center', (0, 0)),
+                                                aoi_data.get('area', 0),
+                                                None,
+                                                aoi_idx,
+                                                image_idx=image_idx,
+                                            )
+                                        event.accept()
+                                        return True
+                                    # Right-clicks outside the thumbnail fall through.
+                                    return False
+
+                                # Left-click handlers below.
+
+                                # Flag icon — leftmost of the bottom-right cluster.
+                                flag_rect = QRect(thumbnail_rect.right() - 60, thumbnail_rect.bottom() - 20, 16, 16)
                                 if flag_rect.contains(event.pos()):
                                     # Ensure this item is selected before toggling
                                     if self.gallery_view.currentIndex() != index:
@@ -546,7 +577,17 @@ class GalleryUIComponent(TranslationMixin, QObject):
                                     event.accept()
                                     return True
 
-                                # Check if click is on location button (bottom-right corner, 16x16 icon) - at the end
+                                # Comment icon — middle of the bottom-right cluster.
+                                comment_rect = QRect(thumbnail_rect.right() - 40, thumbnail_rect.bottom() - 20, 16, 16)
+                                if comment_rect.contains(event.pos()):
+                                    if self.gallery_view.currentIndex() != index:
+                                        self.gallery_view.setCurrentIndex(index)
+                                    if aoi_controller:
+                                        aoi_controller.edit_aoi_comment(aoi_idx, image_idx=image_idx)
+                                    event.accept()
+                                    return True
+
+                                # Location icon — rightmost of the bottom-right cluster.
                                 location_rect = QRect(thumbnail_rect.right() - 20, thumbnail_rect.bottom() - 20, 16, 16)
                                 if location_rect.contains(event.pos()):
                                     # Ensure this item is selected
@@ -555,17 +596,9 @@ class GalleryUIComponent(TranslationMixin, QObject):
                                     # Show AOI location - get the visual rect for anchoring
                                     visual_rect = self.gallery_view.visualRect(index)
                                     anchor_point = self.gallery_view.mapToGlobal(visual_rect.bottomRight())
-                                    if delegate.gallery_controller and hasattr(delegate.gallery_controller.parent, 'aoi_controller'):
-                                        delegate.gallery_controller.parent.aoi_controller.show_aoi_location(aoi_idx, image_idx, anchor_point=anchor_point)
+                                    if aoi_controller:
+                                        aoi_controller.show_aoi_location(aoi_idx, image_idx, anchor_point=anchor_point)
                                     # Prevent the click from propagating
-                                    event.accept()
-                                    return True
-
-                                # Check if click is on comment button (top-left corner, 16x16 icon)
-                                comment_rect = QRect(thumbnail_rect.left() + 5, thumbnail_rect.top() + 5, 16, 16)
-                                if comment_rect.contains(event.pos()):
-                                    # Could add comment editing here in the future
-                                    # For now, just accept the event to prevent item selection
                                     event.accept()
                                     return True
 

--- a/app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py
+++ b/app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py
@@ -88,30 +88,43 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
         # Dialog for displaying results
         self._gallery_dialog = None
 
-    def track_selected_aoi(self):
+    def track_selected_aoi(self, image_idx=None, aoi_idx=None):
         """
-        Track the currently selected AOI across neighboring images.
+        Track a selected AOI across neighboring images.
 
-        This method is triggered by the Z key.
+        Triggered by the Z key. When called with no arguments, the AOI is read
+        from the single-image AOIController. When called with explicit
+        `image_idx` / `aoi_idx`, those are used directly — this is the path
+        used from gallery mode, where the selected AOI may belong to an image
+        other than the one currently displayed in the main viewer.
         """
         try:
-            # Get the currently selected AOI
-            aoi_controller = self.parent.aoi_controller
-            selected_aoi = aoi_controller.get_selected_aoi()
+            if image_idx is not None and aoi_idx is not None:
+                # Gallery-mode selection: resolve AOI from explicit indices
+                if image_idx < 0 or image_idx >= len(self.parent.images):
+                    return
+                current_image = self.parent.images[image_idx]
+                aois = current_image.get('areas_of_interest', [])
+                if aoi_idx < 0 or aoi_idx >= len(aois):
+                    return
+                aoi_data = aois[aoi_idx]
+                current_image_idx = image_idx
+            else:
+                # Single-image selection: read from the AOIController
+                aoi_controller = self.parent.aoi_controller
+                selected_aoi = aoi_controller.get_selected_aoi()
 
-            if not selected_aoi:
-                QMessageBox.information(
-                    self.parent,
-                    self.tr("No AOI Selected"),
-                    self.tr("Please select an AOI first by clicking on it in the thumbnail panel.")
-                )
-                return
+                if not selected_aoi:
+                    QMessageBox.information(
+                        self.parent,
+                        self.tr("No AOI Selected"),
+                        self.tr("Please select an AOI first by clicking on it in the thumbnail panel.")
+                    )
+                    return
 
-            aoi_data, aoi_index = selected_aoi
-
-            # Get the current image
-            current_image_idx = self.parent.current_image
-            current_image = self.parent.images[current_image_idx]
+                aoi_data, _ = selected_aoi
+                current_image_idx = self.parent.current_image
+                current_image = self.parent.images[current_image_idx]
 
             # Get altitude override if set
             agl_override_m = None
@@ -120,11 +133,21 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
                 if alt_ft and alt_ft > 0:
                     agl_override_m = alt_ft * 0.3048
 
-            # Calculate the GPS coordinates of the selected AOI
-            aoi_service = AOIService(current_image, self.parent.current_image_array)
-            aoi_gps = aoi_service.estimate_aoi_gps(current_image, aoi_data, agl_override_m)
+            # Only reuse the viewer's cached pixel array when we're tracking
+            # an AOI on the currently-displayed image; otherwise let
+            # ImageService load the correct image from disk.
+            if current_image_idx == self.parent.current_image:
+                img_array = self.parent.current_image_array
+            else:
+                img_array = None
 
-            if not aoi_gps:
+            # Calculate the GPS coordinates of the selected AOI.
+            # estimate_aoi_gps returns an AOIGPSResult dataclass; the neighbor
+            # service expects a plain (lat, lon) tuple, so convert here.
+            aoi_service = AOIService(current_image, img_array)
+            aoi_gps_result = aoi_service.estimate_aoi_gps(current_image, aoi_data, agl_override_m)
+
+            if not aoi_gps_result:
                 QMessageBox.warning(
                     self.parent,
                     self.tr("Cannot Calculate GPS"),
@@ -134,6 +157,8 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
                     )
                 )
                 return
+
+            aoi_gps = aoi_gps_result.to_tuple()
 
             # Show progress dialog
             self.progress_dialog = QProgressDialog(

--- a/app/core/views/images/viewer/dialogs/AOIFilterDialog.py
+++ b/app/core/views/images/viewer/dialogs/AOIFilterDialog.py
@@ -122,7 +122,7 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         pattern_layout.addWidget(QLabel(self.tr("Pattern:")))
 
         self.comment_pattern_input = QLineEdit()
-        self.comment_pattern_input.setPlaceholderText(self.tr("e.g., *work* or crack* or *damage"))
+        self.comment_pattern_input.setPlaceholderText(self.tr("e.g., damage or crack"))
         if self.comment_filter:
             self.comment_pattern_input.setText(self.comment_filter)
         pattern_layout.addWidget(self.comment_pattern_input)
@@ -130,7 +130,7 @@ class AOIFilterDialog(TranslationMixin, QDialog):
         comment_layout.addLayout(pattern_layout)
 
         # Info labels
-        info_label1 = QLabel(self.tr("Use * as wildcard for any characters (case-insensitive)"))
+        info_label1 = QLabel(self.tr("Case-insensitive substring match (e.g. \"blue\" matches \"blueface\")"))
         info_label1.setStyleSheet("QLabel { color: gray; font-size: 9pt; }")
         comment_layout.addWidget(info_label1)
 

--- a/app/core/views/images/viewer/dialogs/GPSMapDialog.py
+++ b/app/core/views/images/viewer/dialogs/GPSMapDialog.py
@@ -42,9 +42,10 @@ class GPSMapDialog(TranslationMixin, QDialog):
         self.setWindowTitle(self.tr("GPS Map View"))
         self.setModal(False)  # Non-modal so user can interact with main window
 
-        # Set window flags to keep dialog on top (especially important on macOS)
-        # Use WindowStaysOnTopHint to keep it visible when clicking on parent window
-        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
+        # Use Qt.Tool so the dialog floats above its parent viewer but not
+        # above unrelated OS apps, and so modal children of the viewer (e.g.
+        # comment/creation dialogs) are not covered by the map.
+        self.setWindowFlags(self.windowFlags() | Qt.Tool)
 
         self.resize(800, 600)
 
@@ -104,6 +105,10 @@ class GPSMapDialog(TranslationMixin, QDialog):
         self.fit_btn.clicked.connect(self.map_view.fit_all_points)
         controls_layout.addWidget(self.fit_btn)
 
+        self.rotate_btn = QPushButton(self.tr("Rotate (R)"))
+        self.rotate_btn.clicked.connect(self.map_view.toggle_rotation)
+        controls_layout.addWidget(self.rotate_btn)
+
         # Add separator
         controls_layout.addSpacing(20)
 
@@ -135,6 +140,10 @@ class GPSMapDialog(TranslationMixin, QDialog):
 
         # Fit all
         QShortcut(QKeySequence(Qt.Key.Key_F), self, self.map_view.fit_all_points)
+
+        # Rotate (toggle north-up / bearing-aligned). Registered at the dialog
+        # level so the shortcut fires regardless of which child widget has focus.
+        QShortcut(QKeySequence(Qt.Key.Key_R), self, self.map_view.toggle_rotation)
 
         # Arrow keys for panning
         QShortcut(QKeySequence(Qt.Key.Key_Left), self, lambda: self.map_view.pan(-50, 0))


### PR DESCRIPTION
## Summary

Small quality-of-life fixes and additions to the Results Viewer, GPS Map View, and AOI gallery.

### Keyboard shortcuts
- Global Viewer shortcuts (`G`, `Z`, `C`, `R`, `H`, `M`, `E`, `F`, `W`, `O`, `I`) are forwarded from the gallery view's `eventFilter` to the parent window. `QListView`'s built-in keyboard-search was previously consuming letter keys before they reached `Viewer.keyPressEvent`, so shortcuts only fired when the mouse was over the main image. `Left`/`Right` are still consumed locally for gallery navigation.

### Z (AOI neighbor tracking) in gallery mode
- Mirrors the `F` key pattern: `Viewer.keyPressEvent` branches on `gallery_mode`, resolves the selection from the gallery model, and passes `(image_idx, aoi_idx)` explicitly to `AOINeighborTrackingController.track_selected_aoi`. The tracker's signature is widened to accept those optional indices so gallery selections that belong to a non-displayed image are handled without disturbing the main viewer.
- Also fixes a pre-existing bug where `AOIService.estimate_aoi_gps` returns an `AOIGPSResult` dataclass but `AOINeighborService.find_aoi_in_neighbors` expects a `(lat, lon)` tuple. The tracker now calls `.to_tuple()` before passing to the worker. This bug would also have affected single-image-mode `Z` on terrain-refinement–enabled datasets.

### GPS Map View
- `Qt.WindowStaysOnTopHint` replaced with `Qt.Tool` so the map floats above the main viewer but not above unrelated OS apps, and so modal ADIAT dialogs (comment editor, altitude override, etc.) are no longer covered.
- New **Rotate (R)** button placed immediately after **Fit All (F)** in the dialog's control row, wired to `GPSMapView.toggle_rotation`. A matching dialog-level `QShortcut` for `R` is registered so the key fires regardless of which child widget currently holds keyboard focus.

### Gallery AOI comment icon and right-click copy
- Added a clickable comment icon (qtawesome `fa6s.comment`) to each gallery thumbnail, gold `#FFD700` when the AOI has a comment and gray `#808080` when empty — matches the single-image view's convention. Reflowed the bottom-right icon cluster to `flag | comment | location` at `right-60 / right-40 / right-20`. The redundant top-left "C" indicator was removed.
- Left-click on the comment icon calls `AOIController.edit_aoi_comment(aoi_idx, image_idx=…)` and opens the same `AOICommentDialog` as single-image view. The gallery refreshes after save so the icon's gold/gray state updates immediately.
- Right-click on any gallery thumbnail opens the same themed context menu (single `Copy Data` action) as single-image view via `AOIController.show_aoi_context_menu`.
- `edit_aoi_comment`, `calculate_aoi_gps`, `copy_aoi_data`, and `show_aoi_context_menu` on `AOIController` have all been widened with an optional `image_idx=None` parameter (defaulting to `current_image` for backward compatibility). `copy_aoi_data` computes image GPS from the target image's EXIF when it's not the currently displayed image, so gallery copies produce the same clipboard text as single-image copies.

### AOI comment filter: substring matching
- Comment filter is now a case-insensitive substring match in both `AOIController._filter_aois` and `GalleryController._matches_filters`. Typing `blue` now matches both `"The cow is blue"` and `"He has a blueface"` without needing wildcards.
- Saved patterns from the old `fnmatch`-based filter (e.g. `*blue*`, `crack*`) still work because `*` characters are stripped before the substring comparison.
- `AOIFilterDialog`'s placeholder and info label updated to reflect the new behavior.

## Test plan

- [ ] In the Results Viewer, enter gallery mode and click on the gallery to focus it. Press `G` — should toggle back to single-image view. Repeat with `C`, `R`, `H`, `M`, `E`, `F`. `Left`/`Right` should still navigate the gallery (not forwarded).
- [ ] In gallery mode, click an AOI thumbnail whose parent image is **not** the currently displayed image, then press `Z`. The neighbor-tracking progress dialog should appear, results should populate, and the main viewer's current image should **not** change. Single-image `Z` on a selected AOI should still work (regression check).
- [ ] Open the GPS Map View (`M`). Alt-tab to another OS application — the map should disappear behind it instead of staying on top. With the map open, trigger a modal ADIAT dialog (e.g. `Shift+O` altitude override, or Add Comment on an AOI) — the modal should be visible and interactive, not covered.
- [ ] In the GPS Map View, confirm a **Rotate (R)** button appears immediately to the right of **Fit All (F)**. Click it — map should toggle between north-up and bearing-aligned. Press `R` — same effect. Verify the compass rotation matches.
- [ ] In the gallery, left-click the new comment icon on an AOI thumbnail. `AOICommentDialog` should open. Save a comment — the gallery icon should flip from gray to gold immediately. Clear the comment — icon should flip back to gray.
- [ ] Right-click any gallery thumbnail — a dark-themed context menu with **Copy Data** should appear at the cursor. Click it — clipboard should receive the same multi-line format as single-image right-click copy. Toast should read "AOI data copied".
- [ ] Right-click a gallery AOI whose parent image is **not** the currently displayed image. Verify the pasted clipboard text contains the correct image name and GPS coordinates for **that** AOI's image, not the currently displayed one.
- [ ] Open the AOI filter dialog, enable the comment filter, and type `blue` (no wildcards). AOIs with comments like `"The cow is blue"` and `"He has a blueface"` should both match. Confirm an old-style pattern like `*blue*` also still works.