### PR TITLE
feat: hue and threshold expansion for MRMap and HSV detections

### DIFF
--- a/adiat_expansion_spec.md
+++ b/adiat_expansion_spec.md
@@ -1,0 +1,77 @@
+# Hue / Anomaly Expansion — Design Spec
+
+## User-facing
+
+### MRMap (image algorithm)
+Two new optional inputs at the bottom of the MRMap wizard:
+- `threshold_expansion` (int, default 0 = off). Accept pixels where `bin_counts < threshold + threshold_expansion`.
+- `hue_expansion` (int degrees 0–180, default 0 = off). ± window around mean seed hue.
+
+### HSV Color Range (image algorithm)
+One new optional input at the bottom of the HSV wizard:
+- `hue_expansion` (int degrees 0–180, default 0 = off).
+
+Backward compat: both default to 0 (off) → identical behavior to today.
+
+## Per-AOI processing pipeline
+
+Runs after initial detection, before pixel area calculation and overlay rendering.
+
+### MRMap — two stages
+1. **Threshold expansion** (only if `threshold_expansion > 0`)
+   - `expanded_mask = (0 < bin_counts) & (bin_counts < threshold + threshold_expansion)`
+   - Phase A (inside cluster rectangle): `selected |= expanded_mask & rect_mask`. No connectivity required.
+   - Phase B (outside cluster rectangle): BFS / morphological dilation from phase-A `selected` pixels, constrained to `expanded_mask`, until no new pixels.
+2. **Hue expansion** (only if `hue_expansion > 0`)
+   - Reference: circular mean hue of the **original** detected pixels (pre-threshold-expansion).
+   - Build `hue_ok` mask (global, per-AOI): `circular_hue_dist(H, mean_seed_hue) <= hue_expansion`.
+   - `cv2.floodFill` from `selected` into `hue_ok`, bounded by safety cap.
+
+### HSV — single stage
+1. **Hue expansion** only (no threshold expansion).
+   - Seed pixels: mask pixels inside each AOI.
+   - Mean seed hue: circular mean over seed pixels.
+   - Expand as above.
+
+### Safety cap
+- Per-AOI max expanded-pixel count = `max(10_000, 10 * cluster_rect_area)`.
+- If cap hit, stop expansion and log a warning.
+
+### Area calculation
+- When any expansion is applied: `area = cv2.contourArea(cv2.convexHull(selected_coords))`.
+- When expansion is off: unchanged (current behavior — `len(selected_pixels)` for MRMap; `len(aoi_pixels_list)` for HSV).
+
+## Implementation structure
+
+### New shared module: `app/algorithms/Shared/services/DetectionExpansion.py`
+- `circular_mean_hue(hues_uint8) -> float` (OpenCV H ∈ [0,180), wraps at 180).
+- `circular_hue_distance_mask(hsv_image, mean_hue, hue_expansion) -> bool mask`.
+- `expand_threshold_mrmap(bin_counts_grid, threshold_plus_expansion, cluster_rect, seed_mask) -> bool mask`.
+- `expand_hue_flood(selected_mask, hue_ok_mask, cap) -> bool mask`.
+- `convex_hull_area(pixel_coords) -> float`.
+
+### MRMapService changes (`app/algorithms/images/MRMap/services/MRMapService.py`)
+- Read `threshold_expansion`, `hue_expansion` from options in `__init__`.
+- In `process_image`, if either > 0, convert image to HSV once.
+- In `_build_aois_from_clusters`, for each cluster:
+  - Run threshold expansion (uses existing `bin_counts` grid).
+  - Run hue expansion (reference = original cluster pixels).
+  - Compute area via convex hull.
+  - Update detected-pixel overlay to expanded mask.
+
+### HSVColorRangeService changes
+- Read `hue_expansion` from options.
+- After base `identify_areas_of_interest`, for each AOI run hue expansion on the AOI's seed pixels.
+- Recompute area via convex hull when expanded.
+
+### Wizard changes
+- MRMap wizard view + controller: add two QSpinBox fields. Pipe into options dict as `threshold_expansion`, `hue_expansion`.
+- HSV wizard view + controller: add one QSpinBox field for `hue_expansion`.
+
+## Performance
+- Global `hsv_image` conversion once per image: negligible.
+- Per-AOI `hue_ok` mask: O(image_pixels), cheap vectorized numpy.
+- Per-AOI flood fill: O(reachable pixels), bounded by safety cap.
+- Threshold expansion phase A: vectorized mask AND inside rectangle.
+- Threshold expansion phase B: iterative `cv2.dilate` + AND with `expanded_mask`, loop until stable (bounded).
+- Expected net impact: +10–25% on typical images when expansion enabled; 0% overhead when disabled.

