### PR TITLE
fix: point app.spec at drones.csv / xmp.csv after pkl→csv migration

### DIFF
--- a/app.spec
+++ b/app.spec
@@ -29,8 +29,8 @@ if platform.system() == 'Windows':
                 datas=[
                     ('resources/icons/ADIAT.ico','.'),
                     ('app/algorithms.conf','.'),
-                    ('app/drones.pkl', '.'),
-                    ('app/xmp.pkl', '.'),
+                    ('app/drones.csv', '.'),
+                    ('app/xmp.csv', '.'),
                     ('app/colors.pkl', '.'),
                     ('colors.csv', '.'),
                     # AI Person Detector models
@@ -94,8 +94,8 @@ elif platform.system() == 'Darwin':
                     datas=[
                         ('resources/icons/ADIAT.ico','.'),
                         ('app/algorithms.conf','.'),
-                        ('app/drones.pkl', '.'),
-                        ('app/xmp.pkl', '.'),
+                        ('app/drones.csv', '.'),
+                        ('app/xmp.csv', '.'),
                         # Color lists used by ColorListService (expects under app/)
                         ('app/colors.pkl', 'app'),
                         ('colors.csv', 'app'),


### PR DESCRIPTION
## Summary
- PR #110 migrated `app/drones.pkl` and `app/xmp.pkl` to versioned CSV but `app.spec` was not updated. `python setup.py build` now fails with `Unable to find ... drones.pkl when adding binary and data files`.
- Update both the Windows and Darwin `Analysis(datas=...)` blocks to reference `app/drones.csv` and `app/xmp.csv`. `app/colors.pkl` is intentionally untouched — it was not part of the migration.

## Test plan
- [ ] `python setup.py build` completes on Windows (PyInstaller finds all listed data files).
- [ ] Confirm the resulting bundle still loads the drone and XMP registries via `PickleHelper` (which now reads the bundled CSV).