--- a/app/algorithms/DetectionExpansion.py
+++ b/app/algorithms/DetectionExpansion.py
@@ -1,0 +1,208 @@
+# DetectionExpansion.py
+# Shared helpers for MRMap threshold expansion, hue-based flood expansion,
+# and convex-hull area calculation. Used by MRMapService and
+# HSVColorRangeService to make anomalous detections more prominent.
+
+import numpy as np
+import cv2
+
+
+# OpenCV represents Hue as [0, 180) (half-degrees). 180 = full circle.
+HUE_MAX = 180
+
+# Fixed defaults applied when the user enables the corresponding checkbox in
+# the algorithm settings. Values are intentionally not user-editable — these
+# constants are the single source of truth for both wizard and advanced UIs.
+DEFAULT_THRESHOLD_EXPANSION = 400
+DEFAULT_HUE_EXPANSION = 5
+DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT = 35
+DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT = 20
+
+
+def circular_mean_hue(hues):
+    """Compute circular mean of OpenCV hue values.
+
+    Handles wraparound correctly (e.g. mean of [175, 5] is ~0, not 90).
+
+    Args:
+        hues: Iterable of hue values in OpenCV units [0, 180).
+
+    Returns:
+        Circular mean hue in OpenCV units [0, 180), or None if input empty.
+    """
+    arr = np.asarray(hues, dtype=np.float64)
+    if arr.size == 0:
+        return None
+    angles = arr * (2.0 * np.pi / HUE_MAX)
+    mean_angle = np.arctan2(np.sin(angles).mean(), np.cos(angles).mean())
+    if mean_angle < 0:
+        mean_angle += 2.0 * np.pi
+    return float(mean_angle * (HUE_MAX / (2.0 * np.pi)))
+
+
+def hue_distance_mask(hsv_image, mean_hue, hue_expansion, sat_floor=0, val_floor=0):
+    """Build boolean mask of pixels whose hue is within +/- hue_expansion of mean_hue.
+
+    Circular distance (handles wraparound at 0/180 boundary). Optionally
+    rejects pixels whose saturation or value is below a floor — useful for
+    preventing hue expansion from sweeping up gray or dark pixels whose hue
+    is effectively noise.
+
+    Args:
+        hsv_image: HxWx3 uint8 image in OpenCV HSV space.
+        mean_hue: Reference hue in OpenCV units [0, 180).
+        hue_expansion: Half-window size in OpenCV units [0, 90].
+        sat_floor: Minimum saturation in OpenCV units [0, 255]. 0 = no floor.
+        val_floor: Minimum value/brightness in OpenCV units [0, 255]. 0 = no floor.
+
+    Returns:
+        HxW bool array; True where pixel hue is within range AND sat/val floors
+        are met.
+    """
+    h = hsv_image[:, :, 0].astype(np.int32)
+    ref = int(round(mean_hue)) % HUE_MAX
+    d = np.abs(h - ref)
+    d = np.minimum(d, HUE_MAX - d)
+    mask = d <= int(hue_expansion)
+    if sat_floor > 0:
+        mask &= hsv_image[:, :, 1] >= int(sat_floor)
+    if val_floor > 0:
+        mask &= hsv_image[:, :, 2] >= int(val_floor)
+    return mask
+
+
+def expand_threshold_mrmap(expanded_bin_mask, cluster_rect, image_shape):
+    """Two-phase threshold expansion for MRMap.
+
+    Phase A (in-rectangle): every pixel inside the AOI cluster rectangle
+    whose bin_count is below threshold+expansion is selected. Connectivity
+    to the original detection is NOT required.
+
+    Phase B (out-of-rectangle): pixels outside the rectangle are added only
+    if they meet the expanded threshold AND are connected (8-way) through
+    other expanded pixels to a Phase-A pixel. Iterates until stable.
+
+    Args:
+        expanded_bin_mask: HxW bool. True where bin_counts > 0 and
+            bin_counts < (threshold + threshold_expansion).
+        cluster_rect: [xmin, ymin, xmax, ymax] of the AOI cluster.
+        image_shape: (H, W[, C]) of the processing-resolution image.
+
+    Returns:
+        HxW bool mask of selected pixels after both phases.
+    """
+    h, w = int(image_shape[0]), int(image_shape[1])
+    xmin, ymin, xmax, ymax = cluster_rect
+    xmin = max(0, int(xmin))
+    ymin = max(0, int(ymin))
+    xmax = min(w - 1, int(xmax))
+    ymax = min(h - 1, int(ymax))
+
+    # Phase A: everything inside the rectangle that passes the expanded threshold.
+    selected = np.zeros((h, w), dtype=bool)
+    selected[ymin:ymax + 1, xmin:xmax + 1] = expanded_bin_mask[ymin:ymax + 1, xmin:xmax + 1]
+
+    if not selected.any():
+        return selected
+
+    # Phase B: flood outward through connected expanded pixels. Using
+    # connectedComponents on expanded_bin_mask and collecting any component
+    # that overlaps the Phase-A selection is equivalent to iterative dilation
+    # but O(N) instead of O(N*iterations).
+    allowed = expanded_bin_mask | selected
+    num_labels, labels = cv2.connectedComponents(allowed.astype(np.uint8), connectivity=8)
+    seed_labels = np.unique(labels[selected])
+    seed_labels = seed_labels[seed_labels != 0]
+    if seed_labels.size == 0:
+        return selected
+    return np.isin(labels, seed_labels)
+
+
+def expand_hue_flood(selected_mask, hue_ok_mask, safety_cap):
+    """Flood-fill expansion from selected pixels through hue-matching neighbors.
+
+    A pixel is added if it matches the hue criterion and is 8-connected to
+    an already-selected pixel (directly or through other hue-matching pixels).
+    Iterates implicitly via connected components.
+
+    Args:
+        selected_mask: HxW bool. Starting seed pixels.
+        hue_ok_mask: HxW bool. True where hue matches the AOI reference hue
+            within the expansion window.
+        safety_cap: Maximum number of expanded pixels. If exceeded, the
+            expansion is aborted and the original selected_mask is returned
+            along with a capped flag.
+
+    Returns:
+        (expanded_mask, cap_hit):
+            expanded_mask: HxW bool, the result.
+            cap_hit: bool, True if the safety cap was exceeded.
+    """
+    if not selected_mask.any():
+        return selected_mask, False
+
+    allowed = hue_ok_mask | selected_mask
+    num_labels, labels = cv2.connectedComponents(allowed.astype(np.uint8), connectivity=8)
+    seed_labels = np.unique(labels[selected_mask])
+    seed_labels = seed_labels[seed_labels != 0]
+    if seed_labels.size == 0:
+        return selected_mask, False
+
+    expanded = np.isin(labels, seed_labels)
+    pixel_count = int(np.count_nonzero(expanded))
+    if safety_cap > 0 and pixel_count > safety_cap:
+        return selected_mask, True
+    return expanded, False
+
+
+def convex_hull_area_from_mask(mask):
+    """Compute convex-hull area (in pixels) of all True pixels in mask.
+
+    The hull's area includes interior non-selected pixels, which is the
+    intended "total footprint" measure for expanded AOIs.
+
+    Args:
+        mask: HxW bool or uint8 mask.
+
+    Returns:
+        Float area in pixels. Returns pixel count for degenerate cases
+        (fewer than 3 points, collinear points).
+    """
+    if mask.dtype != np.uint8:
+        mask_u8 = mask.astype(np.uint8)
+    else:
+        mask_u8 = mask
+    ys, xs = np.where(mask_u8 > 0)
+    n = len(xs)
+    if n == 0:
+        return 0.0
+    if n < 3:
+        return float(n)
+    pts = np.stack([xs, ys], axis=1).reshape(-1, 1, 2).astype(np.int32)
+    try:
+        hull = cv2.convexHull(pts)
+        area = float(cv2.contourArea(hull))
+    except cv2.error:
+        return float(n)
+    # Guard against collinear points producing zero-area hull.
+    if area <= 0.0:
+        return float(n)
+    return area
+
+
+def compute_safety_cap(cluster_rect, min_floor=10000, multiplier=10):
+    """Compute per-AOI expansion safety cap.
+
+    Args:
+        cluster_rect: [xmin, ymin, xmax, ymax].
+        min_floor: Minimum cap regardless of rect size.
+        multiplier: Cap = multiplier * rect_area.
+
+    Returns:
+        Integer pixel cap.
+    """
+    xmin, ymin, xmax, ymax = cluster_rect
+    rect_w = max(1, int(xmax) - int(xmin) + 1)
+    rect_h = max(1, int(ymax) - int(ymin) + 1)
+    rect_area = rect_w * rect_h
+    return max(min_floor, multiplier * rect_area)

--- a/app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py
+++ b/app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py
@@ -15,7 +15,9 @@ from helpers.TranslationMixin import TranslationMixin
 
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (QWidget, QColorDialog, QLabel, QSizePolicy, QScrollArea,
-                               QVBoxLayout, QPushButton, QHBoxLayout, QSpacerItem)
+                               QVBoxLayout, QPushButton, QHBoxLayout, QSpacerItem, QCheckBox)
+
+from algorithms import DetectionExpansion as _DE
 from PySide6.QtCore import Qt
 
 
@@ -160,6 +162,32 @@ class HSVColorRangeController(TranslationMixin, QWidget, Ui_HSVColorRange, Algor
         self._update_scroll_area()
         # Update empty state visibility
         self._update_empty_state()
+
+        self._build_expansion_controls()
+
+    def _build_expansion_controls(self):
+        """Append optional hue-expansion checkbox. Defaults are fixed in DetectionExpansion."""
+        container = QWidget(self)
+        v = QVBoxLayout(container)
+        v.setContentsMargins(0, 6, 0, 0)
+        v.setSpacing(4)
+
+        row = QHBoxLayout()
+        self.hueExpansionCheckBox = QCheckBox(self.tr("Hue Expansion"), container)
+        self.hueExpansionCheckBox.setToolTip(self.tr(
+            "When enabled, expand each AOI through neighbors whose hue is within +/- {0}\n"
+            "(OpenCV units) of the mean hue of the original detected pixels.\n"
+            "Pixels with saturation below {1}% or value below {2}% are excluded."
+        ).format(
+            _DE.DEFAULT_HUE_EXPANSION,
+            _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT,
+            _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT,
+        ))
+        row.addWidget(self.hueExpansionCheckBox)
+        row.addStretch(1)
+        v.addLayout(row)
+
+        self.verticalLayout.addWidget(container)
 
     def _create_scroll_area(self):
         """Create scroll area for color rows if not in UI file."""
@@ -384,6 +412,7 @@ class HSVColorRangeController(TranslationMixin, QWidget, Ui_HSVColorRange, Algor
             options['hue_threshold'] = None
             options['saturation_threshold'] = None
             options['value_threshold'] = None
+            self._apply_expansion_options(options)
             return options
 
         # New format: list of HSV configurations
@@ -413,8 +442,20 @@ class HSVColorRangeController(TranslationMixin, QWidget, Ui_HSVColorRange, Algor
         options['hue_threshold'] = int((first_hsv_ranges['h_minus'] + first_hsv_ranges['h_plus']) * 90)
         options['saturation_threshold'] = int((first_hsv_ranges['s_minus'] + first_hsv_ranges['s_plus']) * 127)
         options['value_threshold'] = int((first_hsv_ranges['v_minus'] + first_hsv_ranges['v_plus']) * 127)
+        self._apply_expansion_options(options)
 
         return options
+
+    def _apply_expansion_options(self, options):
+        """Populate hue-expansion option keys based on the checkbox state."""
+        if hasattr(self, 'hueExpansionCheckBox') and self.hueExpansionCheckBox.isChecked():
+            options['hue_expansion'] = _DE.DEFAULT_HUE_EXPANSION
+            options['hue_expansion_sat_floor'] = _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT
+            options['hue_expansion_val_floor'] = _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT
+        else:
+            options['hue_expansion'] = 0
+            options['hue_expansion_sat_floor'] = 0
+            options['hue_expansion_val_floor'] = 0
 
     def validate(self):
         """
@@ -493,6 +534,12 @@ class HSVColorRangeController(TranslationMixin, QWidget, Ui_HSVColorRange, Algor
             v_plus = options.get('value_threshold', 50)
 
             self.add_color_row(color, h_minus, h_plus, s_minus, s_plus, v_minus, v_plus)
+
+        if hasattr(self, 'hueExpansionCheckBox') and 'hue_expansion' in options:
+            try:
+                self.hueExpansionCheckBox.setChecked(int(options.get('hue_expansion') or 0) > 0)
+            except (TypeError, ValueError):
+                self.hueExpansionCheckBox.setChecked(False)
 
         self._update_view_range_button()
         self._update_scroll_area()

--- a/app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py
+++ b/app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py
@@ -4,7 +4,9 @@ Wizard controller for Color Range (HSV) algorithm.
 Provides a simplified, guided interface for configuring HSV color range detection.
 """
 
-from PySide6.QtWidgets import QWidget, QLabel, QSizePolicy, QPushButton
+from PySide6.QtWidgets import QWidget, QLabel, QSizePolicy, QPushButton, QHBoxLayout, QVBoxLayout, QCheckBox
+
+from algorithms import DetectionExpansion as _DE
 from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt, Signal
 import cv2
@@ -76,10 +78,37 @@ class HSVColorRangeWizardController(TranslationMixin, QWidget, Ui_HSVColorRangeW
         )
         self.color_selection_menu.attach_to(self.addColorButton)
 
+        self._build_expansion_controls()
+
         # Update empty state visibility
         self._update_empty_state()
         self._update_view_range_button()
         self.validation_changed.emit()
+
+    def _build_expansion_controls(self):
+        """Append optional hue expansion checkbox. Defaults are fixed in DetectionExpansion."""
+        container = QWidget(self)
+        v = QVBoxLayout(container)
+        v.setContentsMargins(0, 10, 0, 0)
+        v.setSpacing(4)
+
+        row = QHBoxLayout()
+        self.hueExpansionCheck = QCheckBox(self.tr("Hue Expansion"), container)
+        self.hueExpansionCheck.setToolTip(self.tr(
+            "When enabled, expand each AOI through neighbors whose hue is within +/- {0}\n"
+            "(OpenCV units) of the mean hue of the original detected pixels.\n"
+            "Pixels with saturation below {1}% or value below {2}% are excluded."
+        ).format(
+            _DE.DEFAULT_HUE_EXPANSION,
+            _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT,
+            _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT,
+        ))
+        row.addWidget(self.hueExpansionCheck)
+        row.addStretch(1)
+        v.addLayout(row)
+
+        # Insert above the trailing vertical spacer in the root layout.
+        self.verticalLayout_root.insertWidget(self.verticalLayout_root.count() - 1, container)
 
         # Ensure an in-page widget has focus so the dialog Close button doesn't take it
         try:
@@ -261,6 +290,7 @@ class HSVColorRangeWizardController(TranslationMixin, QWidget, Ui_HSVColorRangeW
             options['hue_threshold'] = None
             options['saturation_threshold'] = None
             options['value_threshold'] = None
+            self._apply_expansion_options(options)
             return options
 
         # New format: list of HSV configurations (matches non-wizard controller)
@@ -335,7 +365,19 @@ class HSVColorRangeWizardController(TranslationMixin, QWidget, Ui_HSVColorRangeW
         options['hue_threshold'] = int((options['hsv_ranges']['h_minus'] + options['hsv_ranges']['h_plus']) * 90)
         options['saturation_threshold'] = int((options['hsv_ranges']['s_minus'] + options['hsv_ranges']['s_plus']) * 127)
         options['value_threshold'] = int((options['hsv_ranges']['v_minus'] + options['hsv_ranges']['v_plus']) * 127)
+        self._apply_expansion_options(options)
         return options
+
+    def _apply_expansion_options(self, options):
+        """Populate hue-expansion option keys based on the checkbox state."""
+        if hasattr(self, 'hueExpansionCheck') and self.hueExpansionCheck.isChecked():
+            options['hue_expansion'] = _DE.DEFAULT_HUE_EXPANSION
+            options['hue_expansion_sat_floor'] = _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT
+            options['hue_expansion_val_floor'] = _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT
+        else:
+            options['hue_expansion'] = 0
+            options['hue_expansion_sat_floor'] = 0
+            options['hue_expansion_val_floor'] = 0
 
     def validate(self):
         """Validate configuration."""
@@ -382,6 +424,12 @@ class HSVColorRangeWizardController(TranslationMixin, QWidget, Ui_HSVColorRangeW
             if selected_color:
                 color = QColor(selected_color[0], selected_color[1], selected_color[2])
                 self.add_color_row(color, tolerance_index)
+
+        if hasattr(self, 'hueExpansionCheck') and 'hue_expansion' in options:
+            try:
+                self.hueExpansionCheck.setChecked(int(options.get('hue_expansion') or 0) > 0)
+            except (TypeError, ValueError):
+                self.hueExpansionCheck.setChecked(False)
 
         self._update_empty_state()
         self._update_view_range_button()

--- a/app/algorithms/images/HSVColorRange/services/HSVColorRangeService.py
+++ b/app/algorithms/images/HSVColorRange/services/HSVColorRangeService.py
@@ -4,7 +4,18 @@ from ast import literal_eval
 
 from helpers.ColorUtils import ColorUtils
 from algorithms.AlgorithmService import AlgorithmService, AnalysisResult
+from algorithms import DetectionExpansion
 from core.services.LoggerService import LoggerService
+
+
+def _percent_to_u8(value):
+    """Clamp a 0-100 percentage to the OpenCV 0-255 uint8 range."""
+    try:
+        pct = float(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    pct = max(0.0, min(100.0, pct))
+    return int(round(pct / 100.0 * 255.0))
 
 
 class HSVColorRangeService(AlgorithmService):
@@ -30,6 +41,11 @@ class HSVColorRangeService(AlgorithmService):
         """
         self.logger = LoggerService()
         super().__init__('HSVColorRange', identifier, min_area, max_area, aoi_radius, combine_aois, options)
+
+        # Optional hue expansion; default 0 (off) preserves legacy behavior.
+        self.hue_expansion = int(options.get('hue_expansion', 0) or 0)
+        self.hue_expansion_sat_floor = _percent_to_u8(options.get('hue_expansion_sat_floor', 0))
+        self.hue_expansion_val_floor = _percent_to_u8(options.get('hue_expansion_val_floor', 0))
 
         self.target_color_hsv = None
         # Store for backward compatibility
@@ -255,6 +271,13 @@ class HSVColorRangeService(AlgorithmService):
             if areas_of_interest:
                 areas_of_interest = self._add_confidence_scores(areas_of_interest, hsv_distances, mask)
 
+            # Optional hue expansion. Runs after confidence so scores reflect
+            # the original detection, not the expanded footprint.
+            if areas_of_interest and self.hue_expansion > 0:
+                areas_of_interest, mask = self._apply_hue_expansion_aois(
+                    areas_of_interest, img.shape, hsv_image
+                )
+
             output_path = self._construct_output_path(full_path, input_dir, output_dir)
 
             # Store mask instead of duplicating image
@@ -268,6 +291,73 @@ class HSVColorRangeService(AlgorithmService):
         except Exception as e:
             self.logger.error(f"Error processing image {full_path}: {e}")
             return AnalysisResult(full_path, error_message=str(e))
+
+    def _apply_hue_expansion_aois(self, areas_of_interest, img_shape, hsv_image):
+        """Apply iterative hue expansion to each AOI.
+
+        Reference hue per AOI is the circular mean of the AOI's original
+        detected pixels (same basis as the AOI thumbnail color). Neighbors
+        within +/- hue_expansion (circular distance) that are 8-connected
+        through other hue-matching pixels get added. Safety-capped per AOI.
+        Area is replaced with convex-hull area of the expanded pixel set.
+
+        Args:
+            areas_of_interest: List of AOIs (modified in place; also returned).
+            img_shape: (H, W[, C]) of processing image.
+            hsv_image: HxWx3 HSV image.
+
+        Returns:
+            (areas_of_interest, combined_mask). combined_mask is uint8 with
+            255 on every expanded pixel across all AOIs.
+        """
+        h, w = int(img_shape[0]), int(img_shape[1])
+        combined_mask = np.zeros((h, w), dtype=np.uint8)
+
+        for aoi in areas_of_interest:
+            original_pixels = aoi.get('detected_pixels') or []
+            if not original_pixels:
+                continue
+
+            coords = np.asarray(original_pixels, dtype=np.int32)
+            # Clip coords to image bounds for safety (AOIs are at processing resolution).
+            coords[:, 0] = np.clip(coords[:, 0], 0, w - 1)
+            coords[:, 1] = np.clip(coords[:, 1], 0, h - 1)
+
+            seed_mask = np.zeros((h, w), dtype=bool)
+            seed_mask[coords[:, 1], coords[:, 0]] = True
+
+            cluster_rect = [
+                int(coords[:, 0].min()), int(coords[:, 1].min()),
+                int(coords[:, 0].max()), int(coords[:, 1].max()),
+            ]
+            safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
+
+            seed_hues = hsv_image[coords[:, 1], coords[:, 0], 0]
+            mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
+            if mean_hue is None:
+                combined_mask[seed_mask] = 255
+                continue
+
+            hue_ok = DetectionExpansion.hue_distance_mask(
+                hsv_image, mean_hue, self.hue_expansion,
+                sat_floor=self.hue_expansion_sat_floor,
+                val_floor=self.hue_expansion_val_floor,
+            )
+            expanded, cap_hit = DetectionExpansion.expand_hue_flood(seed_mask, hue_ok, safety_cap)
+            if cap_hit:
+                self.logger.warning(
+                    f"HSV hue expansion cap hit for AOI at {aoi.get('center')}; keeping original selection."
+                )
+                expanded = seed_mask
+
+            ys2, xs2 = np.where(expanded)
+            if len(xs2) == 0:
+                continue
+            aoi['detected_pixels'] = np.stack([xs2, ys2], axis=1).tolist()
+            aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(expanded)))
+            combined_mask[expanded] = 255
+
+        return areas_of_interest, combined_mask
 
     def _calculate_hsv_distances(self, hsv_image, target_hsv, mask):
         """

--- a/app/algorithms/images/MRMap/controllers/MRMapController.py
+++ b/app/algorithms/images/MRMap/controllers/MRMapController.py
@@ -3,7 +3,9 @@ import sys
 from algorithms.AlgorithmController import AlgorithmController
 from algorithms.images.MRMap.views.MRMap_ui import Ui_MRMap
 
-from PySide6.QtWidgets import QComboBox, QListView, QWidget
+from PySide6.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLabel, QListView, QVBoxLayout, QWidget
+
+from algorithms import DetectionExpansion as _DE
 
 
 class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
@@ -26,6 +28,48 @@ class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
         self._fixComboBoxForMacOS(self.colorspaceComboBox)
         self._fixComboBoxForMacOS(self.segmentsComboBox)
         self.thresholdSlider.valueChanged.connect(self.updatethreshold)
+        self._build_expansion_controls()
+
+    def _build_expansion_controls(self):
+        """Add optional AOI expansion checkboxes. Defaults are fixed in DetectionExpansion."""
+        container = QWidget(self)
+        v = QVBoxLayout(container)
+        v.setContentsMargins(0, 6, 0, 0)
+        v.setSpacing(4)
+
+        header = QLabel(self.tr("Detection Expansion (optional)"))
+        hf = header.font()
+        hf.setPointSize(10)
+        hf.setBold(True)
+        header.setFont(hf)
+        v.addWidget(header)
+
+        row = QHBoxLayout()
+        self.thresholdExpansionCheckBox = QCheckBox(self.tr("Threshold Expansion"), container)
+        self.thresholdExpansionCheckBox.setToolTip(self.tr(
+            "When enabled, expand each AOI to also include pixels with histogram bin-counts\n"
+            "below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;\n"
+            "pixels outside are added if they are connected through other qualifying pixels."
+        ).format(_DE.DEFAULT_THRESHOLD_EXPANSION))
+        row.addWidget(self.thresholdExpansionCheckBox)
+
+        row.addSpacing(20)
+        self.hueExpansionCheckBox = QCheckBox(self.tr("Hue Expansion"), container)
+        self.hueExpansionCheckBox.setToolTip(self.tr(
+            "When enabled, expand each AOI through neighbors whose hue is within +/- {0}\n"
+            "(OpenCV units) of the mean hue of the original detected pixels.\n"
+            "Pixels with saturation below {1}% or value below {2}% are excluded."
+        ).format(
+            _DE.DEFAULT_HUE_EXPANSION,
+            _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT,
+            _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT,
+        ))
+        row.addWidget(self.hueExpansionCheckBox)
+        row.addStretch(1)
+        v.addLayout(row)
+
+        # Attach to the root layout of the .ui file.
+        self.verticalLayout.addWidget(container)
 
     def _fixComboBoxForMacOS(self, combo):
         """Force non-native dropdown rendering on macOS to fix popup positioning and padding."""
@@ -57,6 +101,17 @@ class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
         options['segments'] = int(self.segmentsComboBox.currentData())
         options['window'] = self.windowSpinBox.value()
         options['colorspace'] = str(self.colorspaceComboBox.currentData())
+        options['threshold_expansion'] = (
+            _DE.DEFAULT_THRESHOLD_EXPANSION if self.thresholdExpansionCheckBox.isChecked() else 0
+        )
+        if self.hueExpansionCheckBox.isChecked():
+            options['hue_expansion'] = _DE.DEFAULT_HUE_EXPANSION
+            options['hue_expansion_sat_floor'] = _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT
+            options['hue_expansion_val_floor'] = _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT
+        else:
+            options['hue_expansion'] = 0
+            options['hue_expansion_sat_floor'] = 0
+            options['hue_expansion_val_floor'] = 0
         return options
 
     def updatethreshold(self):
@@ -100,3 +155,13 @@ class MRMapController(QWidget, Ui_MRMap, AlgorithmController):
                 self.colorspaceComboBox.setCurrentIndex(index)
             else:
                 self.colorspaceComboBox.setCurrentText(str(options['colorspace']))
+        if 'threshold_expansion' in options:
+            try:
+                self.thresholdExpansionCheckBox.setChecked(int(options.get('threshold_expansion') or 0) > 0)
+            except (TypeError, ValueError):
+                self.thresholdExpansionCheckBox.setChecked(False)
+        if 'hue_expansion' in options:
+            try:
+                self.hueExpansionCheckBox.setChecked(int(options.get('hue_expansion') or 0) > 0)
+            except (TypeError, ValueError):
+                self.hueExpansionCheckBox.setChecked(False)

--- a/app/algorithms/images/MRMap/controllers/MRMapWizardController.py
+++ b/app/algorithms/images/MRMap/controllers/MRMapWizardController.py
@@ -4,7 +4,9 @@ Wizard controller for MRMap algorithm.
 Provides a simplified, guided interface for configuring MRMap detection parameters.
 """
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QButtonGroup
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QButtonGroup, QHBoxLayout, QLabel, QCheckBox
+
+from algorithms import DetectionExpansion as _DE
 
 from algorithms.AlgorithmController import AlgorithmController
 from core.views.components.LabeledSlider import TextLabeledSlider
@@ -46,6 +48,47 @@ class MRMapWizardController(QWidget, Ui_MRMapWizard, AlgorithmController):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.aggressivenessSlider)
 
+        self._build_expansion_controls()
+
+    def _build_expansion_controls(self):
+        """Add optional AOI expansion checkboxes. Defaults are fixed in DetectionExpansion."""
+        container = QWidget(self)
+        v = QVBoxLayout(container)
+        v.setContentsMargins(0, 10, 0, 0)
+        v.setSpacing(4)
+
+        header = QLabel(self.tr("Detection Expansion (optional)"))
+        header_font = header.font()
+        header_font.setPointSize(12)
+        header.setFont(header_font)
+        v.addWidget(header)
+
+        row = QHBoxLayout()
+        self.thresholdExpansionCheck = QCheckBox(self.tr("Threshold Expansion"), container)
+        self.thresholdExpansionCheck.setToolTip(self.tr(
+            "When enabled, expand each AOI to also include pixels with histogram bin-counts\n"
+            "below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;\n"
+            "pixels outside are added if they are connected through other qualifying pixels."
+        ).format(_DE.DEFAULT_THRESHOLD_EXPANSION))
+        row.addWidget(self.thresholdExpansionCheck)
+
+        row.addSpacing(20)
+        self.hueExpansionCheck = QCheckBox(self.tr("Hue Expansion"), container)
+        self.hueExpansionCheck.setToolTip(self.tr(
+            "When enabled, expand each AOI through neighbors whose hue is within +/- {0}\n"
+            "(OpenCV units) of the mean hue of the original detected pixels.\n"
+            "Pixels with saturation below {1}% or value below {2}% are excluded."
+        ).format(
+            _DE.DEFAULT_HUE_EXPANSION,
+            _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT,
+            _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT,
+        ))
+        row.addWidget(self.hueExpansionCheck)
+        row.addStretch(1)
+        v.addLayout(row)
+
+        self.verticalLayout_root.insertWidget(self.verticalLayout_root.count() - 1, container)
+
     def _read_ui_state(self):
         """Read current UI selections into simple values."""
         complex_scene = self.radioComplexYes.isChecked()
@@ -78,6 +121,17 @@ class MRMapWizardController(QWidget, Ui_MRMapWizard, AlgorithmController):
         options['segments'] = segments
         options['window'] = window
         options['colorspace'] = 'LAB'  # Default to LAB to match UI default
+        options['threshold_expansion'] = (
+            _DE.DEFAULT_THRESHOLD_EXPANSION if self.thresholdExpansionCheck.isChecked() else 0
+        )
+        if self.hueExpansionCheck.isChecked():
+            options['hue_expansion'] = _DE.DEFAULT_HUE_EXPANSION
+            options['hue_expansion_sat_floor'] = _DE.DEFAULT_HUE_EXPANSION_SAT_FLOOR_PCT
+            options['hue_expansion_val_floor'] = _DE.DEFAULT_HUE_EXPANSION_VAL_FLOOR_PCT
+        else:
+            options['hue_expansion'] = 0
+            options['hue_expansion_sat_floor'] = 0
+            options['hue_expansion_val_floor'] = 0
 
         # Wizard fields retained for reference
         options['complex_scene'] = complex_scene
@@ -122,3 +176,14 @@ class MRMapWizardController(QWidget, Ui_MRMapWizard, AlgorithmController):
             else:
                 index = 4  # Very Aggressive
             self.aggressivenessSlider.setValue(index)
+
+        if 'threshold_expansion' in options:
+            try:
+                self.thresholdExpansionCheck.setChecked(int(options.get('threshold_expansion') or 0) > 0)
+            except (TypeError, ValueError):
+                self.thresholdExpansionCheck.setChecked(False)
+        if 'hue_expansion' in options:
+            try:
+                self.hueExpansionCheck.setChecked(int(options.get('hue_expansion') or 0) > 0)
+            except (TypeError, ValueError):
+                self.hueExpansionCheck.setChecked(False)

--- a/app/algorithms/images/MRMap/services/MRMapService.py
+++ b/app/algorithms/images/MRMap/services/MRMapService.py
@@ -5,11 +5,22 @@ import math
 import traceback
 
 from algorithms.AlgorithmService import AlgorithmService, AnalysisResult
+from algorithms import DetectionExpansion
 from core.services.LoggerService import LoggerService
 from collections import deque
 
 MAX_SHADES = 256
 NUMBER_OF_QUANTIZED_HISTOGRAM_BINS = 26
+
+
+def _percent_to_u8(value):
+    """Clamp a 0-100 percentage to the OpenCV 0-255 uint8 range."""
+    try:
+        pct = float(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    pct = max(0.0, min(100.0, pct))
+    return int(round(pct / 100.0 * 255.0))
 
 
 class MRMapService(AlgorithmService):
@@ -41,6 +52,12 @@ class MRMapService(AlgorithmService):
         self.threshold = options['threshold']
         self.window_size = options['window']
         self.colorspace = options.get('colorspace', 'LAB')  # Default to LAB to match UI default
+        # Optional AOI expansion. All default to 0 (off) — preserves legacy behavior.
+        self.threshold_expansion = int(options.get('threshold_expansion', 0) or 0)
+        self.hue_expansion = int(options.get('hue_expansion', 0) or 0)
+        # Floors are user-facing percentages (0-100); convert to OpenCV S/V (0-255).
+        self.hue_expansion_sat_floor = _percent_to_u8(options.get('hue_expansion_sat_floor', 0))
+        self.hue_expansion_val_floor = _percent_to_u8(options.get('hue_expansion_val_floor', 0))
 
     def process_image(self, img, full_path, input_dir, output_dir):
         """Process a single image using the MR Map algorithm.
@@ -87,9 +104,26 @@ class MRMapService(AlgorithmService):
 
             areas_of_interest, base_contour_count = self._build_aois_from_clusters(clusters, img.shape)
 
-            # Add confidence scores to AOIs based on bin counts (rarity scores)
+            # Confidence scores run on the *original* detection so rarity reflects
+            # the anomaly itself, not pixels added by expansion.
             if areas_of_interest:
                 areas_of_interest = self._add_confidence_scores(areas_of_interest, bin_counts, mask)
+
+            # Optional anomaly / hue expansion. Overwrites detected_pixels and area
+            # on each AOI and rewrites `mask` to match the expanded pixel set.
+            if areas_of_interest and (self.threshold_expansion > 0 or self.hue_expansion > 0):
+                expanded_bin_mask = None
+                if self.threshold_expansion > 0:
+                    expanded_threshold = self.threshold + self.threshold_expansion
+                    expanded_bin_mask = (0 < bin_counts) & (bin_counts < expanded_threshold)
+
+                hsv_img = None
+                if self.hue_expansion > 0:
+                    hsv_img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+
+                areas_of_interest, mask = self._apply_expansion(
+                    areas_of_interest, img.shape, expanded_bin_mask, hsv_img
+                )
 
             output_path = self._construct_output_path(full_path, input_dir, output_dir)
 
@@ -361,6 +395,96 @@ class MRMapService(AlgorithmService):
 
         combined_aois.sort(key=lambda item: (item['center'][1], item['center'][0]))
         return combined_aois, base_contour_count
+
+    def _apply_expansion(self, areas_of_interest, img_shape, expanded_bin_mask, hsv_img):
+        """Apply threshold and/or hue expansion to each AOI.
+
+        Threshold expansion (MRMap-specific): per AOI, expand to all pixels
+        inside the cluster rectangle that pass bin_counts < threshold+expansion,
+        then flood to connected pixels meeting that criterion outside the rect.
+
+        Hue expansion: circular mean hue of the original detected pixels is
+        the reference. Any pixel within +/- hue_expansion of that mean
+        (circular distance) reachable by 8-connected flood from the current
+        selection is added. Safety-capped per AOI.
+
+        Area is replaced with convex-hull area of the expanded pixel set.
+
+        Args:
+            areas_of_interest: List of AOIs (modified in place; also returned).
+            img_shape: (H, W[, C]) of processing image.
+            expanded_bin_mask: Global bool mask for threshold expansion, or None.
+            hsv_img: HxWx3 HSV image for hue expansion, or None.
+
+        Returns:
+            (areas_of_interest, combined_mask). combined_mask is uint8 with
+            255 on every expanded pixel across all AOIs.
+        """
+        h, w = int(img_shape[0]), int(img_shape[1])
+        combined_mask = np.zeros((h, w), dtype=np.uint8)
+
+        for aoi in areas_of_interest:
+            original_pixels = aoi.get('detected_pixels') or []
+            if not original_pixels:
+                continue
+
+            # Seed mask from original detected pixels.
+            coords = np.asarray(original_pixels, dtype=np.int32)
+            seed_mask = np.zeros((h, w), dtype=bool)
+            seed_mask[coords[:, 1], coords[:, 0]] = True
+
+            # Derive cluster rect from the stored contour corners. MRMap stores
+            # the axis-aligned cluster rectangle as 4 corner points.
+            contour = aoi.get('contour') or []
+            if contour:
+                xs = [int(p[0]) for p in contour]
+                ys = [int(p[1]) for p in contour]
+                cluster_rect = [min(xs), min(ys), max(xs), max(ys)]
+            else:
+                cluster_rect = [
+                    int(coords[:, 0].min()), int(coords[:, 1].min()),
+                    int(coords[:, 0].max()), int(coords[:, 1].max()),
+                ]
+
+            safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
+
+            # Stage 1: threshold expansion (MRMap only).
+            selected = seed_mask
+            if expanded_bin_mask is not None:
+                threshold_selected = DetectionExpansion.expand_threshold_mrmap(
+                    expanded_bin_mask, cluster_rect, (h, w)
+                )
+                selected = seed_mask | threshold_selected
+
+            # Stage 2: hue expansion. Reference = circular mean of *original*
+            # detected pixel hues.
+            if hsv_img is not None and self.hue_expansion > 0:
+                seed_hues = hsv_img[coords[:, 1], coords[:, 0], 0]
+                mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
+                if mean_hue is not None:
+                    hue_ok = DetectionExpansion.hue_distance_mask(
+                        hsv_img, mean_hue, self.hue_expansion,
+                        sat_floor=self.hue_expansion_sat_floor,
+                        val_floor=self.hue_expansion_val_floor,
+                    )
+                    flooded, cap_hit = DetectionExpansion.expand_hue_flood(selected, hue_ok, safety_cap)
+                    if cap_hit:
+                        self.logger.warning(
+                            f"MRMap hue expansion cap hit for AOI at {aoi.get('center')}; keeping pre-hue selection."
+                        )
+                    else:
+                        selected = flooded
+
+            # Commit expanded selection back to AOI.
+            ys2, xs2 = np.where(selected)
+            if len(xs2) == 0:
+                continue
+            aoi['detected_pixels'] = np.stack([xs2, ys2], axis=1).tolist()
+            aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(selected)))
+
+            combined_mask[selected] = 255
+
+        return areas_of_interest, combined_mask
 
     def _add_confidence_scores(self, areas_of_interest, bin_counts, mask):
         """Add confidence scores to AOIs based on histogram bin counts (rarity scores).


### PR DESCRIPTION
## Summary

Adds optional post-detection expansion to the MRMap and HSV Color Range algorithms so anomalous detections become more prominent in the reported AOIs. The expansion features are off by default and surface in the algorithm settings as simple checkboxes.

### MRMap (two independent toggles)

- **Threshold Expansion** — when enabled, each AOI is grown to include pixels whose histogram bin-count is below `threshold + 400`. Pixels *inside* the AOI cluster rectangle are added unconditionally. Pixels *outside* the rectangle are added only if connected (8-way) through other qualifying pixels.
- **Hue Expansion** — when enabled, each AOI is flood-filled through neighbors whose hue is within ±5 (OpenCV units) of the circular mean hue of the original detected pixels. A saturation floor (35%) and value floor (20%) reject gray and dark pixels so background is not pulled in.

### HSV Color Range

- **Hue Expansion** — same iterative flood as MRMap, with the same defaults.

### Area & confidence semantics

- When any expansion is applied, each AOI's `area` is replaced with the convex-hull area of the expanded pixel set (includes non-selected interior pixels — the intended "total footprint" measure).
- `detected_pixels` and the saved mask TIFF are updated to reflect the expanded set.
- Confidence / rarity scores still run on the *original* detection, so they remain a measure of how anomalous the seed was.

### Safety

- Each AOI's expansion is capped at `max(10_000, 10 × cluster_rect_area)` pixels. If exceeded, the expansion step bails out, the pre-expansion selection is kept, and a warning is logged.

### UI

- Simple checkboxes — no user-editable expansion values. Defaults live in `app/algorithms/DetectionExpansion.py` so wizard and advanced controllers stay in sync.

### Files

- `app/algorithms/DetectionExpansion.py` (new) — circular mean hue, hue-distance mask, two-phase MRMap threshold expansion, hue flood, convex-hull area, safety-cap helper, default constants.
- `app/algorithms/images/MRMap/services/MRMapService.py` — wires expansion into `process_image`.
- `app/algorithms/images/HSVColorRange/services/HSVColorRangeService.py` — same.
- All four wizard and advanced controllers for MRMap and HSV — checkbox UI + `get_options` / `load_options`.
- `adiat_expansion_spec.md` — design doc.

## Test plan

- [ ] Open the MRMap wizard and the MRMap advanced settings — confirm two new checkboxes appear at the bottom (Threshold Expansion, Hue Expansion).
- [ ] Open the HSV Color Range wizard and advanced settings — confirm one new checkbox appears (Hue Expansion).
- [ ] Run MRMap with both checkboxes off — verify behavior is identical to the prior release.
- [ ] Run MRMap on a known-anomaly image with Threshold Expansion checked — verify AOIs visibly grow into nearby same-bin pixels and `area` increases.
- [ ] Run MRMap with Hue Expansion checked on a colorful target — verify expansion follows the dominant hue without sweeping in background gray (sat/val floors at work).
- [ ] Run HSV Color Range with Hue Expansion checked — verify each AOI expands to neighboring same-hue pixels.
- [ ] Verify AOI area in the report panel reflects the convex hull (not just the original pixel count) when expansion is on.
- [ ] Verify a stored config containing the new `threshold_expansion` / `hue_expansion` keys round-trips correctly through `load_options`.