### PR TITLE
feat: perspective Person Size Reference overlay + shadow-based height measurement

### DIFF
--- a/app.spec
+++ b/app.spec
@@ -41,6 +41,13 @@ if platform.system() == 'Windows':
                 hiddenimports=[
                     'shapely',
                     'shapely.geometry',
+                    # pysolar dispatches between numeric_numpy / numeric_python at runtime;
+                    # PyInstaller's static analysis misses the fallback path.
+                    'pysolar',
+                    'pysolar.solar',
+                    'pysolar.numeric',
+                    'pysolar.numeric_numpy',
+                    'pysolar.numeric_python',
                     # Image algorithm services (dynamically loaded via importlib in AnalyzeService)
                     'algorithms.images.ColorRange.services.ColorRangeService',
                     'algorithms.images.HSVColorRange.services.HSVColorRangeService',
@@ -106,6 +113,13 @@ elif platform.system() == 'Darwin':
                     hiddenimports=[
                         'shapely',
                         'shapely.geometry',
+                        # pysolar dispatches between numeric_numpy / numeric_python at runtime;
+                        # PyInstaller's static analysis misses the fallback path.
+                        'pysolar',
+                        'pysolar.solar',
+                        'pysolar.numeric',
+                        'pysolar.numeric_numpy',
+                        'pysolar.numeric_python',
                         # Image algorithm services (dynamically loaded via importlib in AnalyzeService)
                         'algorithms.images.ColorRange.services.ColorRangeService',
                         'algorithms.images.HSVColorRange.services.HSVColorRangeService',

--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -1819,12 +1819,31 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             self.personOverlayButton.setToolTip(
                 self.tr("Person Size Reference is unavailable: no GSD for this image")
             )
-        # If the dialog is open, push the updated GSD/provider into it so it rescales.
+        # If the dialog is open, rebuild it for the current image.
         if self.person_reference_dialog is not None and self.person_reference_dialog.isVisible():
-            self.person_reference_dialog.update_gsd(
-                gsd,
-                gsd_at_pixel=self._build_gsd_at_pixel_provider(),
-            )
+            image_service, image_path = self._current_person_reference_inputs()
+            if image_service is not None and image_path:
+                self.person_reference_dialog.update_for_image(
+                    image_service, image_path,
+                    agl_override_m=self._person_reference_agl_override(),
+                )
+
+    def _current_person_reference_inputs(self):
+        """Return (ImageService, image_path) for the current image, or (None, None)."""
+        image_service = getattr(self, 'current_image_service', None)
+        image_path = None
+        images = getattr(self, 'images', None)
+        current = getattr(self, 'current_image', -1)
+        if images and 0 <= current < len(images):
+            image_path = images[current].get('path')
+        return image_service, image_path
+
+    def _person_reference_agl_override(self):
+        """Custom AGL altitude in metres for the person tool, or None."""
+        custom_ft = getattr(self, 'custom_agl_altitude_ft', None)
+        if custom_ft and custom_ft > 0:
+            return custom_ft * 0.3048
+        return None
 
     def _open_person_reference_dialog(self):
         """Opens the person-size reference overlay dialog."""
@@ -1836,16 +1855,18 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             # Tool is supposed to be disabled in this case; bail silently.
             return
 
+        image_service, image_path = self._current_person_reference_inputs()
+        if image_service is None or not image_path:
+            return
+
         # Close help dialog if open to prevent blocking
         self._close_help_dialog_if_open()
 
-        # Ensure the per-pixel GSD service is fresh before opening.
-        self._refresh_current_gsd_service()
-
         if self.person_reference_dialog is None or not self.person_reference_dialog.isVisible():
             self.person_reference_dialog = PersonReferenceDialog(
-                self, self.main_image, gsd, self.distance_unit,
-                gsd_at_pixel=self._build_gsd_at_pixel_provider(),
+                self, self.main_image, image_service, image_path,
+                self.distance_unit,
+                agl_override_m=self._person_reference_agl_override(),
             )
             self.person_reference_dialog.finished.connect(self._on_person_reference_dialog_closed)
             self.person_reference_dialog_open = True

--- a/app/core/services/CameraModel.py
+++ b/app/core/services/CameraModel.py
@@ -1,0 +1,190 @@
+"""CameraModel - forward projection of 3D world points to image pixels.
+
+Builds a pinhole camera model from a drone image's metadata pose (AGL
+altitude, gimbal pitch/yaw, lens intrinsics) and projects 3D points given in
+a local North/East/Down (NED) frame centred on the camera.
+
+Used by the Person Size Reference tool to draw perspective-correct
+silhouettes and shadows - foreshortened at oblique gimbal angles and toward
+the frame edges - instead of a flat top-down silhouette scaled by GSD.
+
+The rotation conventions match AOIService._calculate_ground_position and
+AOINeighborService.gps_to_pixel, so projected geometry lines up with the
+imagery and with computed AOI ground positions. Lens distortion and gimbal
+roll are not modelled (roll is omitted to stay consistent with
+gps_to_pixel); both are minor for the reference-overlay use case.
+"""
+
+import math
+from typing import Optional, Tuple
+
+
+class CameraModel:
+    """Pinhole camera built from a drone image's metadata pose.
+
+    Coordinates use a local North/East/Down (NED) metric frame with the
+    camera at the origin. The optical axis points down-and-forward per the
+    gimbal pitch and yaw. project() maps a 3D NED point to its pixel;
+    pixel_to_ground() casts a pixel ray onto a horizontal ground plane.
+    """
+
+    def __init__(self, agl_m, pitch_deg, yaw_deg,
+                 focal_mm, sensor_w_mm, sensor_h_mm, width, height):
+        """
+        Args:
+            agl_m: camera height above ground level, metres (> 0).
+            pitch_deg: gimbal pitch; -90 = nadir (straight down), 0 = horizontal.
+            yaw_deg: gimbal yaw; 0 = north, increasing clockwise.
+            focal_mm: lens focal length, mm.
+            sensor_w_mm: sensor width, mm.
+            sensor_h_mm: sensor height, mm.
+            width: image width, pixels.
+            height: image height, pixels.
+
+        Raises:
+            ValueError: if the inputs are degenerate.
+        """
+        if not agl_m or agl_m <= 0:
+            raise ValueError("CameraModel requires a positive AGL altitude")
+        if not width or not height or width <= 0 or height <= 0:
+            raise ValueError("CameraModel requires positive image dimensions")
+        if not focal_mm or not sensor_w_mm or not sensor_h_mm:
+            raise ValueError("CameraModel requires valid lens intrinsics")
+
+        self.agl_m = float(agl_m)
+        self.width = float(width)
+        self.height = float(height)
+
+        # Intrinsics: focal length in pixels, principal point at image centre.
+        self.fx = focal_mm / (sensor_w_mm / width)
+        self.fy = focal_mm / (sensor_h_mm / height)
+        self.cx = width / 2.0
+        self.cy = height / 2.0
+
+        # Camera axes expressed in the NED frame - same construction as
+        # AOINeighborService.gps_to_pixel (elevation = pitch, azimuth = yaw).
+        elev = math.radians(pitch_deg)
+        az = math.radians(yaw_deg)
+        cos_e, sin_e = math.cos(elev), math.sin(elev)
+        cos_a, sin_a = math.cos(az), math.sin(az)
+
+        # Camera Z (optical axis) and Y (image-down) in NED.
+        self._r3 = (cos_e * cos_a, cos_e * sin_a, -sin_e)
+        self._r2 = (sin_e * cos_a, sin_e * sin_a, cos_e)
+        # Camera X (image-right) = cross(optical axis, up), normalised.
+        up = (-sin_e * cos_a, -sin_e * sin_a, -cos_e)  # = -r2
+        r1 = (
+            self._r3[1] * up[2] - self._r3[2] * up[1],
+            self._r3[2] * up[0] - self._r3[0] * up[2],
+            self._r3[0] * up[1] - self._r3[1] * up[0],
+        )
+        norm = math.sqrt(r1[0] ** 2 + r1[1] ** 2 + r1[2] ** 2)
+        if norm < 1e-10:
+            raise ValueError("CameraModel: degenerate camera orientation")
+        self._r1 = (r1[0] / norm, r1[1] / norm, r1[2] / norm)
+
+    @classmethod
+    def from_image_service(cls, image_service, agl_override_m=None):
+        """Build a CameraModel from an ImageService.
+
+        Args:
+            image_service: an ImageService for the loaded image.
+            agl_override_m: optional AGL altitude (metres) overriding metadata.
+
+        Returns:
+            CameraModel, or None when the metadata needed to build one
+            (intrinsics, altitude, image array) is unavailable.
+        """
+        try:
+            intrinsics = image_service.get_camera_intrinsics()
+            if intrinsics is None:
+                return None
+
+            if agl_override_m and agl_override_m > 0:
+                agl = agl_override_m
+            else:
+                agl = image_service.get_relative_altitude('m')
+            if not agl or agl <= 0:
+                return None
+
+            pitch = image_service.get_camera_pitch()
+            if pitch is None:
+                pitch = -90.0  # assume nadir when the gimbal angle is missing
+            yaw = image_service.get_camera_yaw() or 0.0
+
+            img = image_service.img_array
+            if img is None:
+                return None
+            height, width = img.shape[:2]
+
+            return cls(
+                agl, pitch, yaw,
+                intrinsics['focal_length_mm'],
+                intrinsics['sensor_width_mm'],
+                intrinsics['sensor_height_mm'],
+                width, height,
+            )
+        except Exception:
+            return None
+
+    def project(self, north, east, down) -> Optional[Tuple[float, float]]:
+        """Project a 3D NED point (relative to the camera) to a pixel.
+
+        Args:
+            north, east, down: point coordinates in metres, relative to the
+                camera (down is positive below the camera).
+
+        Returns:
+            (u, v) pixel coordinates, or None if the point is at or behind
+            the image plane.
+        """
+        point = (north, east, down)
+        cam_x = self._dot(self._r1, point)
+        cam_y = self._dot(self._r2, point)
+        cam_z = self._dot(self._r3, point)
+        if cam_z <= 1e-6:
+            return None
+        u = (cam_x / cam_z) * self.fx + self.cx
+        v = (cam_y / cam_z) * self.fy + self.cy
+        return u, v
+
+    def pixel_ray(self, u, v) -> Tuple[float, float, float]:
+        """Return the NED direction of the ray through pixel (u, v).
+
+        The ray is not normalised; its components are convenient for
+        intersecting horizontal planes (the down component is the per-unit
+        descent rate).
+        """
+        a = (u - self.cx) / self.fx
+        b = (v - self.cy) / self.fy
+        return (
+            a * self._r1[0] + b * self._r2[0] + self._r3[0],
+            a * self._r1[1] + b * self._r2[1] + self._r3[1],
+            a * self._r1[2] + b * self._r2[2] + self._r3[2],
+        )
+
+    def pixel_to_ground(self, u, v, ground_down=None) -> Optional[Tuple[float, float, float]]:
+        """Cast the ray through pixel (u, v) onto a horizontal ground plane.
+
+        Args:
+            u, v: pixel coordinates.
+            ground_down: depth (metres below the camera) of the ground plane.
+                Defaults to the camera AGL - i.e. flat ground at nadir level.
+
+        Returns:
+            (north, east, down) of the intersection, or None if the ray does
+            not descend to the plane.
+        """
+        if ground_down is None:
+            ground_down = self.agl_m
+        ray = self.pixel_ray(u, v)
+        if ray[2] <= 1e-9:
+            return None  # ray is level or points upward
+        t = ground_down / ray[2]
+        if t <= 0:
+            return None
+        return (t * ray[0], t * ray[1], t * ray[2])
+
+    @staticmethod
+    def _dot(a, b):
+        return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]

--- a/app/core/services/PersonModel.py
+++ b/app/core/services/PersonModel.py
@@ -1,0 +1,98 @@
+"""PersonModel - 3D geometry for the Person Size Reference overlay.
+
+Generates a cloud of 3D surface points for a person of a given height in an
+upright pose (standing or sitting). Points are in a person-local metric
+frame: x = right, y = forward, z = up, origin at the feet on the ground.
+
+Projecting these points through a CameraModel and taking the convex hull of
+the result yields a perspective-correct silhouette - a compact top-down
+shape viewed from near-nadir, a foreshortened upright figure viewed
+obliquely or near a frame edge.
+
+A recumbent (lying) person is essentially flat on the ground and is rendered
+separately by projecting a flat outline, so it is not produced here.
+
+Body proportions match the top-down silhouettes in PersonReferenceDialog
+(head diameter 0.135H, shoulder width 0.26H, body depth 0.19H).
+"""
+
+import math
+from typing import List, Tuple
+
+Point3D = Tuple[float, float, float]
+
+
+def _ellipse_ring(semi_x: float, semi_y: float, z: float, count: int) -> List[Point3D]:
+    """Return `count` points evenly spaced around an ellipse at height z."""
+    ring = []
+    for i in range(count):
+        angle = 2.0 * math.pi * i / count
+        ring.append((semi_x * math.cos(angle), semi_y * math.sin(angle), z))
+    return ring
+
+
+def _sphere_points(center_z: float, radius: float,
+                   lat_bands: int, lon_count: int) -> List[Point3D]:
+    """Return points sampled over a sphere centred on the z axis at center_z."""
+    points: List[Point3D] = []
+    for lat in range(1, lat_bands):
+        phi = math.pi * lat / lat_bands          # 0..pi, measured from the top
+        z = center_z + radius * math.cos(phi)
+        r = radius * math.sin(phi)
+        for lon in range(lon_count):
+            angle = 2.0 * math.pi * lon / lon_count
+            points.append((r * math.cos(angle), r * math.sin(angle), z))
+    points.append((0.0, 0.0, center_z + radius))  # top pole
+    points.append((0.0, 0.0, center_z - radius))  # bottom pole
+    return points
+
+
+def build_standing_points(height_m: float, ring_count: int = 24) -> List[Point3D]:
+    """3D surface points for a standing person of the given height in metres.
+
+    The body is an elliptical column (shoulder width by body depth) from the
+    feet to the shoulders, topped by a spherical head.
+    """
+    h = float(height_m)
+    head_diam = 0.135 * h
+    semi_x = 0.130 * h        # half shoulder width
+    semi_y = 0.095 * h        # half body depth
+    body_top = max(0.0, h - head_diam)
+
+    points: List[Point3D] = []
+    points += _ellipse_ring(semi_x, semi_y, 0.0, ring_count)        # feet ring
+    points += _ellipse_ring(semi_x, semi_y, body_top, ring_count)   # shoulder ring
+    points += _sphere_points(h - head_diam / 2.0, head_diam / 2.0, 4, 8)
+    return points
+
+
+def build_sitting_points(height_m: float, ring_count: int = 24) -> List[Point3D]:
+    """3D surface points for a person sitting upright.
+
+    `height_m` is the person's standing height; the seated form is shorter
+    and has a wider footprint (knees/lap).
+    """
+    h = float(height_m)
+    head_diam = 0.135 * h
+    semi_x = 0.150 * h        # wider footprint - knees and lap
+    semi_y = 0.150 * h
+    torso_top = 0.40 * h      # seated torso height
+
+    points: List[Point3D] = []
+    points += _ellipse_ring(semi_x, semi_y, 0.0, ring_count)
+    points += _ellipse_ring(semi_x * 0.75, semi_y * 0.75, torso_top, ring_count)
+    points += _sphere_points(torso_top + head_diam / 2.0, head_diam / 2.0, 4, 8)
+    return points
+
+
+def build_points(height_m: float, pose: str) -> List[Point3D]:
+    """Return the 3D point cloud for an upright pose ('standing' or 'sitting').
+
+    Raises:
+        ValueError: if `pose` is not an upright pose handled by this module.
+    """
+    if pose == "standing":
+        return build_standing_points(height_m)
+    if pose == "sitting":
+        return build_sitting_points(height_m)
+    raise ValueError(f"PersonModel.build_points: unsupported pose {pose!r}")

--- a/app/core/services/shadow/PersonShadow.py
+++ b/app/core/services/shadow/PersonShadow.py
@@ -1,0 +1,95 @@
+"""PersonShadow - cast a standing person's shadow onto the ground.
+
+The forward complement of ShadowHeightEstimator: given a known person
+height and the sun position (from SolarPosition at the image's capture
+time), project the person's 3D form along the sun ray onto the ground to
+produce the shadow outline.
+
+Geometry is computed in the same local North/East/Down (NED) frame used by
+CameraModel, so the resulting ground points can be projected straight to
+image pixels.
+
+The `slope` parameter is a hook for a terrain-slope correction (the shadow
+is shorter uphill, longer downhill). Callers that have DEM data can sample
+the grade along the shadow direction and pass it in; with slope = 0 the
+shadow is computed on flat ground at the (already DEM-placed) foot level.
+"""
+
+import math
+from typing import List, Sequence, Tuple
+
+Point3D = Tuple[float, float, float]
+
+
+def shadow_length(height_m: float, sun_elevation_deg: float, slope: float = 0.0) -> float:
+    """Horizontal length of the shadow cast by a vertical object.
+
+    Args:
+        height_m: object height above the ground, metres.
+        sun_elevation_deg: sun elevation above the horizon, degrees.
+        slope: terrain gradient along the shadow direction (rise/run);
+            positive means the ground rises away from the sun, shortening
+            the shadow. Default 0 (flat ground).
+
+    Returns:
+        Horizontal shadow length in metres, or 0.0 when the sun is at or
+        below the horizon (no usable shadow).
+    """
+    if sun_elevation_deg <= 0.0:
+        return 0.0
+    denom = math.tan(math.radians(sun_elevation_deg)) + slope
+    if denom <= 1e-6:
+        return 0.0
+    return max(0.0, height_m) / denom
+
+
+def compute_shadow_ground_points(
+    person_points: Sequence[Point3D],
+    foot_ned: Point3D,
+    sun_elevation_deg: float,
+    sun_azimuth_deg: float,
+    slope: float = 0.0,
+) -> List[Point3D]:
+    """Cast a 3D person point cloud along the sun ray onto the ground.
+
+    Each point is dropped along the sun ray to the ground: a point at
+    height z lands a horizontal distance z / (tan(elevation) + slope) away,
+    in the direction opposite the sun.
+
+    Args:
+        person_points: person-local surface points (x = right, y = forward,
+            z = up), origin at the feet.
+        foot_ned: (north, east, down) of the person's feet in the camera
+            NED frame.
+        sun_elevation_deg: sun elevation above the horizon, degrees.
+        sun_azimuth_deg: sun azimuth, degrees (0 = north, clockwise).
+        slope: terrain gradient along the shadow direction; default 0 (flat).
+
+    Returns:
+        Ground points (north, east, down) for every cast point. Empty when
+        the sun is at or below the horizon.
+    """
+    if sun_elevation_deg <= 0.0:
+        return []
+    denom = math.tan(math.radians(sun_elevation_deg)) + slope
+    if denom <= 1e-6:
+        return []
+
+    foot_n, foot_e, foot_d = foot_ned
+    # Shadows fall away from the sun.
+    anti_sun = math.radians(sun_azimuth_deg + 180.0)
+    dir_north = math.cos(anti_sun)
+    dir_east = math.sin(anti_sun)
+
+    ground: List[Point3D] = []
+    for px, py, pz in person_points:
+        # Person-local -> camera NED: x = right = east, y = forward = north.
+        base_n = foot_n + py
+        base_e = foot_e + px
+        length = max(0.0, pz) / denom
+        ground.append((
+            base_n + length * dir_north,
+            base_e + length * dir_east,
+            foot_d,
+        ))
+    return ground

--- a/app/core/services/shadow/ShadowHeightEstimator.py
+++ b/app/core/services/shadow/ShadowHeightEstimator.py
@@ -150,14 +150,13 @@ class ShadowHeightEstimator:
         if base_gps is None:
             return _reject(
                 result,
-                "Could not project the base click onto terrain. "
-                "Check that the click is on the ground and metadata is complete."
+                _diagnose_projection_failure(aoi_service, exif_data, "base"),
             )
         tip_gps = aoi_service.estimate_aoi_gps(image, {'center': tuple(tip_px)})
         if tip_gps is None:
             return _reject(
                 result,
-                "Could not project the shadow-tip click onto terrain."
+                _diagnose_projection_failure(aoi_service, exif_data, "shadow-tip"),
             )
 
         result.base_lat_lon = (base_gps.latitude, base_gps.longitude)
@@ -280,6 +279,102 @@ def _reject(result: ShadowHeightResult, reason: str) -> ShadowHeightResult:
     result.rejection_reason = reason
     result.warnings.append(reason)
     return result
+
+
+def _diagnose_projection_failure(aoi_service, exif_data, which: str) -> str:
+    """Translate a generic AOIService rejection into a specific user message.
+
+    AOIService logs the precise reason but only returns None to callers, so
+    we re-derive the failure mode from the metadata to surface something
+    actionable in the dialog.
+    """
+    image_service = getattr(aoi_service, 'image_service', None)
+
+    # GPS is the cheapest precondition to verify.
+    gps = (exif_data or {}).get('GPS') or {}
+    if not gps:
+        return (
+            f"Could not project the {which} click: image has no GPS "
+            "coordinates in EXIF."
+        )
+
+    # Camera intrinsics — typically missing when the drone/camera isn't in
+    # drones.csv.
+    intrinsics = None
+    if image_service is not None:
+        try:
+            intrinsics = image_service.get_camera_intrinsics()
+        except Exception:
+            intrinsics = None
+    if not intrinsics:
+        make = _decode(exif_data.get('0th', {}).get(_PIEXIF_MAKE_TAG))
+        model = _decode(exif_data.get('0th', {}).get(_PIEXIF_MODEL_TAG))
+        descriptor = " / ".join(filter(None, [make, model])) or "this camera"
+        return (
+            f"Could not project the {which} click: no camera profile for "
+            f"{descriptor} in drones.csv (need sensor + focal length)."
+        )
+
+    # AGL — DJI carries it in XMP RelativeAltitude; airframe/WALDO imagery
+    # gets it synthesized by the WALDO pre-pass.
+    agl = None
+    pitch = None
+    if image_service is not None:
+        try:
+            agl = image_service.get_relative_altitude('m')
+        except Exception:
+            agl = None
+        try:
+            pitch = image_service.get_camera_pitch()
+        except Exception:
+            pitch = None
+    if not agl or agl <= 0:
+        make = _decode(exif_data.get('0th', {}).get(_PIEXIF_MAKE_TAG)) or ''
+        if make.upper().startswith(('CANON', 'SONY', 'NIKON', 'FUJI')):
+            return (
+                f"Could not project the {which} click: airframe imagery "
+                "without AGL. Run Tools > WALDO Pre-Pass on this folder "
+                "first so per-image altitude and gimbal angles are written "
+                "into the XMP."
+            )
+        return (
+            f"Could not project the {which} click: no RelativeAltitude in "
+            "XMP and no terrain-derived AGL fallback. Verify the drone "
+            "wrote altitude metadata."
+        )
+
+    # Pitch — AOIService assumes nadir (-90°) when missing; pitch >= 0 means
+    # the optical axis is at or above the horizon, so the ray never hits ground.
+    if pitch is not None and pitch >= 0:
+        return (
+            f"Could not project the {which} click: camera pitch is "
+            f"{pitch:.1f}° (at or above horizon), so the click can't be "
+            "projected onto terrain."
+        )
+
+    # Last resort — the ray went off into space (clicked above horizon, or
+    # terrain coverage doesn't reach that far).
+    return (
+        f"Could not project the {which} click onto terrain. The ray "
+        "either missed terrain coverage or landed above the horizon. "
+        "Check that the click is on the ground."
+    )
+
+
+_PIEXIF_MAKE_TAG = 271   # piexif.ImageIFD.Make
+_PIEXIF_MODEL_TAG = 272  # piexif.ImageIFD.Model
+
+
+def _decode(value) -> Optional[str]:
+    """Best-effort bytes→str for piexif IFD0 tags."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        try:
+            return value.decode('utf-8', errors='ignore').strip().rstrip('\x00')
+        except Exception:
+            return None
+    return str(value).strip()
 
 
 def _propagate_sigma(

--- a/app/core/services/shadow/ShadowHeightEstimator.py
+++ b/app/core/services/shadow/ShadowHeightEstimator.py
@@ -125,8 +125,16 @@ class ShadowHeightEstimator:
         except Exception as exc:
             return _reject(result, f"Could not read EXIF: {exc}")
 
+        # XMP carries the capture-time offset that DJI (and most modern
+        # cameras) omit from OffsetTimeOriginal. Read it lazily here so the
+        # resolver can fall back to it without re-parsing the file.
         try:
-            utc_dt, time_source = resolve_capture_utc(exif_data)
+            xmp_data = MetaDataHelper.get_xmp_data(image['path'], parse=True)
+        except Exception:
+            xmp_data = None
+
+        try:
+            utc_dt, time_source = resolve_capture_utc(exif_data, xmp_data)
         except SolarTimeUnresolvable as exc:
             return _reject(result, str(exc))
         result.utc_used = utc_dt

--- a/app/core/services/shadow/ShadowHeightEstimator.py
+++ b/app/core/services/shadow/ShadowHeightEstimator.py
@@ -92,6 +92,9 @@ class ShadowHeightResult:
     utc_used: Optional[datetime] = None
     time_source: Optional[str] = None
     rejection_reason: Optional[str] = None
+    # True when the rejection is specifically an azimuth-band failure; the
+    # dialog uses this to surface a "Use anyway" override button.
+    azimuth_override_available: bool = False
 
 
 class ShadowHeightEstimator:
@@ -105,6 +108,7 @@ class ShadowHeightEstimator:
         image: dict,
         base_px: Tuple[float, float],
         tip_px: Tuple[float, float],
+        allow_azimuth_override: bool = False,
     ) -> ShadowHeightResult:
         """Compute height of a vertical object from its shadow.
 
@@ -112,6 +116,10 @@ class ShadowHeightEstimator:
             image: ADIAT image-metadata dict (must contain 'path').
             base_px: (u, v) pixel of the object's ground base.
             tip_px:  (u, v) pixel of the shadow tip.
+            allow_azimuth_override: if True, demote an out-of-tolerance
+                shadow-azimuth mismatch from rejection to warning. The
+                dialog sets this when the user clicks "Use anyway" on a
+                previously-rejected measurement.
 
         Returns:
             ShadowHeightResult — always returned, even on rejection.
@@ -236,13 +244,22 @@ class ShadowHeightEstimator:
         result.delta_az_deg = delta_az
 
         if abs(delta_az) > AZ_WARNING_DEG:
-            return _reject(
-                result,
-                f"Drawn line is {delta_az:+.1f}° off the expected shadow "
-                f"direction (sun azimuth {sun_az:.1f}°). Click the object "
-                "base first, then the shadow tip. Override available."
-            )
-        if abs(delta_az) > AZ_OK_DEG:
+            if allow_azimuth_override:
+                result.warnings.append(
+                    f"Shadow direction is {abs(delta_az):.1f}° off the "
+                    f"expected direction; override accepted, but the "
+                    "estimate is sensitive to this mismatch."
+                )
+            else:
+                rejected = _reject(
+                    result,
+                    f"Drawn line is {delta_az:+.1f}° off the expected shadow "
+                    f"direction (sun azimuth {sun_az:.1f}°). Click the object "
+                    "base first, then the shadow tip."
+                )
+                rejected.azimuth_override_available = True
+                return rejected
+        elif abs(delta_az) > AZ_OK_DEG:
             result.warnings.append(
                 f"Shadow direction differs from expected by "
                 f"{abs(delta_az):.1f}°; result may be inaccurate."

--- a/app/core/services/shadow/ShadowHeightEstimator.py
+++ b/app/core/services/shadow/ShadowHeightEstimator.py
@@ -1,0 +1,349 @@
+"""Shadow-based object height estimation.
+
+Given two user-clicked pixels in a drone image (object base + shadow tip),
+project both to ground using AOIService, then apply the simple shadow
+geometry:
+
+    H = Delta_h + d_h * tan(alpha)
+
+where d_h is horizontal ground distance between projected points,
+Delta_h is their elevation difference (terrain slope), and alpha is the
+solar elevation at the capture time.
+
+Reuses the battle-tested pixel-to-ground projection from
+:class:`core.services.image.AOIService.AOIService` — same rotations,
+same iterative terrain convergence — and layers solar geometry on top.
+No new photogrammetry math is introduced here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+import utm
+
+from helpers.MetaDataHelper import MetaDataHelper
+from core.services.image.AOIService import AOIService
+from core.services.LoggerService import LoggerService
+from core.services.shadow.SolarPosition import (
+    get_solar_position,
+    resolve_capture_utc,
+    SolarTimeUnresolvable,
+)
+
+
+# Sun-elevation gates per design §5.9. Below the lower bound shadows are
+# unstable; above the upper bound they're too short to read.
+MIN_SUN_ELEV_DEG = 5.0
+MAX_SUN_ELEV_DEG = 85.0
+
+# Azimuth-mismatch confidence bands per design §5.8.
+AZ_OK_DEG = 5.0
+AZ_WARNING_DEG = 15.0
+
+# Conservative DEM vertical-accuracy estimate: USGS 3DEP 1 m lidar runs
+# ~0.3 m RMSE; coarser DEMs scale roughly with horizontal resolution.
+# Floored at 0.3 m so we never claim sub-decimetre accuracy.
+DEM_VERTICAL_SIGMA_FLOOR_M = 0.3
+DEM_VERTICAL_SIGMA_PER_M = 0.3
+
+# Solar-elevation sigma is dominated by ephemeris model error; the
+# subsecond timestamp jitter from drone EXIF is ~0.005°/s and negligible.
+SUN_ELEV_SIGMA_DEG = 0.1
+
+# Minimum horizontal separation between the two projected ground points
+# before we treat the click as degenerate.
+MIN_GROUND_SEPARATION_M = 0.05
+
+
+@dataclass
+class ShadowHeightResult:
+    """Output of a shadow-based height estimate.
+
+    `confidence` is one of:
+        'ok'        — geometry consistent, within tolerance
+        'warning'   — proceeded with a soft warning (e.g. azimuth off 5-15°)
+        'rejected'  — refused to estimate; `height_m` is None
+
+    All world coordinates are local-ENU meters relative to the base point
+    (so the base is (0, 0, 0); tip is offset). This keeps the numbers small
+    and easy to read in the UI/debug log; it has no effect on H.
+    """
+
+    confidence: str
+    warnings: List[str] = field(default_factory=list)
+    height_m: Optional[float] = None
+    sigma_m: Optional[float] = None
+    sun_elev_deg: Optional[float] = None
+    sun_az_deg: Optional[float] = None
+    measured_shadow_az_deg: Optional[float] = None
+    delta_az_deg: Optional[float] = None
+    base_world_xyz: Optional[Tuple[float, float, float]] = None
+    tip_world_xyz: Optional[Tuple[float, float, float]] = None
+    horizontal_dist_m: Optional[float] = None
+    elev_delta_m: Optional[float] = None
+    base_lat_lon: Optional[Tuple[float, float]] = None
+    tip_lat_lon: Optional[Tuple[float, float]] = None
+    dem_source: Optional[str] = None
+    terrain_resolution_m: Optional[float] = None
+    utc_used: Optional[datetime] = None
+    time_source: Optional[str] = None
+    rejection_reason: Optional[str] = None
+
+
+class ShadowHeightEstimator:
+    """Estimate height from a base+tip pixel pair and image metadata."""
+
+    def __init__(self, logger: Optional[LoggerService] = None):
+        self.logger = logger or LoggerService()
+
+    def estimate(
+        self,
+        image: dict,
+        base_px: Tuple[float, float],
+        tip_px: Tuple[float, float],
+    ) -> ShadowHeightResult:
+        """Compute height of a vertical object from its shadow.
+
+        Args:
+            image: ADIAT image-metadata dict (must contain 'path').
+            base_px: (u, v) pixel of the object's ground base.
+            tip_px:  (u, v) pixel of the shadow tip.
+
+        Returns:
+            ShadowHeightResult — always returned, even on rejection.
+            Callers should branch on `.confidence`.
+        """
+        result = ShadowHeightResult(confidence='rejected')
+
+        # --- Capture-time → UTC ---
+        try:
+            exif_data = MetaDataHelper.get_exif_data_piexif(image['path'])
+        except Exception as exc:
+            return _reject(result, f"Could not read EXIF: {exc}")
+
+        try:
+            utc_dt, time_source = resolve_capture_utc(exif_data)
+        except SolarTimeUnresolvable as exc:
+            return _reject(result, str(exc))
+        result.utc_used = utc_dt
+        result.time_source = time_source
+
+        # --- Project both pixels to the ground ---
+        try:
+            aoi_service = AOIService(image)
+        except Exception as exc:
+            return _reject(result, f"Could not load image for projection: {exc}")
+
+        base_gps = aoi_service.estimate_aoi_gps(image, {'center': tuple(base_px)})
+        if base_gps is None:
+            return _reject(
+                result,
+                "Could not project the base click onto terrain. "
+                "Check that the click is on the ground and metadata is complete."
+            )
+        tip_gps = aoi_service.estimate_aoi_gps(image, {'center': tuple(tip_px)})
+        if tip_gps is None:
+            return _reject(
+                result,
+                "Could not project the shadow-tip click onto terrain."
+            )
+
+        result.base_lat_lon = (base_gps.latitude, base_gps.longitude)
+        result.tip_lat_lon = (tip_gps.latitude, tip_gps.longitude)
+        result.dem_source = base_gps.elevation_source
+        result.terrain_resolution_m = base_gps.terrain_resolution_m
+
+        # --- Convert to local meters (UTM, both points forced into the same zone) ---
+        base_east, base_north, zone_no, zone_letter = utm.from_latlon(
+            base_gps.latitude, base_gps.longitude
+        )
+        tip_east, tip_north, _, _ = utm.from_latlon(
+            tip_gps.latitude, tip_gps.longitude,
+            force_zone_number=zone_no,
+            force_zone_letter=zone_letter,
+        )
+
+        d_east = tip_east - base_east
+        d_north = tip_north - base_north
+        d_h = math.hypot(d_east, d_north)
+
+        if d_h < MIN_GROUND_SEPARATION_M:
+            return _reject(
+                result,
+                "Base and shadow-tip clicks project to the same ground point. "
+                "Pick two clearly different pixels."
+            )
+
+        # Elevation difference — only meaningful when both ground points
+        # came from a real DEM, not a flat-terrain fallback.
+        if base_gps.elevation_source == 'terrain' and tip_gps.elevation_source == 'terrain':
+            base_elev = base_gps.terrain_elevation_m or 0.0
+            tip_elev = tip_gps.terrain_elevation_m or 0.0
+            delta_h = tip_elev - base_elev
+        else:
+            base_elev = 0.0
+            tip_elev = 0.0
+            delta_h = 0.0
+            result.warnings.append(
+                "No DEM available for this location; assuming flat terrain. "
+                "Estimate ignores ground slope."
+            )
+
+        # Express both points in local-ENU relative to base.
+        result.base_world_xyz = (0.0, 0.0, 0.0)
+        result.tip_world_xyz = (d_east, d_north, delta_h)
+        result.horizontal_dist_m = d_h
+        result.elev_delta_m = delta_h
+
+        # Bearing of the drawn shadow line, base→tip, clockwise from north.
+        measured_az = math.degrees(math.atan2(d_east, d_north)) % 360.0
+        result.measured_shadow_az_deg = measured_az
+
+        # --- Sun position ---
+        sun_elev, sun_az = get_solar_position(
+            base_gps.latitude, base_gps.longitude, utc_dt
+        )
+        result.sun_elev_deg = sun_elev
+        result.sun_az_deg = sun_az
+
+        if sun_elev < MIN_SUN_ELEV_DEG:
+            return _reject(
+                result,
+                f"Sun is too low ({sun_elev:.1f}°). Shadow geometry is "
+                "unreliable below 5°."
+            )
+        if sun_elev > MAX_SUN_ELEV_DEG:
+            return _reject(
+                result,
+                f"Sun is nearly overhead ({sun_elev:.1f}°). Shadows are "
+                "too short to measure reliably above 85°."
+            )
+
+        # Expected shadow direction = away from sun.
+        expected_az = (sun_az + 180.0) % 360.0
+        delta_az = ((measured_az - expected_az + 180.0) % 360.0) - 180.0
+        result.delta_az_deg = delta_az
+
+        if abs(delta_az) > AZ_WARNING_DEG:
+            return _reject(
+                result,
+                f"Drawn line is {delta_az:+.1f}° off the expected shadow "
+                f"direction (sun azimuth {sun_az:.1f}°). Click the object "
+                "base first, then the shadow tip. Override available."
+            )
+        if abs(delta_az) > AZ_OK_DEG:
+            result.warnings.append(
+                f"Shadow direction differs from expected by "
+                f"{abs(delta_az):.1f}°; result may be inaccurate."
+            )
+
+        # --- Height ---
+        alpha = math.radians(sun_elev)
+        height_m = delta_h + d_h * math.tan(alpha)
+        if height_m <= 0:
+            return _reject(
+                result,
+                f"Computed negative or zero height ({height_m:.2f} m). "
+                "Likely the base/tip click order is reversed."
+            )
+        result.height_m = height_m
+
+        # --- Uncertainty (design §5.10) ---
+        result.sigma_m = _propagate_sigma(
+            d_h=d_h,
+            alpha=alpha,
+            terrain_resolution_m=base_gps.terrain_resolution_m,
+            base_effective_agl_m=base_gps.effective_agl_m,
+            tip_effective_agl_m=tip_gps.effective_agl_m,
+            image_service=aoi_service.image_service,
+        )
+
+        result.confidence = 'warning' if result.warnings else 'ok'
+        return result
+
+
+def _reject(result: ShadowHeightResult, reason: str) -> ShadowHeightResult:
+    """Stamp the rejection reason and return the result unchanged otherwise."""
+    result.confidence = 'rejected'
+    result.rejection_reason = reason
+    result.warnings.append(reason)
+    return result
+
+
+def _propagate_sigma(
+    d_h: float,
+    alpha: float,
+    terrain_resolution_m: Optional[float],
+    base_effective_agl_m: Optional[float],
+    tip_effective_agl_m: Optional[float],
+    image_service,
+) -> float:
+    """First-order uncertainty propagation for H = Delta_h + d_h * tan(alpha).
+
+    σ_H² ≈ (tan α · σ_dh)²  +  (d_h · sec²α · σ_α)²  +  σ_Δh²
+    """
+    # σ_α: ephemeris + timestamp jitter (radians).
+    sigma_alpha = math.radians(SUN_ELEV_SIGMA_DEG)
+
+    # σ_Δh: terrain DEM vertical accuracy, combined for two endpoints.
+    if terrain_resolution_m is not None:
+        sigma_dem_vert = max(
+            DEM_VERTICAL_SIGMA_FLOOR_M,
+            DEM_VERTICAL_SIGMA_PER_M * terrain_resolution_m,
+        )
+    else:
+        sigma_dem_vert = DEM_VERTICAL_SIGMA_FLOOR_M
+    sigma_delta_h = sigma_dem_vert * math.sqrt(2.0)
+
+    # σ_dh: pixel-localization noise projected to ground via the per-pixel
+    # GSD at each endpoint. Approximate GSD as effective_AGL / focal_px —
+    # exact at nadir, conservative-low under oblique viewing.
+    sigma_dh = _estimate_horizontal_sigma(
+        base_effective_agl_m, tip_effective_agl_m, image_service
+    )
+
+    cos_a = math.cos(alpha)
+    sec2_a = 1.0 / (cos_a * cos_a) if cos_a != 0 else 0.0
+    var = (
+        (math.tan(alpha) * sigma_dh) ** 2
+        + (d_h * sec2_a * sigma_alpha) ** 2
+        + sigma_delta_h ** 2
+    )
+    return math.sqrt(var)
+
+
+def _estimate_horizontal_sigma(
+    base_agl_m: Optional[float],
+    tip_agl_m: Optional[float],
+    image_service,
+) -> float:
+    """Estimate σ_dh from the per-pixel ground sample distance at each endpoint.
+
+    Falls back to a conservative 1 m when intrinsics are unavailable.
+    """
+    try:
+        intrinsics = image_service.get_camera_intrinsics()
+    except Exception:
+        intrinsics = None
+    if not intrinsics:
+        return 1.0
+
+    focal_mm = intrinsics.get('focal_length_mm')
+    sensor_w_mm = intrinsics.get('sensor_width_mm')
+    img_width = image_service.img_array.shape[1] if image_service.img_array is not None else None
+    if not (focal_mm and sensor_w_mm and img_width):
+        return 1.0
+
+    focal_px = focal_mm * img_width / sensor_w_mm
+    base_agl = base_agl_m if (base_agl_m and base_agl_m > 0) else 0.0
+    tip_agl = tip_agl_m if (tip_agl_m and tip_agl_m > 0) else 0.0
+    if base_agl == 0.0 and tip_agl == 0.0:
+        return 1.0
+
+    gsd_base = base_agl / focal_px if base_agl > 0 else 0.0
+    gsd_tip = tip_agl / focal_px if tip_agl > 0 else 0.0
+    return math.sqrt(2.0) * math.hypot(gsd_base, gsd_tip)

--- a/app/core/services/shadow/SolarPosition.py
+++ b/app/core/services/shadow/SolarPosition.py
@@ -46,12 +46,18 @@ def get_solar_position(lat: float, lon: float, utc_dt: datetime) -> Tuple[float,
     return elev, az
 
 
-def resolve_capture_utc(exif_data: dict) -> Tuple[datetime, str]:
+def resolve_capture_utc(
+    exif_data: dict,
+    xmp_data: Optional[dict] = None,
+) -> Tuple[datetime, str]:
     """Resolve image capture time to a tz-aware UTC datetime.
 
-    Resolution order (matches design §8.1):
+    Resolution order:
         1. EXIF GPSDateStamp + GPSTimeStamp — already UTC, preferred.
-        2. EXIF DateTimeOriginal + OffsetTimeOriginal — local with explicit offset.
+        2. EXIF DateTimeOriginal + OffsetTimeOriginal — canonical local+offset.
+        3. XMP xmp:CreateDate / xmp:ModifyDate — ISO 8601 with offset.
+           DJI and most camera firmware write the capture timezone here even
+           when they skip OffsetTimeOriginal.
 
     Without timezonefinder we deliberately do NOT fall back to "assume local";
     a bare DateTimeOriginal yields an unknown offset that can shift sun
@@ -60,10 +66,12 @@ def resolve_capture_utc(exif_data: dict) -> Tuple[datetime, str]:
 
     Args:
         exif_data: piexif-format dict ({'0th': ..., 'Exif': ..., 'GPS': ...}).
+        xmp_data: optional parsed XMP dict (keys without namespace prefix,
+            as produced by MetaDataHelper.get_xmp_data(..., parse=True)).
 
     Returns:
-        (utc_datetime, source_tag) where source_tag is 'gps' or
-        'exif_with_offset'.
+        (utc_datetime, source_tag) where source_tag is one of
+        'gps', 'exif_with_offset', 'xmp_create_date', 'xmp_modify_date'.
 
     Raises:
         SolarTimeUnresolvable: no resolvable timestamp present.
@@ -86,10 +94,20 @@ def resolve_capture_utc(exif_data: dict) -> Tuple[datetime, str]:
         except ValueError:
             pass
 
+    if xmp_data:
+        for key, source in (('CreateDate', 'xmp_create_date'),
+                            ('ModifyDate', 'xmp_modify_date')):
+            value = xmp_data.get(key)
+            if value:
+                try:
+                    return _from_iso8601(value), source
+                except ValueError:
+                    continue
+
     raise SolarTimeUnresolvable(
-        "Cannot resolve image capture time to UTC. Need either "
-        "GPSDateStamp+GPSTimeStamp (preferred) or "
-        "DateTimeOriginal+OffsetTimeOriginal."
+        "Cannot resolve image capture time to UTC. Need GPSDateStamp+"
+        "GPSTimeStamp, DateTimeOriginal+OffsetTimeOriginal, or an XMP "
+        "CreateDate/ModifyDate with timezone offset."
     )
 
 
@@ -129,6 +147,26 @@ def _from_local_with_offset(dt_orig, offset) -> datetime:
     tz = timezone(timedelta(minutes=offset_minutes))
     local_dt = datetime(year, month, day, hour, minute, second, 0, tzinfo=tz)
     return local_dt.astimezone(timezone.utc)
+
+
+def _from_iso8601(value) -> datetime:
+    """Parse an ISO 8601 datetime string with a timezone offset.
+
+    Accepts the XMP form 'YYYY-MM-DDTHH:MM:SS±HH:MM' and a few common
+    variants ('Z' suffix, space separator instead of 'T'). Raises
+    ValueError if no offset is present — a naive timestamp here would
+    silently corrupt the sun azimuth.
+    """
+    if isinstance(value, bytes):
+        value = value.decode('ascii', errors='ignore')
+    value = str(value).strip().replace(' ', 'T')
+    # Python 3.11 handles 'Z' natively; on 3.10 we have to swap it.
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        raise ValueError(f"ISO 8601 timestamp lacks timezone: {value!r}")
+    return dt.astimezone(timezone.utc)
 
 
 def _to_str(value) -> str:

--- a/app/core/services/shadow/SolarPosition.py
+++ b/app/core/services/shadow/SolarPosition.py
@@ -1,0 +1,148 @@
+"""Solar position lookup and EXIF-time-to-UTC resolution.
+
+Thin wrapper over `pysolar` plus a UTC resolver that walks the standard
+EXIF/GPS timestamp fields. Kept separate from the rest of the shadow
+pipeline so the underlying solar library can be swapped (e.g. for an
+in-tree NREL SPA implementation) by editing only this file.
+
+pysolar 0.13 conventions:
+    altitude: degrees, 0 = horizon, 90 = zenith
+    azimuth:  degrees, 0 = north, clockwise (0..360)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Tuple
+
+import piexif
+from pysolar.solar import get_altitude, get_azimuth
+
+
+class SolarTimeUnresolvable(ValueError):
+    """Raised when the EXIF/GPS timestamp cannot be resolved to UTC."""
+
+
+@dataclass
+class SolarPositionResult:
+    """Sun position at a given location/time."""
+    elevation_deg: float
+    azimuth_deg: float
+    utc_used: datetime
+    time_source: str  # 'gps' | 'exif_with_offset'
+
+
+def get_solar_position(lat: float, lon: float, utc_dt: datetime) -> Tuple[float, float]:
+    """Return (elevation_deg, azimuth_deg) for the sun at lat/lon/utc_dt.
+
+    utc_dt must be a timezone-aware datetime; pysolar relies on tz info to
+    compute the true UTC offset.
+    """
+    if utc_dt.tzinfo is None:
+        raise ValueError("utc_dt must be timezone-aware")
+    elev = float(get_altitude(lat, lon, utc_dt))
+    az = float(get_azimuth(lat, lon, utc_dt)) % 360.0
+    return elev, az
+
+
+def resolve_capture_utc(exif_data: dict) -> Tuple[datetime, str]:
+    """Resolve image capture time to a tz-aware UTC datetime.
+
+    Resolution order (matches design §8.1):
+        1. EXIF GPSDateStamp + GPSTimeStamp — already UTC, preferred.
+        2. EXIF DateTimeOriginal + OffsetTimeOriginal — local with explicit offset.
+
+    Without timezonefinder we deliberately do NOT fall back to "assume local";
+    a bare DateTimeOriginal yields an unknown offset that can shift sun
+    azimuth by ~15°/hour, which silently corrupts the height estimate.
+    Reject loudly instead.
+
+    Args:
+        exif_data: piexif-format dict ({'0th': ..., 'Exif': ..., 'GPS': ...}).
+
+    Returns:
+        (utc_datetime, source_tag) where source_tag is 'gps' or
+        'exif_with_offset'.
+
+    Raises:
+        SolarTimeUnresolvable: no resolvable timestamp present.
+    """
+    gps = exif_data.get('GPS') or {}
+    gps_date = gps.get(piexif.GPSIFD.GPSDateStamp)
+    gps_time = gps.get(piexif.GPSIFD.GPSTimeStamp)
+    if gps_date and gps_time:
+        try:
+            return _from_gps(gps_date, gps_time), 'gps'
+        except (ValueError, TypeError, ZeroDivisionError):
+            pass
+
+    exif = exif_data.get('Exif') or {}
+    dt_orig = exif.get(piexif.ExifIFD.DateTimeOriginal)
+    offset = exif.get(piexif.ExifIFD.OffsetTimeOriginal)
+    if dt_orig and offset:
+        try:
+            return _from_local_with_offset(dt_orig, offset), 'exif_with_offset'
+        except ValueError:
+            pass
+
+    raise SolarTimeUnresolvable(
+        "Cannot resolve image capture time to UTC. Need either "
+        "GPSDateStamp+GPSTimeStamp (preferred) or "
+        "DateTimeOriginal+OffsetTimeOriginal."
+    )
+
+
+def _from_gps(gps_date, gps_time) -> datetime:
+    """Build a UTC datetime from EXIF GPSDateStamp + GPSTimeStamp."""
+    date_str = _to_str(gps_date)
+    year, month, day = [int(part) for part in date_str.split(':')]
+    hours = _rational_to_float(gps_time[0])
+    minutes = _rational_to_float(gps_time[1])
+    seconds = _rational_to_float(gps_time[2])
+    h_int = int(hours)
+    m_int = int(minutes)
+    total_seconds = seconds + (hours - h_int) * 3600 + (minutes - m_int) * 60
+    s_int = int(total_seconds)
+    micro = int(round((total_seconds - s_int) * 1_000_000))
+    if micro >= 1_000_000:
+        s_int += 1
+        micro -= 1_000_000
+    return datetime(year, month, day, h_int, m_int, s_int, micro, tzinfo=timezone.utc)
+
+
+def _from_local_with_offset(dt_orig, offset) -> datetime:
+    """Build a UTC datetime from EXIF DateTimeOriginal + OffsetTimeOriginal."""
+    dt_str = _to_str(dt_orig)
+    off_str = _to_str(offset).strip()
+    # EXIF format: 'YYYY:MM:DD HH:MM:SS'
+    date_part, time_part = dt_str.split(' ')
+    year, month, day = [int(p) for p in date_part.split(':')]
+    hour, minute, second = [int(p) for p in time_part.split(':')]
+    # Offset like '+05:30', '-07:00', 'Z'
+    if off_str.upper() == 'Z':
+        offset_minutes = 0
+    else:
+        sign = 1 if off_str[0] == '+' else -1
+        oh, om = off_str[1:].split(':')
+        offset_minutes = sign * (int(oh) * 60 + int(om))
+    tz = timezone(timedelta(minutes=offset_minutes))
+    local_dt = datetime(year, month, day, hour, minute, second, 0, tzinfo=tz)
+    return local_dt.astimezone(timezone.utc)
+
+
+def _to_str(value) -> str:
+    """piexif returns most string fields as bytes; normalise."""
+    if isinstance(value, bytes):
+        return value.decode('ascii', errors='ignore').rstrip('\x00')
+    return str(value)
+
+
+def _rational_to_float(rational) -> float:
+    """piexif rationals are (numerator, denominator) tuples."""
+    if isinstance(rational, (tuple, list)) and len(rational) == 2:
+        num, den = rational
+        if den == 0:
+            raise ZeroDivisionError("zero denominator in EXIF rational")
+        return num / den
+    return float(rational)

--- a/app/core/services/shadow/__init__.py
+++ b/app/core/services/shadow/__init__.py
@@ -1,0 +1,1 @@
+"""Shadow-based object height estimation services."""

--- a/app/core/views/images/viewer/dialogs/MeasureDialog.py
+++ b/app/core/views/images/viewer/dialogs/MeasureDialog.py
@@ -3,9 +3,12 @@
 import math
 from PySide6.QtCore import Qt, QPointF, Signal
 from helpers.TranslationMixin import TranslationMixin
-from PySide6.QtGui import QPen, QColor, QFont
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QGroupBox
-from PySide6.QtWidgets import QGraphicsLineItem, QGraphicsEllipseItem, QGraphicsTextItem
+from PySide6.QtGui import QPen, QColor, QFont, QBrush
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QGroupBox, QCheckBox
+from PySide6.QtWidgets import QGraphicsLineItem, QGraphicsEllipseItem, QGraphicsTextItem, QGraphicsPolygonItem
+from PySide6.QtGui import QPolygonF
+
+from core.services.shadow.ShadowHeightEstimator import ShadowHeightEstimator
 
 
 class MeasureDialog(TranslationMixin, QDialog):
@@ -31,6 +34,12 @@ class MeasureDialog(TranslationMixin, QDialog):
         self.first_point = None
         self.second_point = None
         self.measuring = False
+
+        # Shadow-measurement state (additive — coexists with regular measurement
+        # so toggling the checkbox doesn't lose graphics)
+        self.shadow_mode = False
+        self.shadow_estimator = None  # Lazy-init on first shadow measurement
+        self.shadow_graphics = []  # All shadow-related QGraphics items, for bulk removal
 
         # Graphics items
         self.line_item = None
@@ -66,13 +75,23 @@ class MeasureDialog(TranslationMixin, QDialog):
         # Use WindowStaysOnTopHint to keep it visible when clicking on parent window
         self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
 
-        self.setMinimumWidth(300)
+        self.setMinimumWidth(320)
 
         # Main layout
         layout = QVBoxLayout()
 
+        # Mode toggle — drives whether the two clicks measure a length or
+        # estimate an object's height from its shadow.
+        self.shadow_mode_checkbox = QCheckBox(self.tr("Measure Shadow"))
+        self.shadow_mode_checkbox.setToolTip(self.tr(
+            "When checked, the two clicks estimate the height of a vertical "
+            "object from its shadow. Click the base of the object first, "
+            "then the tip of its shadow."
+        ))
+        layout.addWidget(self.shadow_mode_checkbox)
+
         # GSD input group
-        gsd_group = QGroupBox(self.tr("Ground Sample Distance"))
+        self.gsd_group = QGroupBox(self.tr("Ground Sample Distance"))
         gsd_layout = QHBoxLayout()
 
         gsd_label = QLabel(self.tr("GSD:"))
@@ -86,10 +105,10 @@ class MeasureDialog(TranslationMixin, QDialog):
         gsd_layout.addWidget(gsd_label)
         gsd_layout.addWidget(self.gsd_input)
         gsd_layout.addWidget(gsd_unit_label)
-        gsd_group.setLayout(gsd_layout)
+        self.gsd_group.setLayout(gsd_layout)
 
         # Distance display group
-        distance_group = QGroupBox(self.tr("Measurement"))
+        self.distance_group = QGroupBox(self.tr("Measurement"))
         distance_layout = QHBoxLayout()
 
         distance_label = QLabel(self.tr("Distance:"))
@@ -99,16 +118,30 @@ class MeasureDialog(TranslationMixin, QDialog):
         distance_layout.addWidget(distance_label)
         distance_layout.addWidget(self.distance_display)
         distance_layout.addStretch()
-        distance_group.setLayout(distance_layout)
+        self.distance_group.setLayout(distance_layout)
 
-        # Instructions
-        instructions = QLabel(
-            self.tr(
-                "Click on the image to place the first point,\nthen click again to place the second point."
-            )
-        )
-        instructions.setWordWrap(True)
-        instructions.setStyleSheet("QLabel { color: gray; }")
+        # Shadow-height result group (hidden until shadow mode is on)
+        self.shadow_group = QGroupBox(self.tr("Shadow Height Estimate"))
+        shadow_layout = QVBoxLayout()
+        self.shadow_height_display = QLabel(self.tr("--"))
+        self.shadow_height_display.setStyleSheet("QLabel { font-weight: bold; font-size: 14pt; }")
+        self.shadow_details = QLabel("")
+        self.shadow_details.setStyleSheet("QLabel { color: gray; font-size: 9pt; }")
+        self.shadow_details.setWordWrap(True)
+        self.shadow_warnings = QLabel("")
+        self.shadow_warnings.setStyleSheet("QLabel { color: #b8860b; font-size: 9pt; }")
+        self.shadow_warnings.setWordWrap(True)
+        shadow_layout.addWidget(self.shadow_height_display)
+        shadow_layout.addWidget(self.shadow_details)
+        shadow_layout.addWidget(self.shadow_warnings)
+        self.shadow_group.setLayout(shadow_layout)
+        self.shadow_group.setVisible(False)
+
+        # Instructions — text swaps with mode.
+        self.instructions = QLabel("")
+        self.instructions.setWordWrap(True)
+        self.instructions.setStyleSheet("QLabel { color: gray; }")
+        self._update_instructions_text()
 
         # Buttons
         button_layout = QHBoxLayout()
@@ -122,13 +155,26 @@ class MeasureDialog(TranslationMixin, QDialog):
         button_layout.addWidget(self.close_button)
 
         # Add all to main layout
-        layout.addWidget(gsd_group)
-        layout.addWidget(distance_group)
-        layout.addWidget(instructions)
+        layout.addWidget(self.gsd_group)
+        layout.addWidget(self.distance_group)
+        layout.addWidget(self.shadow_group)
+        layout.addWidget(self.instructions)
         layout.addLayout(button_layout)
         layout.addStretch()
 
         self.setLayout(layout)
+
+    def _update_instructions_text(self):
+        """Refresh the instruction copy for the active measurement mode."""
+        if self.shadow_mode:
+            self.instructions.setText(self.tr(
+                "Click the BASE of the object first, then the TIP of its shadow."
+            ))
+        else:
+            self.instructions.setText(self.tr(
+                "Click on the image to place the first point,\n"
+                "then click again to place the second point."
+            ))
 
     def showEvent(self, event):
         """Override showEvent to ensure dialog receives focus on macOS."""
@@ -152,7 +198,25 @@ class MeasureDialog(TranslationMixin, QDialog):
         # Connect to zoom changes to update item sizes
         self.image_viewer.zoomChanged.connect(self.onZoomChanged)
 
+        # Shadow-mode toggle
+        self.shadow_mode_checkbox.toggled.connect(self._on_shadow_mode_toggled)
+
         # Mouse tracking is already enabled in QtImageViewer
+
+    def _on_shadow_mode_toggled(self, checked):
+        """Switch the dialog between length and shadow-height modes.
+
+        Toggling clears the current measurement and swaps which result
+        groups are visible — keeps the GSD field and the shadow-result
+        panel from being on screen at the same time.
+        """
+        self.shadow_mode = checked
+        self.clearMeasurement()
+        self.gsd_group.setVisible(not checked)
+        self.distance_group.setVisible(not checked)
+        self.shadow_group.setVisible(checked)
+        self.setWindowTitle(self.tr("Measure Shadow Height") if checked else self.tr("Measure Distance"))
+        self._update_instructions_text()
 
     def onGsdChanged(self, text):
         """Handle GSD value changes.
@@ -191,17 +255,46 @@ class MeasureDialog(TranslationMixin, QDialog):
             return
 
         point = QPointF(x, y)
+        zoom = self.image_viewer.getZoom() if hasattr(self.image_viewer, 'getZoom') else 1.0
+        radius = self.fixed_point_radius / zoom
+        pen_width = self.fixed_line_width / zoom
+
+        if self.shadow_mode:
+            # Gold for shadow base + tip; hollow circle on the tip helps
+            # distinguish the two when zoomed out.
+            colour = QColor(255, 215, 0)
+            if not self.measuring:
+                self.clearMeasurement()
+                self.first_point = point
+                self.measuring = True
+                self.point1_item = self._make_point_marker(
+                    x, y, radius, pen_width, fill=colour
+                )
+                self._add_shadow_label('B', x, y, radius, colour)
+            else:
+                self.second_point = point
+                self.measuring = False
+                if self.temp_line_item:
+                    self.image_viewer.scene.removeItem(self.temp_line_item)
+                    self.temp_line_item = None
+                self.point2_item = self._make_point_marker(
+                    x, y, radius, pen_width, fill=None, outline=colour
+                )
+                self._add_shadow_label('T', x, y, radius, colour)
+                self.line_item = QGraphicsLineItem(
+                    self.first_point.x(), self.first_point.y(),
+                    self.second_point.x(), self.second_point.y()
+                )
+                self.line_item.setPen(QPen(colour, pen_width))
+                self.image_viewer.scene.addItem(self.line_item)
+                self._estimate_and_render_shadow_height(pen_width, colour)
+            return
 
         if not self.measuring:
             # First click - place first point
             self.clearMeasurement()
             self.first_point = point
             self.measuring = True
-
-            # Draw first point with size adjusted for current zoom
-            zoom = self.image_viewer.getZoom() if hasattr(self.image_viewer, 'getZoom') else 1.0
-            radius = self.fixed_point_radius / zoom
-            pen_width = self.fixed_line_width / zoom
 
             self.point1_item = QGraphicsEllipseItem(x - radius, y - radius, radius * 2, radius * 2)
             self.point1_item.setBrush(QColor(255, 0, 0))
@@ -217,11 +310,6 @@ class MeasureDialog(TranslationMixin, QDialog):
             if self.temp_line_item:
                 self.image_viewer.scene.removeItem(self.temp_line_item)
                 self.temp_line_item = None
-
-            # Draw second point with size adjusted for current zoom
-            zoom = self.image_viewer.getZoom() if hasattr(self.image_viewer, 'getZoom') else 1.0
-            radius = self.fixed_point_radius / zoom
-            pen_width = self.fixed_line_width / zoom
 
             self.point2_item = QGraphicsEllipseItem(x - radius, y - radius, radius * 2, radius * 2)
             self.point2_item.setBrush(QColor(255, 0, 0))
@@ -239,6 +327,37 @@ class MeasureDialog(TranslationMixin, QDialog):
             # Calculate and display distance
             self.calculateDistance()
 
+    def _make_point_marker(self, x, y, radius, pen_width, fill=None, outline=None):
+        """Create a circular marker on the image scene.
+
+        Pass `fill` to make a filled disc (base point); pass only `outline`
+        to make a hollow ring (shadow tip).
+        """
+        item = QGraphicsEllipseItem(x - radius, y - radius, radius * 2, radius * 2)
+        if fill is not None:
+            item.setBrush(fill)
+            item.setPen(QPen(QColor(255, 255, 255), pen_width))
+        else:
+            item.setBrush(QBrush(Qt.NoBrush))
+            item.setPen(QPen(outline or QColor(255, 215, 0), pen_width * 1.5))
+        self.image_viewer.scene.addItem(item)
+        return item
+
+    def _add_shadow_label(self, letter, x, y, radius, colour):
+        """Add a 'B' / 'T' glyph next to a shadow endpoint marker."""
+        label = QGraphicsTextItem()
+        label.setHtml(
+            f'<div style="color: rgb({colour.red()},{colour.green()},{colour.blue()}); '
+            f'font-weight: bold;">{letter}</div>'
+        )
+        font = QFont()
+        font.setPointSize(10)
+        font.setBold(True)
+        label.setFont(font)
+        label.setPos(x + radius * 1.5, y - radius * 2.5)
+        self.image_viewer.scene.addItem(label)
+        self.shadow_graphics.append(label)
+
     def onMouseMove(self, pos):
         """Handle mouse movement for live line drawing.
 
@@ -253,12 +372,155 @@ class MeasureDialog(TranslationMixin, QDialog):
             zoom = self.image_viewer.getZoom() if hasattr(self.image_viewer, 'getZoom') else 1.0
             pen_width = self.fixed_line_width / zoom
 
+            colour = QColor(255, 215, 0) if self.shadow_mode else QColor(255, 255, 0)
             self.temp_line_item = QGraphicsLineItem(
                 self.first_point.x(), self.first_point.y(),
                 pos.x(), pos.y()
             )
-            self.temp_line_item.setPen(QPen(QColor(255, 255, 0), pen_width, Qt.DashLine))
+            self.temp_line_item.setPen(QPen(colour, pen_width, Qt.DashLine))
             self.image_viewer.scene.addItem(self.temp_line_item)
+
+    def _current_image_metadata(self):
+        """Return the active image's metadata dict via the parent Viewer.
+
+        Returns None when the viewer state is in transition (e.g. between
+        image loads).
+        """
+        viewer = self.parent()
+        if viewer is None:
+            return None
+        images = getattr(viewer, 'images', None)
+        index = getattr(viewer, 'current_image', None)
+        if images is None or index is None:
+            return None
+        try:
+            return images[index]
+        except (IndexError, TypeError):
+            return None
+
+    def _estimate_and_render_shadow_height(self, pen_width, colour):
+        """Run the shadow-height estimator on the two clicks and update the UI."""
+        image_dict = self._current_image_metadata()
+        if image_dict is None or not image_dict.get('path'):
+            self.shadow_height_display.setText(self.tr("Image metadata unavailable"))
+            self.shadow_details.setText("")
+            self.shadow_warnings.setText("")
+            return
+
+        if self.shadow_estimator is None:
+            self.shadow_estimator = ShadowHeightEstimator()
+
+        base_px = (self.first_point.x(), self.first_point.y())
+        tip_px = (self.second_point.x(), self.second_point.y())
+        result = self.shadow_estimator.estimate(image_dict, base_px, tip_px)
+
+        self._render_shadow_result_in_dialog(result)
+        self._render_shadow_result_on_image(result, pen_width, colour)
+
+    def _render_shadow_result_in_dialog(self, result):
+        """Update the sidebar group with the estimator's verdict."""
+        if result.confidence == 'rejected':
+            self.shadow_height_display.setText(self.tr("Rejected"))
+            self.shadow_details.setText("")
+            self.shadow_warnings.setText(result.rejection_reason or "")
+            return
+
+        height_str = self._format_length(result.height_m)
+        sigma_str = self._format_length(result.sigma_m) if result.sigma_m is not None else "?"
+        self.shadow_height_display.setText(f"{height_str} ± {sigma_str}")
+
+        details = (
+            f"Sun: elev {result.sun_elev_deg:.1f}°, az {result.sun_az_deg:.1f}°\n"
+            f"Shadow az measured {result.measured_shadow_az_deg:.1f}° "
+            f"(Δ {result.delta_az_deg:+.1f}°)\n"
+            f"Horizontal distance: {self._format_length(result.horizontal_dist_m)}, "
+            f"terrain Δh: {self._format_length(result.elev_delta_m)}\n"
+            f"DEM source: {result.dem_source or 'n/a'}"
+        )
+        if result.terrain_resolution_m:
+            details += f" ({result.terrain_resolution_m:.1f} m)"
+        self.shadow_details.setText(details)
+
+        warnings = [w for w in result.warnings if w]
+        self.shadow_warnings.setText("\n".join(warnings))
+
+    def _render_shadow_result_on_image(self, result, pen_width, colour):
+        """Overlay the height label (and a direction arrow) on the image."""
+        if self.first_point is None or self.second_point is None:
+            return
+
+        mid_x = (self.first_point.x() + self.second_point.x()) / 2.0
+        mid_y = (self.first_point.y() + self.second_point.y()) / 2.0
+
+        # Direction arrow at the midpoint, pointing base->tip.
+        dx = self.second_point.x() - self.first_point.x()
+        dy = self.second_point.y() - self.first_point.y()
+        length = math.hypot(dx, dy)
+        if length > 0:
+            ux, uy = dx / length, dy / length
+            arrow_size = max(8.0, pen_width * 4)
+            tip_x = mid_x + ux * arrow_size
+            tip_y = mid_y + uy * arrow_size
+            left_x = mid_x - uy * arrow_size * 0.5
+            left_y = mid_y + ux * arrow_size * 0.5
+            right_x = mid_x + uy * arrow_size * 0.5
+            right_y = mid_y - ux * arrow_size * 0.5
+            polygon = QPolygonF([
+                QPointF(tip_x, tip_y),
+                QPointF(left_x, left_y),
+                QPointF(right_x, right_y),
+            ])
+            arrow_item = QGraphicsPolygonItem(polygon)
+            arrow_item.setBrush(colour)
+            arrow_item.setPen(QPen(colour, pen_width))
+            self.image_viewer.scene.addItem(arrow_item)
+            self.shadow_graphics.append(arrow_item)
+
+        label_text = self._build_image_label_text(result)
+        label = QGraphicsTextItem()
+        # Colour-code by confidence so a glance at the image tells you whether
+        # to trust the number.
+        if result.confidence == 'rejected':
+            text_color = 'red'
+        elif result.confidence == 'warning':
+            text_color = '#ffcc00'
+        else:
+            text_color = '#ffd700'
+        label.setHtml(
+            f'<div style="background-color: rgba(0,0,0,180); '
+            f'color: {text_color}; padding: 2px; font-weight: bold;">'
+            f'{label_text}</div>'
+        )
+        font = QFont()
+        font.setPointSize(11)
+        font.setBold(True)
+        label.setFont(font)
+        label.setPos(mid_x + pen_width * 4, mid_y + pen_width * 4)
+        self.image_viewer.scene.addItem(label)
+        self.shadow_graphics.append(label)
+        # Reuse the existing distance_text_item slot so clearMeasurement
+        # cleans up alongside everything else.
+        self.distance_text_item = label
+
+    def _build_image_label_text(self, result):
+        if result.confidence == 'rejected':
+            return self.tr("Rejected")
+        return (
+            f"H ≈ {self._format_length(result.height_m)} "
+            f"± {self._format_length(result.sigma_m)}  "
+            f"☉ {result.sun_elev_deg:.0f}° az {result.sun_az_deg:.0f}°"
+        )
+
+    def _format_length(self, value_m):
+        """Format a length (in metres) per the user's distance-unit preference."""
+        if value_m is None:
+            return "?"
+        if self.distance_unit == 'ft':
+            v = value_m * 3.28084
+            return f"{v:.2f} ft"
+        if abs(value_m) < 1.0:
+            return f"{value_m * 100:.1f} cm"
+        return f"{value_m:.2f} m"
 
     def calculateDistance(self):
         """Calculate and display the distance between the two points."""
@@ -327,6 +589,15 @@ class MeasureDialog(TranslationMixin, QDialog):
             if item:
                 self.image_viewer.scene.removeItem(item)
 
+        # Shadow overlays (labels / arrow) live in their own bucket so this
+        # loop catches them whether or not a regular line was drawn.
+        for item in self.shadow_graphics:
+            try:
+                self.image_viewer.scene.removeItem(item)
+            except Exception:
+                pass
+        self.shadow_graphics = []
+
         # Reset state
         self.line_item = None
         self.point1_item = None
@@ -337,6 +608,9 @@ class MeasureDialog(TranslationMixin, QDialog):
         self.second_point = None
         self.measuring = False
         self.distance_display.setText("--")
+        self.shadow_height_display.setText("--")
+        self.shadow_details.setText("")
+        self.shadow_warnings.setText("")
 
     def updateItemSizes(self):
         """Update the sizes of all measurement items based on current zoom."""

--- a/app/core/views/images/viewer/dialogs/MeasureDialog.py
+++ b/app/core/views/images/viewer/dialogs/MeasureDialog.py
@@ -131,9 +131,19 @@ class MeasureDialog(TranslationMixin, QDialog):
         self.shadow_warnings = QLabel("")
         self.shadow_warnings.setStyleSheet("QLabel { color: #b8860b; font-size: 9pt; }")
         self.shadow_warnings.setWordWrap(True)
+        # "Use anyway" override appears only on an azimuth-band rejection.
+        self.shadow_override_button = QPushButton(self.tr("Use Anyway"))
+        self.shadow_override_button.setToolTip(self.tr(
+            "Force the estimate with the current base/tip clicks even though "
+            "the drawn line doesn't match the expected shadow direction. "
+            "Use only when you're confident the geometry is correct."
+        ))
+        self.shadow_override_button.setVisible(False)
+        self.shadow_override_button.clicked.connect(self._on_shadow_override_clicked)
         shadow_layout.addWidget(self.shadow_height_display)
         shadow_layout.addWidget(self.shadow_details)
         shadow_layout.addWidget(self.shadow_warnings)
+        shadow_layout.addWidget(self.shadow_override_button)
         self.shadow_group.setLayout(shadow_layout)
         self.shadow_group.setVisible(False)
 
@@ -398,7 +408,7 @@ class MeasureDialog(TranslationMixin, QDialog):
         except (IndexError, TypeError):
             return None
 
-    def _estimate_and_render_shadow_height(self, pen_width, colour):
+    def _estimate_and_render_shadow_height(self, pen_width, colour, allow_azimuth_override=False):
         """Run the shadow-height estimator on the two clicks and update the UI."""
         image_dict = self._current_image_metadata()
         if image_dict is None or not image_dict.get('path'):
@@ -412,10 +422,41 @@ class MeasureDialog(TranslationMixin, QDialog):
 
         base_px = (self.first_point.x(), self.first_point.y())
         tip_px = (self.second_point.x(), self.second_point.y())
-        result = self.shadow_estimator.estimate(image_dict, base_px, tip_px)
+        result = self.shadow_estimator.estimate(
+            image_dict, base_px, tip_px,
+            allow_azimuth_override=allow_azimuth_override,
+        )
 
         self._render_shadow_result_in_dialog(result)
         self._render_shadow_result_on_image(result, pen_width, colour)
+
+    def _on_shadow_override_clicked(self):
+        """Re-run the most recent shadow measurement with the azimuth gate relaxed."""
+        if self.first_point is None or self.second_point is None:
+            return
+        # Drop the previously rendered (rejected) overlay before redrawing.
+        self._clear_shadow_overlays()
+        zoom = self.image_viewer.getZoom() if hasattr(self.image_viewer, 'getZoom') else 1.0
+        pen_width = self.fixed_line_width / zoom
+        colour = QColor(255, 215, 0)
+        self._estimate_and_render_shadow_height(
+            pen_width, colour, allow_azimuth_override=True
+        )
+
+    def _clear_shadow_overlays(self):
+        """Remove only the shadow-specific overlays, keep the B/T points + line."""
+        for item in self.shadow_graphics:
+            try:
+                self.image_viewer.scene.removeItem(item)
+            except Exception:
+                pass
+        self.shadow_graphics = []
+        if self.distance_text_item is not None:
+            try:
+                self.image_viewer.scene.removeItem(self.distance_text_item)
+            except Exception:
+                pass
+            self.distance_text_item = None
 
     def _render_shadow_result_in_dialog(self, result):
         """Update the sidebar group with the estimator's verdict."""
@@ -423,6 +464,7 @@ class MeasureDialog(TranslationMixin, QDialog):
             self.shadow_height_display.setText(self.tr("Rejected"))
             self.shadow_details.setText("")
             self.shadow_warnings.setText(result.rejection_reason or "")
+            self.shadow_override_button.setVisible(bool(result.azimuth_override_available))
             return
 
         height_str = self._format_length(result.height_m)
@@ -443,6 +485,7 @@ class MeasureDialog(TranslationMixin, QDialog):
 
         warnings = [w for w in result.warnings if w]
         self.shadow_warnings.setText("\n".join(warnings))
+        self.shadow_override_button.setVisible(False)
 
     def _render_shadow_result_on_image(self, result, pen_width, colour):
         """Overlay the height label (and a direction arrow) on the image."""
@@ -611,6 +654,7 @@ class MeasureDialog(TranslationMixin, QDialog):
         self.shadow_height_display.setText("--")
         self.shadow_details.setText("")
         self.shadow_warnings.setText("")
+        self.shadow_override_button.setVisible(False)
 
     def updateItemSizes(self):
         """Update the sizes of all measurement items based on current zoom."""

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -1,0 +1,658 @@
+"""PersonReferenceDialog - perspective-projected person-size overlay.
+
+Draws standing and recumbent (and optional sitting) person silhouettes on
+the image at true perspective scale, plus the standing person's shadow.
+
+Unlike a flat top-down silhouette scaled by GSD, the overlay is built by
+projecting a 3D person model through a CameraModel derived from the image's
+metadata pose. The silhouette is therefore foreshortened correctly - a
+compact top-down shape near the nadir point, an upright side-on figure
+toward oblique frame edges - and the shadow is cast from the real sun
+position at the image's capture time.
+
+Engine pieces:
+- CameraModel       - 3D world point -> image pixel projection.
+- PersonModel       - 3D point cloud for standing/sitting poses.
+- PersonShadow      - casts the standing person's outline onto the ground.
+- SolarPosition     - capture-time EXIF -> sun elevation/azimuth.
+"""
+
+import cv2
+import numpy as np
+
+from PySide6.QtCore import Qt, QRectF, QPointF
+from PySide6.QtGui import QPen, QColor, QBrush, QPainterPath, QPolygonF
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QWidget,
+    QGroupBox, QComboBox, QFormLayout, QCheckBox, QGraphicsPathItem,
+    QGraphicsEllipseItem, QGraphicsItem, QColorDialog,
+)
+
+from helpers.TranslationMixin import TranslationMixin
+from helpers.MetaDataHelper import MetaDataHelper
+from helpers.LocationInfo import LocationInfo
+from core.services.SettingsService import SettingsService
+from core.services.LoggerService import LoggerService
+from core.services.CameraModel import CameraModel
+from core.services import PersonModel
+from core.services.shadow.PersonShadow import compute_shadow_ground_points
+from core.services.shadow.SolarPosition import (
+    resolve_capture_utc, get_solar_position, SolarTimeUnresolvable,
+)
+
+# Persisted setting key for the user's preferred overlay color.
+SETTING_OVERLAY_COLOR = 'PersonReferenceOverlayColor'
+DEFAULT_OVERLAY_COLOR = '#00ff00'  # bright green
+
+# Reference size classes: key, label, standing height (inches), weight (lb).
+SIZE_CLASSES = [
+    ("large_adult", "Large adult",           6 * 12 + 2,  220),
+    ("average_adult", "Average adult",       5 * 12 + 7,  185),
+    ("small_adult", "Small adult",           5 * 12 + 2,  120),
+    ("child", "Child",                       4 * 12 + 0,  50),
+    ("small_child", "Small child / toddler", 3 * 12 + 0,  30),
+    ("infant", "Infant",                     2 * 12 + 4,  20),
+]
+
+CM_PER_INCH = 2.54
+
+
+def _build_recumbent_path(height_cm):
+    """Top-down silhouette of a person lying flat.
+
+    Built by drawing the head, body, arms, and legs as separate closed paths
+    and merging them with QPainterPath.united() into a single outer outline.
+    Coordinates are centimetres, centred on the origin.
+    """
+    h = height_cm
+    cx = 0.0
+
+    head_diam = 0.135 * h
+    head_r = head_diam / 2.0
+
+    body_half_w = 0.118 * h
+    body_top_y = 0.115 * h
+    body_bot_y = 0.555 * h
+    neck_half_w = 0.045 * h
+    neck_top_y = head_diam * 0.85
+
+    arm_cx_offset = 0.108 * h
+    arm_half_w = 0.038 * h
+    arm_top_y = body_top_y + 0.010 * h
+    arm_bot_y = body_bot_y + 0.005 * h
+
+    leg_cx_offset = 0.058 * h
+    thigh_half_w = 0.052 * h
+    knee_half_w = 0.044 * h
+    ankle_half_w = 0.034 * h
+    foot_outer = 0.066 * h
+    foot_inner = 0.005 * h
+    hip_y = body_bot_y - 0.025 * h
+    knee_y = 0.730 * h
+    ankle_y = 0.955 * h
+    foot_tip_y = 1.000 * h
+
+    total_len = foot_tip_y
+    y0 = -total_len / 2.0
+
+    head = QPainterPath()
+    head.addEllipse(QRectF(cx - head_r, y0, head_diam, head_diam))
+
+    body = QPainterPath()
+    body.moveTo(cx + neck_half_w, y0 + neck_top_y)
+    body.cubicTo(
+        cx + neck_half_w + 0.020 * h, y0 + body_top_y - 0.005 * h,
+        cx + body_half_w - 0.020 * h, y0 + body_top_y,
+        cx + body_half_w, y0 + body_top_y + 0.015 * h,
+    )
+    body.lineTo(cx + body_half_w, y0 + body_bot_y - 0.020 * h)
+    body.cubicTo(
+        cx + body_half_w, y0 + body_bot_y,
+        cx - body_half_w, y0 + body_bot_y,
+        cx - body_half_w, y0 + body_bot_y - 0.020 * h,
+    )
+    body.lineTo(cx - body_half_w, y0 + body_top_y + 0.015 * h)
+    body.cubicTo(
+        cx - body_half_w + 0.020 * h, y0 + body_top_y,
+        cx - neck_half_w - 0.020 * h, y0 + body_top_y - 0.005 * h,
+        cx - neck_half_w, y0 + neck_top_y,
+    )
+    body.closeSubpath()
+
+    arms = []
+    for sign in (1, -1):
+        ax = sign * arm_cx_offset
+        arm = QPainterPath()
+        arm.addRoundedRect(
+            QRectF(ax - arm_half_w, y0 + arm_top_y,
+                   arm_half_w * 2.0, arm_bot_y - arm_top_y),
+            arm_half_w, arm_half_w,
+        )
+        arms.append(arm)
+
+    legs = []
+    for sign in (1, -1):
+        lx = sign * leg_cx_offset
+        leg = QPainterPath()
+        leg.moveTo(lx + sign * thigh_half_w, y0 + hip_y)
+        leg.cubicTo(
+            lx + sign * thigh_half_w, y0 + hip_y + 0.080 * h,
+            lx + sign * knee_half_w * 1.06, y0 + knee_y - 0.040 * h,
+            lx + sign * knee_half_w, y0 + knee_y,
+        )
+        leg.cubicTo(
+            lx + sign * knee_half_w, y0 + knee_y + 0.060 * h,
+            lx + sign * ankle_half_w, y0 + ankle_y - 0.060 * h,
+            lx + sign * ankle_half_w, y0 + ankle_y,
+        )
+        leg.lineTo(lx + sign * foot_outer, y0 + foot_tip_y)
+        leg.lineTo(lx + sign * foot_inner, y0 + foot_tip_y)
+        leg.lineTo(lx - sign * ankle_half_w * 0.85, y0 + ankle_y)
+        leg.cubicTo(
+            lx - sign * ankle_half_w * 0.85, y0 + ankle_y - 0.060 * h,
+            lx - sign * knee_half_w * 0.85, y0 + knee_y + 0.060 * h,
+            lx - sign * knee_half_w * 0.85, y0 + knee_y,
+        )
+        leg.cubicTo(
+            lx - sign * knee_half_w * 0.95, y0 + knee_y - 0.040 * h,
+            lx - sign * thigh_half_w * 0.70, y0 + hip_y + 0.080 * h,
+            lx - sign * thigh_half_w * 0.70, y0 + hip_y,
+        )
+        leg.closeSubpath()
+        legs.append(leg)
+
+    result = head.united(body)
+    for arm in arms:
+        result = result.united(arm)
+    for leg in legs:
+        result = result.united(leg)
+    return result, total_len
+
+
+class _AnchorHandle(QGraphicsEllipseItem):
+    """Draggable marker for the person's ground position.
+
+    Ignores the view transform so it stays a constant screen size; its scene
+    position is the pixel the silhouettes and shadow are projected from.
+    """
+
+    def __init__(self, dialog, radius=9):
+        super().__init__(-radius, -radius, 2 * radius, 2 * radius)
+        self._dialog = dialog
+        self.setZValue(1003)
+        self.setBrush(QBrush(QColor(255, 255, 255, 200)))
+        self.setPen(QPen(QColor(40, 40, 40), 2))
+        self.setCursor(Qt.OpenHandCursor)
+        self.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.ItemSendsGeometryChanges, True)
+        self.setFlag(QGraphicsItem.ItemIgnoresTransformations, True)
+
+    def itemChange(self, change, value):
+        if (change == QGraphicsItem.ItemPositionHasChanged
+                and self._dialog is not None):
+            self._dialog._on_anchor_moved()
+        return super().itemChange(change, value)
+
+
+class PersonReferenceDialog(TranslationMixin, QDialog):
+    """Dialog for placing perspective-projected person silhouettes on the image."""
+
+    def __init__(self, parent, image_viewer, image_service, image_path,
+                 distance_unit, agl_override_m=None):
+        """
+        Args:
+            parent: Parent widget (Viewer).
+            image_viewer: QtImageViewer showing the current image.
+            image_service: ImageService for the current image (camera pose).
+            image_path: Path to the current image (EXIF capture time / GPS).
+            distance_unit: 'ft' for imperial display, else metric.
+            agl_override_m: Optional AGL altitude override in metres.
+        """
+        super().__init__(parent)
+        self.logger = LoggerService()
+        self._parent_viewer = parent
+        self.image_viewer = image_viewer
+        self.distance_unit = distance_unit
+
+        self.size_key = SIZE_CLASSES[1][0]  # default: Average adult
+
+        # Camera + sun state for the current image.
+        self.camera = None
+        self.image_path = None
+        self.drone_lat = None
+        self.drone_lon = None
+        self.sun_elev = None
+        self.sun_az = None
+        self.sun_error = None
+
+        # Overlay color (persisted so the user only sets it once).
+        self._settings_service = SettingsService()
+        saved = self._settings_service.get_setting(SETTING_OVERLAY_COLOR)
+        color = QColor(saved) if saved else QColor(DEFAULT_OVERLAY_COLOR)
+        self.overlay_color = color if color.isValid() else QColor(DEFAULT_OVERLAY_COLOR)
+
+        # Scene items: persistent, re-pathed on every move.
+        self.anchor_item = None
+        self.pose_items = {}   # 'standing'|'recumbent'|'sitting' -> QGraphicsPathItem
+        self.shadow_item = None
+
+        self._setup_ui()
+        self._connect_signals()
+        self._apply_translations()
+
+        self._load_image(image_service, image_path, agl_override_m)
+
+    # ---------------- UI ----------------
+    def _setup_ui(self):
+        self.setWindowTitle(self.tr("Person Size Reference"))
+        self.setModal(False)
+        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
+        self.setMinimumWidth(340)
+
+        layout = QVBoxLayout(self)
+
+        params_group = QGroupBox(self.tr("Reference Person"))
+        form = QFormLayout()
+
+        self.size_combo = QComboBox()
+        for key, label, height_in, weight_lb in SIZE_CLASSES:
+            ft, inch = height_in // 12, height_in % 12
+            if self.distance_unit == 'ft':
+                text = f"{self.tr(label)}  ({ft}'{inch}\", {weight_lb} lb)"
+            else:
+                h_cm = round(height_in * CM_PER_INCH)
+                w_kg = round(weight_lb * 0.4536, 1)
+                text = f"{self.tr(label)}  ({h_cm} cm, {w_kg} kg)"
+            self.size_combo.addItem(text, key)
+        self.size_combo.setCurrentIndex(1)
+
+        self.standing_check = QCheckBox(self.tr("Standing"))
+        self.standing_check.setChecked(True)
+        self.recumbent_check = QCheckBox(self.tr("Lying down"))
+        self.recumbent_check.setChecked(True)
+        self.sitting_check = QCheckBox(self.tr("Sitting"))
+        self.sitting_check.setChecked(False)
+        poses_row = QHBoxLayout()
+        poses_row.addWidget(self.standing_check)
+        poses_row.addWidget(self.recumbent_check)
+        poses_row.addWidget(self.sitting_check)
+        poses_widget = QWidget()
+        poses_widget.setLayout(poses_row)
+
+        self.shadow_check = QCheckBox(self.tr("Show shadow (from capture time)"))
+        self.shadow_check.setChecked(True)
+
+        self.color_button = QPushButton()
+        self.color_button.setFixedWidth(60)
+        self.color_button.setToolTip(self.tr("Click to choose overlay color"))
+        self._apply_color_button_style()
+        color_row = QHBoxLayout()
+        color_row.addWidget(self.color_button)
+        color_row.addStretch()
+        color_widget = QWidget()
+        color_widget.setLayout(color_row)
+
+        form.addRow(self.tr("Size:"), self.size_combo)
+        form.addRow(self.tr("Show:"), poses_widget)
+        form.addRow("", self.shadow_check)
+        form.addRow(self.tr("Color:"), color_widget)
+        params_group.setLayout(form)
+
+        self.status_label = QLabel()
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("QLabel { color: #d9822b; }")
+        self.status_label.setVisible(False)
+
+        self.sun_label = QLabel()
+        self.sun_label.setWordWrap(True)
+        self.sun_label.setStyleSheet("QLabel { color: gray; }")
+
+        instructions = QLabel(self.tr(
+            "Drag the white handle to position the reference person. The "
+            "silhouettes are projected at true perspective scale for this "
+            "image's camera angle - they foreshorten toward oblique edges."
+        ))
+        instructions.setWordWrap(True)
+        instructions.setStyleSheet("QLabel { color: gray; }")
+
+        button_row = QHBoxLayout()
+        self.recenter_button = QPushButton(self.tr("Recenter"))
+        self.close_button = QPushButton(self.tr("Close"))
+        button_row.addWidget(self.recenter_button)
+        button_row.addStretch()
+        button_row.addWidget(self.close_button)
+
+        layout.addWidget(params_group)
+        layout.addWidget(self.status_label)
+        layout.addWidget(self.sun_label)
+        layout.addWidget(instructions)
+        layout.addLayout(button_row)
+        layout.addStretch()
+
+    def _apply_translations(self):
+        # Static strings are set inline; this hook is kept for consistency
+        # with the other translatable dialogs.
+        pass
+
+    def _connect_signals(self):
+        self.size_combo.currentIndexChanged.connect(self._on_params_changed)
+        self.standing_check.toggled.connect(self._on_params_changed)
+        self.recumbent_check.toggled.connect(self._on_params_changed)
+        self.sitting_check.toggled.connect(self._on_params_changed)
+        self.shadow_check.toggled.connect(self._on_params_changed)
+        self.color_button.clicked.connect(self._on_color_button_clicked)
+        self.recenter_button.clicked.connect(self._recenter)
+        self.close_button.clicked.connect(self.close)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.activateWindow()
+        self.raise_()
+        if not getattr(self, '_position_adjusted', False):
+            try:
+                pos = self.pos()
+                self.move(pos.x() + 100, pos.y())
+            except Exception:
+                pass
+            self._position_adjusted = True
+
+    # ---------------- image / camera / sun ----------------
+    def _load_image(self, image_service, image_path, agl_override_m):
+        """Build the camera model and sun position for an image, then render."""
+        self.image_path = image_path
+        self.camera = CameraModel.from_image_service(image_service, agl_override_m)
+        self._resolve_sun()
+        self._build_overlay()
+        self._update_sun_label()
+        self._render_all()
+
+        if self.camera is None:
+            self._show_status(self.tr(
+                "Perspective overlay unavailable: this image is missing the "
+                "altitude or lens metadata needed to project a person."
+            ))
+        else:
+            self._show_status(None)
+
+    def update_for_image(self, image_service, image_path, agl_override_m=None):
+        """Rebuild the camera/sun for a newly selected image (called by Viewer)."""
+        self._clear_items()
+        self._load_image(image_service, image_path, agl_override_m)
+
+    def _resolve_sun(self):
+        """Resolve the sun elevation/azimuth from the image capture metadata."""
+        self.sun_elev = None
+        self.sun_az = None
+        self.sun_error = None
+        if not self.image_path:
+            self.sun_error = self.tr("no image loaded")
+            return
+        try:
+            exif = MetaDataHelper.get_exif_data_piexif(self.image_path)
+        except Exception:
+            self.sun_error = self.tr("image metadata could not be read")
+            return
+        gps = LocationInfo.get_gps(exif_data=exif)
+        if not gps:
+            self.sun_error = self.tr("image has no GPS coordinates")
+            return
+        self.drone_lat = gps['latitude']
+        self.drone_lon = gps['longitude']
+        try:
+            xmp = MetaDataHelper.get_xmp_data(self.image_path, parse=True)
+        except Exception:
+            xmp = None
+        try:
+            utc, _source = resolve_capture_utc(exif, xmp)
+        except SolarTimeUnresolvable:
+            self.sun_error = self.tr("capture time / timezone not in metadata")
+            return
+        try:
+            elev, az = get_solar_position(self.drone_lat, self.drone_lon, utc)
+        except Exception:
+            self.sun_error = self.tr("sun position could not be computed")
+            return
+        self.sun_elev = elev
+        self.sun_az = az
+
+    def _update_sun_label(self):
+        """Refresh the sun-info line and enable/disable the shadow toggle."""
+        if self.sun_elev is not None and self.sun_elev > 0:
+            self.sun_label.setText(self.tr(
+                "Sun at capture: {elev:.0f}° above horizon, "
+                "azimuth {az:.0f}°."
+            ).format(elev=self.sun_elev, az=self.sun_az))
+            self.shadow_check.setEnabled(True)
+        else:
+            if self.sun_elev is not None and self.sun_elev <= 0:
+                reason = self.tr("the sun was below the horizon at capture")
+            else:
+                reason = self.sun_error or self.tr("sun position unavailable")
+            self.sun_label.setText(self.tr("Shadow unavailable: {reason}.")
+                                   .format(reason=reason))
+            self.shadow_check.setEnabled(False)
+
+    # ---------------- overlay items ----------------
+    def _build_overlay(self):
+        """Create the anchor handle and one path item per pose + shadow."""
+        if self.camera is None:
+            return
+        scene = self.image_viewer.scene
+
+        self.anchor_item = _AnchorHandle(self)
+        self.anchor_item.setPos(self._viewport_center_scene())
+        scene.addItem(self.anchor_item)
+
+        # Shadow sits below the silhouettes; silhouettes below the handle.
+        self.shadow_item = QGraphicsPathItem()
+        self.shadow_item.setZValue(1000)
+        self.shadow_item.setPen(QPen(QColor(0, 0, 0, 110), 1, Qt.DashLine))
+        self.shadow_item.setBrush(QBrush(QColor(0, 0, 0, 70)))
+        scene.addItem(self.shadow_item)
+
+        for pose in ("recumbent", "sitting", "standing"):
+            item = QGraphicsPathItem()
+            item.setZValue(1001)
+            scene.addItem(item)
+            self.pose_items[pose] = item
+        self._apply_color_to_items()
+
+    def _clear_items(self):
+        """Remove every overlay item from the scene."""
+        scene = getattr(self.image_viewer, 'scene', None)
+        for item in list(self.pose_items.values()):
+            if scene is not None and item is not None:
+                try:
+                    scene.removeItem(item)
+                except Exception:
+                    pass
+        self.pose_items.clear()
+        for attr in ('shadow_item', 'anchor_item'):
+            item = getattr(self, attr, None)
+            if item is not None and scene is not None:
+                try:
+                    scene.removeItem(item)
+                except Exception:
+                    pass
+            setattr(self, attr, None)
+
+    # ---------------- rendering ----------------
+    def _selected_height_cm(self):
+        idx = max(0, self.size_combo.currentIndex())
+        return SIZE_CLASSES[idx][2] * CM_PER_INCH
+
+    def _foot_ned(self):
+        """Ground point (NED, metres from the camera) under the anchor handle."""
+        if self.camera is None or self.anchor_item is None:
+            return None
+        pos = self.anchor_item.pos()
+        return self.camera.pixel_to_ground(pos.x(), pos.y())
+
+    def _project_person_local(self, person_points, foot_ned):
+        """Project person-local (x=right, y=forward, z=up) points to pixels."""
+        fn, fe, fd = foot_ned
+        pixels = []
+        for px, py, pz in person_points:
+            uv = self.camera.project(fn + py, fe + px, fd - pz)
+            if uv is not None:
+                pixels.append(uv)
+        return pixels
+
+    @staticmethod
+    def _hull_path(pixels):
+        """Closed QPainterPath around the convex hull of projected pixels."""
+        if len(pixels) < 3:
+            return None
+        hull = cv2.convexHull(np.array(pixels, dtype=np.float32))
+        poly = QPolygonF([QPointF(float(p[0][0]), float(p[0][1])) for p in hull])
+        path = QPainterPath()
+        path.addPolygon(poly)
+        path.closeSubpath()
+        return path
+
+    @staticmethod
+    def _polyline_path(pixels):
+        """Closed QPainterPath through projected pixels in order."""
+        if len(pixels) < 3:
+            return None
+        path = QPainterPath()
+        path.moveTo(pixels[0][0], pixels[0][1])
+        for u, v in pixels[1:]:
+            path.lineTo(u, v)
+        path.closeSubpath()
+        return path
+
+    def _recumbent_local_points(self, height_cm):
+        """Sample the recumbent silhouette outline as flat ground points (metres)."""
+        path, _ = _build_recumbent_path(height_cm)
+        polygons = path.toSubpathPolygons()
+        if not polygons:
+            return []
+        outline = max(polygons, key=lambda p: p.count())
+        points = []
+        for i in range(outline.count()):
+            qp = outline.at(i)
+            # Centimetres -> metres; lie flat on the ground (z = 0).
+            points.append((qp.x() / 100.0, -qp.y() / 100.0, 0.0))
+        return points
+
+    def _render_all(self):
+        """Re-project every enabled pose and the shadow at the anchor."""
+        if self.camera is None:
+            return
+        foot = self._foot_ned()
+        height_cm = self._selected_height_cm()
+        height_m = height_cm / 100.0
+
+        upright = {
+            'standing': self.standing_check.isChecked(),
+            'sitting': self.sitting_check.isChecked(),
+        }
+        for pose, enabled in upright.items():
+            item = self.pose_items.get(pose)
+            if item is None:
+                continue
+            path = None
+            if enabled and foot is not None:
+                points = PersonModel.build_points(height_m, pose)
+                path = self._hull_path(self._project_person_local(points, foot))
+            item.setPath(path or QPainterPath())
+            item.setVisible(path is not None)
+
+        rec_item = self.pose_items.get('recumbent')
+        if rec_item is not None:
+            path = None
+            if self.recumbent_check.isChecked() and foot is not None:
+                points = self._recumbent_local_points(height_cm)
+                path = self._polyline_path(self._project_person_local(points, foot))
+            rec_item.setPath(path or QPainterPath())
+            rec_item.setVisible(path is not None)
+
+        self._render_shadow(height_m, foot)
+
+    def _render_shadow(self, height_m, foot):
+        """Re-project the standing person's shadow."""
+        if self.shadow_item is None:
+            return
+        draw = (self.shadow_check.isChecked() and self.shadow_check.isEnabled()
+                and self.standing_check.isChecked() and foot is not None
+                and self.sun_elev is not None and self.sun_elev > 0)
+        path = None
+        if draw:
+            points = PersonModel.build_standing_points(height_m)
+            ground = compute_shadow_ground_points(
+                points, foot, self.sun_elev, self.sun_az
+            )
+            pixels = []
+            for north, east, down in ground:
+                uv = self.camera.project(north, east, down)
+                if uv is not None:
+                    pixels.append(uv)
+            path = self._hull_path(pixels)
+        self.shadow_item.setPath(path or QPainterPath())
+        self.shadow_item.setVisible(path is not None)
+
+    # ---------------- colour ----------------
+    def _apply_color_button_style(self):
+        c = self.overlay_color
+        border = '#ffffff' if c.lightness() < 128 else '#222222'
+        self.color_button.setStyleSheet(
+            f"QPushButton {{ background-color: {c.name()}; "
+            f"border: 1px solid {border}; min-height: 22px; }}"
+        )
+
+    def _apply_color_to_items(self):
+        pen = QPen(QColor(self.overlay_color))
+        pen.setCosmetic(True)
+        pen.setWidth(2)
+        fill = QColor(self.overlay_color)
+        fill.setAlpha(60)
+        for item in self.pose_items.values():
+            if item is not None:
+                item.setPen(pen)
+                item.setBrush(QBrush(fill))
+
+    def _on_color_button_clicked(self):
+        chosen = QColorDialog.getColor(
+            self.overlay_color, self, self.tr("Choose Overlay Color")
+        )
+        if not chosen.isValid():
+            return
+        self.overlay_color = chosen
+        self._settings_service.set_setting(SETTING_OVERLAY_COLOR, chosen.name())
+        self._apply_color_button_style()
+        self._apply_color_to_items()
+
+    # ---------------- helpers ----------------
+    def _viewport_center_scene(self):
+        try:
+            return self.image_viewer.mapToScene(
+                self.image_viewer.viewport().rect().center()
+            )
+        except Exception:
+            return self.image_viewer.sceneRect().center()
+
+    def _show_status(self, message):
+        if message:
+            self.status_label.setText(message)
+            self.status_label.setVisible(True)
+        else:
+            self.status_label.setVisible(False)
+
+    # ---------------- event handlers ----------------
+    def _on_params_changed(self, *_):
+        self.size_key = self.size_combo.currentData()
+        self._render_all()
+
+    def _on_anchor_moved(self):
+        self._render_all()
+
+    def _recenter(self):
+        if self.anchor_item is not None:
+            self.anchor_item.setPos(self._viewport_center_scene())
+            self._render_all()
+
+    # ---------------- close ----------------
+    def closeEvent(self, event):
+        self._clear_items()
+        super().closeEvent(event)

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -17,6 +17,8 @@ Engine pieces:
 - SolarPosition     - capture-time EXIF -> sun elevation/azimuth.
 """
 
+import math
+
 import cv2
 import numpy as np
 
@@ -24,7 +26,7 @@ from PySide6.QtCore import Qt, QRectF, QPointF
 from PySide6.QtGui import QPen, QColor, QBrush, QPainterPath, QPolygonF
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QWidget,
-    QGroupBox, QComboBox, QFormLayout, QCheckBox, QGraphicsPathItem,
+    QGroupBox, QComboBox, QSpinBox, QFormLayout, QCheckBox, QGraphicsPathItem,
     QGraphicsEllipseItem, QGraphicsItem, QColorDialog,
 )
 
@@ -219,6 +221,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.distance_unit = distance_unit
 
         self.size_key = SIZE_CLASSES[1][0]  # default: Average adult
+        self.rotation_deg = 0  # ground heading of the reference person
 
         # Camera + sun state for the current image.
         self.camera = None
@@ -286,6 +289,15 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.shadow_check = QCheckBox(self.tr("Show shadows (from capture time)"))
         self.shadow_check.setChecked(True)
 
+        # Ground rotation of the person, for lining a pose up with an object.
+        self.rotation_spin = QSpinBox()
+        self.rotation_spin.setRange(0, 359)
+        self.rotation_spin.setWrapping(True)
+        self.rotation_spin.setSuffix("°")
+        self.rotation_spin.setToolTip(
+            self.tr("Rotate the person on the ground to line it up with an object")
+        )
+
         self.color_button = QPushButton()
         self.color_button.setFixedWidth(60)
         self.color_button.setToolTip(self.tr("Click to choose overlay color"))
@@ -298,6 +310,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
 
         form.addRow(self.tr("Size:"), self.size_combo)
         form.addRow(self.tr("Show:"), poses_widget)
+        form.addRow(self.tr("Rotation:"), self.rotation_spin)
         form.addRow("", self.shadow_check)
         form.addRow(self.tr("Color:"), color_widget)
         params_group.setLayout(form)
@@ -344,6 +357,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.recumbent_check.toggled.connect(self._on_params_changed)
         self.sitting_check.toggled.connect(self._on_params_changed)
         self.shadow_check.toggled.connect(self._on_params_changed)
+        self.rotation_spin.valueChanged.connect(self._on_rotation_changed)
         self.color_button.clicked.connect(self._on_color_button_clicked)
         self.recenter_button.clicked.connect(self._recenter)
         self.close_button.clicked.connect(self.close)
@@ -540,6 +554,20 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             points.append((qp.x() / 100.0, -qp.y() / 100.0, 0.0))
         return points
 
+    def _orient(self, points):
+        """Rotate person-local (x, y) points by the current rotation setting."""
+        if not self.rotation_deg:
+            return list(points)
+        theta = math.radians(self.rotation_deg)
+        cos_t, sin_t = math.cos(theta), math.sin(theta)
+        return [(x * cos_t + y * sin_t, -x * sin_t + y * cos_t, z)
+                for x, y, z in points]
+
+    def _on_rotation_changed(self, value):
+        """Re-render when the user changes the person's ground rotation."""
+        self.rotation_deg = int(value)
+        self._render_all()
+
     def _render_all(self):
         """Re-project every enabled pose and the shadow at the anchor."""
         if self.camera is None:
@@ -558,7 +586,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
                 continue
             path = None
             if enabled and foot is not None:
-                points = PersonModel.build_points(height_m, pose)
+                points = self._orient(PersonModel.build_points(height_m, pose))
                 path = self._hull_path(self._project_person_local(points, foot))
             item.setPath(path or QPainterPath())
             item.setVisible(path is not None)
@@ -567,7 +595,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         if rec_item is not None:
             path = None
             if self.recumbent_check.isChecked() and foot is not None:
-                points = self._recumbent_local_points(height_cm)
+                points = self._orient(self._recumbent_local_points(height_cm))
                 path = self._polyline_path(self._project_person_local(points, foot))
             rec_item.setPath(path or QPainterPath())
             rec_item.setVisible(path is not None)
@@ -615,7 +643,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         else:
             points = PersonModel.build_points(height_m, pose)
         ground = compute_shadow_ground_points(
-            points, foot, self.sun_elev, self.sun_az
+            self._orient(points), foot, self.sun_elev, self.sun_az
         )
         return self._hull_path(self._project_ground(ground))
 

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -58,6 +58,10 @@ SIZE_CLASSES = [
 
 CM_PER_INCH = 2.54
 
+# WGS-84 equatorial radius, for the local NED <-> lat/lon conversion used by
+# the DEM terrain lookups.
+EARTH_RADIUS_M = 6378137.0
+
 # A person lying down is a low slab; this fraction of their standing height
 # is the body thickness used to cast the recumbent shadow.
 RECUMBENT_THICKNESS_FRACTION = 0.12
@@ -232,6 +236,10 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.sun_az = None
         self.sun_error = None
 
+        # DEM terrain state for the current image.
+        self.terrain_service = None
+        self.terrain_nadir_elev = None
+
         # Overlay color (persisted so the user only sets it once).
         self._settings_service = SettingsService()
         saved = self._settings_service.get_setting(SETTING_OVERLAY_COLOR)
@@ -289,6 +297,9 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.shadow_check = QCheckBox(self.tr("Show shadows (from capture time)"))
         self.shadow_check.setChecked(True)
 
+        self.terrain_check = QCheckBox(self.tr("Use terrain elevation (DEM)"))
+        self.terrain_check.setChecked(True)
+
         # Ground rotation of the person, for lining a pose up with an object.
         self.rotation_spin = QSpinBox()
         self.rotation_spin.setRange(0, 359)
@@ -312,6 +323,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         form.addRow(self.tr("Show:"), poses_widget)
         form.addRow(self.tr("Rotation:"), self.rotation_spin)
         form.addRow("", self.shadow_check)
+        form.addRow("", self.terrain_check)
         form.addRow(self.tr("Color:"), color_widget)
         params_group.setLayout(form)
 
@@ -357,6 +369,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.recumbent_check.toggled.connect(self._on_params_changed)
         self.sitting_check.toggled.connect(self._on_params_changed)
         self.shadow_check.toggled.connect(self._on_params_changed)
+        self.terrain_check.toggled.connect(self._on_params_changed)
         self.rotation_spin.valueChanged.connect(self._on_rotation_changed)
         self.color_button.clicked.connect(self._on_color_button_clicked)
         self.recenter_button.clicked.connect(self._recenter)
@@ -380,8 +393,10 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.image_path = image_path
         self.camera = CameraModel.from_image_service(image_service, agl_override_m)
         self._resolve_sun()
+        self._resolve_terrain()
         self._build_overlay()
         self._update_sun_label()
+        self._update_terrain_check()
         self._render_all()
 
         if self.camera is None:
@@ -500,11 +515,125 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         return SIZE_CLASSES[idx][2] * CM_PER_INCH
 
     def _foot_ned(self):
-        """Ground point (NED, metres from the camera) under the anchor handle."""
+        """Ground point (NED, metres from the camera) under the anchor handle.
+
+        Casts the anchor pixel onto the DEM terrain surface when terrain use
+        is enabled and available, otherwise onto a flat plane at the AGL.
+        """
         if self.camera is None or self.anchor_item is None:
             return None
         pos = self.anchor_item.pos()
+        if self._terrain_active():
+            terrain_foot = self._terrain_foot_ned(pos.x(), pos.y())
+            if terrain_foot is not None:
+                return terrain_foot
         return self.camera.pixel_to_ground(pos.x(), pos.y())
+
+    # ---------------- DEM terrain ----------------
+    def _resolve_terrain(self):
+        """Look up the terrain service and the nadir reference elevation."""
+        self.terrain_service = None
+        self.terrain_nadir_elev = None
+        try:
+            from core.services.image.AOIService import _get_terrain_service
+            service = _get_terrain_service()
+        except Exception:
+            return
+        if service is None or not getattr(service, 'enabled', False):
+            return
+        self.terrain_service = service
+        # Reference elevation: the terrain directly under the drone (nadir).
+        self.terrain_nadir_elev = self._terrain_elevation(0.0, 0.0)
+
+    def _update_terrain_check(self):
+        """Enable the terrain checkbox only when DEM data covers this image."""
+        available = (self.terrain_service is not None
+                     and self.terrain_nadir_elev is not None)
+        self.terrain_check.setEnabled(available)
+        if available:
+            self.terrain_check.setToolTip(self.tr(
+                "Place the person and shadow on the DEM terrain surface"
+            ))
+        else:
+            self.terrain_check.setToolTip(self.tr(
+                "Terrain (DEM) data is not available for this image"
+            ))
+
+    def _terrain_active(self):
+        """Whether terrain-aware placement is currently enabled and usable."""
+        return (self.terrain_check.isChecked() and self.terrain_check.isEnabled()
+                and self.terrain_service is not None
+                and self.terrain_nadir_elev is not None)
+
+    def _ned_to_latlon(self, north, east):
+        """Convert a camera-NED horizontal offset to a (lat, lon)."""
+        lat = self.drone_lat + math.degrees(north / EARTH_RADIUS_M)
+        lon = self.drone_lon + math.degrees(
+            east / (EARTH_RADIUS_M * math.cos(math.radians(self.drone_lat)))
+        )
+        return lat, lon
+
+    def _terrain_elevation(self, north, east):
+        """Terrain elevation (metres) at a camera-NED ground point, or None."""
+        if self.terrain_service is None or self.drone_lat is None:
+            return None
+        lat, lon = self._ned_to_latlon(north, east)
+        try:
+            result = self.terrain_service.get_elevation(lat, lon)
+        except Exception:
+            return None
+        if (result is None or getattr(result, 'source', None) != 'terrain'
+                or result.elevation_m is None):
+            return None
+        return result.elevation_m
+
+    def _terrain_foot_ned(self, u, v):
+        """Iteratively cast the pixel ray onto the DEM surface.
+
+        The camera AGL is taken as the height above the terrain at the nadir
+        point, so a point whose terrain is higher than the nadir is
+        correspondingly closer to the camera.
+        """
+        ray = self.camera.pixel_ray(u, v)
+        if ray[2] <= 1e-9:
+            return None
+        down = self.camera.agl_m
+        for _ in range(5):
+            t = down / ray[2]
+            elev = self._terrain_elevation(t * ray[0], t * ray[1])
+            if elev is None:
+                break
+            new_down = self.camera.agl_m - (elev - self.terrain_nadir_elev)
+            if new_down <= 1.0:
+                break  # implausible - keep the previous estimate
+            if abs(new_down - down) < 0.05:
+                down = new_down
+                break
+            down = new_down
+        t = down / ray[2]
+        if t <= 0:
+            return None
+        return (t * ray[0], t * ray[1], t * ray[2])
+
+    def _shadow_slope(self, foot):
+        """Terrain grade along the shadow direction (rise/run), or 0.0 if flat.
+
+        Positive means the ground rises away from the sun, which shortens
+        shadows; negative lengthens them.
+        """
+        if not self._terrain_active() or foot is None or self.sun_az is None:
+            return 0.0
+        foot_elev = self._terrain_elevation(foot[0], foot[1])
+        if foot_elev is None:
+            return 0.0
+        baseline_m = 10.0
+        anti_sun = math.radians(self.sun_az + 180.0)
+        tip_n = foot[0] + baseline_m * math.cos(anti_sun)
+        tip_e = foot[1] + baseline_m * math.sin(anti_sun)
+        tip_elev = self._terrain_elevation(tip_n, tip_e)
+        if tip_elev is None:
+            return 0.0
+        return (tip_elev - foot_elev) / baseline_m
 
     def _project_person_local(self, person_points, foot_ned):
         """Project person-local (x=right, y=forward, z=up) points to pixels."""
@@ -611,6 +740,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
                      and self.sun_elev is not None and self.sun_elev > 0)
         combined = None
         if shadow_on:
+            slope = self._shadow_slope(foot)
             enabled = {
                 'standing': self.standing_check.isChecked(),
                 'sitting': self.sitting_check.isChecked(),
@@ -619,14 +749,15 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             for pose, is_on in enabled.items():
                 if not is_on:
                     continue
-                path = self._shadow_path_for_pose(pose, height_cm, height_m, foot)
+                path = self._shadow_path_for_pose(
+                    pose, height_cm, height_m, foot, slope)
                 if path is None or path.isEmpty():
                     continue
                 combined = path if combined is None else combined.united(path)
         self.shadow_item.setPath(combined or QPainterPath())
         self.shadow_item.setVisible(combined is not None)
 
-    def _shadow_path_for_pose(self, pose, height_cm, height_m, foot):
+    def _shadow_path_for_pose(self, pose, height_cm, height_m, foot, slope=0.0):
         """Build the ground-shadow QPainterPath cast by one pose, or None.
 
         Every pose is cast the same way: a cloud of 3D body points is dropped
@@ -643,7 +774,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         else:
             points = PersonModel.build_points(height_m, pose)
         ground = compute_shadow_ground_points(
-            self._orient(points), foot, self.sun_elev, self.sun_az
+            self._orient(points), foot, self.sun_elev, self.sun_az, slope
         )
         return self._hull_path(self._project_ground(ground))
 

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -56,6 +56,10 @@ SIZE_CLASSES = [
 
 CM_PER_INCH = 2.54
 
+# A person lying down is a low slab; this fraction of their standing height
+# is the body thickness used to cast the recumbent shadow.
+RECUMBENT_THICKNESS_FRACTION = 0.12
+
 
 def _build_recumbent_path(height_cm):
     """Top-down silhouette of a person lying flat.
@@ -279,7 +283,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         poses_widget = QWidget()
         poses_widget.setLayout(poses_row)
 
-        self.shadow_check = QCheckBox(self.tr("Show shadow (from capture time)"))
+        self.shadow_check = QCheckBox(self.tr("Show shadows (from capture time)"))
         self.shadow_check.setChecked(True)
 
         self.color_button = QPushButton()
@@ -568,29 +572,72 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             rec_item.setPath(path or QPainterPath())
             rec_item.setVisible(path is not None)
 
-        self._render_shadow(height_m, foot)
+        self._render_shadows(height_cm, height_m, foot)
 
-    def _render_shadow(self, height_m, foot):
-        """Re-project the standing person's shadow."""
+    def _render_shadows(self, height_cm, height_m, foot):
+        """Re-project the shadow of every enabled pose into one shadow shape."""
         if self.shadow_item is None:
             return
-        draw = (self.shadow_check.isChecked() and self.shadow_check.isEnabled()
-                and self.standing_check.isChecked() and foot is not None
-                and self.sun_elev is not None and self.sun_elev > 0)
-        path = None
-        if draw:
-            points = PersonModel.build_standing_points(height_m)
+        shadow_on = (self.shadow_check.isChecked() and self.shadow_check.isEnabled()
+                     and foot is not None
+                     and self.sun_elev is not None and self.sun_elev > 0)
+        combined = None
+        if shadow_on:
+            enabled = {
+                'standing': self.standing_check.isChecked(),
+                'sitting': self.sitting_check.isChecked(),
+                'recumbent': self.recumbent_check.isChecked(),
+            }
+            for pose, is_on in enabled.items():
+                if not is_on:
+                    continue
+                path = self._shadow_path_for_pose(pose, height_cm, height_m, foot)
+                if path is None or path.isEmpty():
+                    continue
+                combined = path if combined is None else combined.united(path)
+        self.shadow_item.setPath(combined or QPainterPath())
+        self.shadow_item.setVisible(combined is not None)
+
+    def _shadow_path_for_pose(self, pose, height_cm, height_m, foot):
+        """Build the ground-shadow QPainterPath cast by one pose, or None."""
+        if pose in ('standing', 'sitting'):
+            # Upright volume: cast the 3D point cloud, hull the ground points.
+            points = PersonModel.build_points(height_m, pose)
             ground = compute_shadow_ground_points(
                 points, foot, self.sun_elev, self.sun_az
             )
-            pixels = []
-            for north, east, down in ground:
-                uv = self.camera.project(north, east, down)
-                if uv is not None:
-                    pixels.append(uv)
-            path = self._hull_path(pixels)
-        self.shadow_item.setPath(path or QPainterPath())
-        self.shadow_item.setVisible(path is not None)
+            return self._hull_path(self._project_ground(ground))
+
+        # Recumbent: a low slab. Sweep the flat body outline from the ground
+        # up to its lying thickness, so the shadow is the body shape plus a
+        # thin fringe on the side away from the sun.
+        outline = self._recumbent_local_points(height_cm)
+        if not outline:
+            return None
+        thickness = RECUMBENT_THICKNESS_FRACTION * height_m
+        flat = compute_shadow_ground_points(
+            outline, foot, self.sun_elev, self.sun_az
+        )
+        raised = [(x, y, thickness) for x, y, _z in outline]
+        sheared = compute_shadow_ground_points(
+            raised, foot, self.sun_elev, self.sun_az
+        )
+        flat_path = self._polyline_path(self._project_ground(flat))
+        sheared_path = self._polyline_path(self._project_ground(sheared))
+        if flat_path is None:
+            return sheared_path
+        if sheared_path is None:
+            return flat_path
+        return flat_path.united(sheared_path)
+
+    def _project_ground(self, ground_points):
+        """Project NED ground points to pixels, dropping any behind the camera."""
+        pixels = []
+        for north, east, down in ground_points:
+            uv = self.camera.project(north, east, down)
+            if uv is not None:
+                pixels.append(uv)
+        return pixels
 
     # ---------------- colour ----------------
     def _apply_color_button_style(self):

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -599,36 +599,25 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.shadow_item.setVisible(combined is not None)
 
     def _shadow_path_for_pose(self, pose, height_cm, height_m, foot):
-        """Build the ground-shadow QPainterPath cast by one pose, or None."""
-        if pose in ('standing', 'sitting'):
-            # Upright volume: cast the 3D point cloud, hull the ground points.
-            points = PersonModel.build_points(height_m, pose)
-            ground = compute_shadow_ground_points(
-                points, foot, self.sun_elev, self.sun_az
-            )
-            return self._hull_path(self._project_ground(ground))
+        """Build the ground-shadow QPainterPath cast by one pose, or None.
 
-        # Recumbent: a low slab. Sweep the flat body outline from the ground
-        # up to its lying thickness, so the shadow is the body shape plus a
-        # thin fringe on the side away from the sun.
-        outline = self._recumbent_local_points(height_cm)
-        if not outline:
-            return None
-        thickness = RECUMBENT_THICKNESS_FRACTION * height_m
-        flat = compute_shadow_ground_points(
-            outline, foot, self.sun_elev, self.sun_az
+        Every pose is cast the same way: a cloud of 3D body points is dropped
+        along the sun ray to the ground and the convex hull of the result is
+        the shadow - one coherent dark patch. Standing and sitting use their
+        upright volumes; the recumbent body is the lying outline given a small
+        lying thickness so it casts a low shadow that hugs the body.
+        """
+        if pose == 'recumbent':
+            outline = self._recumbent_local_points(height_cm)
+            thickness = RECUMBENT_THICKNESS_FRACTION * height_m
+            points = ([(x, y, 0.0) for x, y, _z in outline]
+                      + [(x, y, thickness) for x, y, _z in outline])
+        else:
+            points = PersonModel.build_points(height_m, pose)
+        ground = compute_shadow_ground_points(
+            points, foot, self.sun_elev, self.sun_az
         )
-        raised = [(x, y, thickness) for x, y, _z in outline]
-        sheared = compute_shadow_ground_points(
-            raised, foot, self.sun_elev, self.sun_az
-        )
-        flat_path = self._polyline_path(self._project_ground(flat))
-        sheared_path = self._polyline_path(self._project_ground(sheared))
-        if flat_path is None:
-            return sheared_path
-        if sheared_path is None:
-            return flat_path
-        return flat_path.united(sheared_path)
+        return self._hull_path(self._project_ground(ground))
 
     def _project_ground(self, ground_points):
         """Project NED ground points to pixels, dropping any behind the camera."""

--- a/app/tests/core/services/shadow/test_person_shadow.py
+++ b/app/tests/core/services/shadow/test_person_shadow.py
@@ -1,0 +1,73 @@
+"""Unit tests for core.services.shadow.PersonShadow."""
+
+import math
+
+import pytest
+
+from core.services.shadow.PersonShadow import (
+    compute_shadow_ground_points,
+    shadow_length,
+)
+
+
+def test_shadow_length_at_45_degrees_equals_height():
+    assert shadow_length(1.8, 45.0) == pytest.approx(1.8, rel=1e-6)
+
+
+def test_shadow_length_grows_as_sun_lowers():
+    assert shadow_length(1.8, 30.0) > shadow_length(1.8, 60.0)
+
+
+def test_shadow_length_zero_when_sun_at_or_below_horizon():
+    assert shadow_length(1.8, 0.0) == 0.0
+    assert shadow_length(1.8, -5.0) == 0.0
+
+
+def test_shadow_length_slope_shortens_uphill():
+    flat = shadow_length(1.8, 45.0, slope=0.0)
+    uphill = shadow_length(1.8, 45.0, slope=1.0)
+    assert uphill < flat
+    assert uphill == pytest.approx(0.9, rel=1e-6)
+
+
+def test_shadow_falls_away_from_sun():
+    """Sun in the north -> shadow extends south."""
+    points = [(0.0, 0.0, 2.0)]  # one point 2 m up
+    ground = compute_shadow_ground_points(
+        points, foot_ned=(0.0, 0.0, 100.0),
+        sun_elevation_deg=45.0, sun_azimuth_deg=0.0,
+    )
+    assert len(ground) == 1
+    north, east, down = ground[0]
+    assert north == pytest.approx(-2.0, abs=1e-6)  # 2 m south
+    assert east == pytest.approx(0.0, abs=1e-6)
+    assert down == pytest.approx(100.0, abs=1e-6)
+
+
+def test_shadow_direction_follows_sun_azimuth():
+    """Sun in the east -> shadow extends west."""
+    points = [(0.0, 0.0, 2.0)]
+    ground = compute_shadow_ground_points(
+        points, foot_ned=(0.0, 0.0, 100.0),
+        sun_elevation_deg=45.0, sun_azimuth_deg=90.0,
+    )
+    north, east, _ = ground[0]
+    assert north == pytest.approx(0.0, abs=1e-6)
+    assert east == pytest.approx(-2.0, abs=1e-6)  # 2 m west
+
+
+def test_ground_point_at_feet_has_no_offset():
+    points = [(0.5, -0.3, 0.0)]  # a point already on the ground
+    ground = compute_shadow_ground_points(
+        points, foot_ned=(10.0, 20.0, 100.0),
+        sun_elevation_deg=30.0, sun_azimuth_deg=120.0,
+    )
+    north, east, _ = ground[0]
+    assert north == pytest.approx(10.0 + (-0.3), abs=1e-6)
+    assert east == pytest.approx(20.0 + 0.5, abs=1e-6)
+
+
+def test_no_shadow_when_sun_below_horizon():
+    points = [(0.0, 0.0, 2.0)]
+    assert compute_shadow_ground_points(
+        points, (0.0, 0.0, 100.0), -1.0, 0.0) == []

--- a/app/tests/core/services/shadow/test_shadow_height_estimator.py
+++ b/app/tests/core/services/shadow/test_shadow_height_estimator.py
@@ -271,6 +271,46 @@ def test_azimuth_off_by_90deg_rejects(monkeypatch):
     )
     assert result.confidence == 'rejected'
     assert 'shadow direction' in (result.rejection_reason or '').lower()
+    # The dialog uses this flag to surface a "Use anyway" button.
+    assert result.azimuth_override_available is True
+
+
+def test_azimuth_override_demotes_rejection_to_warning(monkeypatch):
+    """With override on, an off-azimuth click yields a warning, not a reject."""
+    base = ('b',)
+    tip = ('t',)
+    # Same off-direction geometry as the rejection test above.
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (0.0, 2.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip,
+        allow_azimuth_override=True,
+    )
+    assert result.confidence == 'warning'
+    assert result.height_m is not None
+    assert any('override accepted' in w.lower() for w in result.warnings)
+
+
+def test_azimuth_override_only_relaxes_azimuth(monkeypatch):
+    """Override must NOT rescue a sun-too-low or other gate failure."""
+    base = ('b',)
+    tip = ('t',)
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (-2.0, 0.0, 100.0),  # aligned with expected shadow direction
+    })
+    _install(monkeypatch, scene, sun_elev_deg=3.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip,
+        allow_azimuth_override=True,
+    )
+    assert result.confidence == 'rejected'
+    assert 'too low' in (result.rejection_reason or '').lower()
 
 
 def test_sun_too_low_rejects(monkeypatch):

--- a/app/tests/core/services/shadow/test_shadow_height_estimator.py
+++ b/app/tests/core/services/shadow/test_shadow_height_estimator.py
@@ -1,0 +1,431 @@
+"""Tests for ShadowHeightEstimator.
+
+AOIService and pysolar are stubbed so each test exercises only the
+geometry inside the estimator. The integration with real EXIF/DEM/sun
+data is verified by the smoke test against a known capture.
+"""
+
+import math
+from datetime import datetime, timezone
+from typing import Optional, Tuple
+
+import piexif
+import pytest
+import utm
+
+import core.services.shadow.ShadowHeightEstimator as she_module
+from core.services.image.AOIService import AOIGPSResult
+from core.services.shadow.ShadowHeightEstimator import (
+    ShadowHeightEstimator,
+    ShadowHeightResult,
+)
+
+
+# El Dorado Hills, CA — used as the anchor location for synthetic scenes.
+ANCHOR_LAT = 38.685
+ANCHOR_LON = -121.082
+
+# Anchor in UTM so test scenes can round-trip exactly through the same
+# projection the estimator uses (utm.from_latlon). Avoids sub-degree
+# azimuth drift from a sphere-vs-ellipsoid mismatch.
+_ANCHOR_EAST, _ANCHOR_NORTH, _ANCHOR_ZONE_NO, _ANCHOR_ZONE_LETTER = utm.from_latlon(
+    ANCHOR_LAT, ANCHOR_LON
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_exif(monkeypatch):
+    """Make EXIF reads return a canned GPS-stamped exif dict."""
+
+    def fake_exif(_path):
+        return {
+            '0th': {},
+            'Exif': {},
+            'GPS': {
+                piexif.GPSIFD.GPSDateStamp: b'2025:06:15',
+                piexif.GPSIFD.GPSTimeStamp: ((19, 1), (30, 1), (0, 1)),
+            },
+        }
+
+    monkeypatch.setattr(
+        she_module.MetaDataHelper, 'get_exif_data_piexif', fake_exif
+    )
+
+
+class _FakeImageService:
+    """Mimics the slice of ImageService that the sigma estimator touches."""
+
+    def __init__(self):
+        # Real-ish drone optics: 1/2.3" sensor, 24mm equiv, 4000 px wide.
+        self.img_array = None
+
+    def get_camera_intrinsics(self):
+        return None  # forces estimator to fall back to its 1 m sigma default
+
+
+class _FakeAOIService:
+    """Returns canned AOIGPSResult per pixel; never touches disk or EXIF."""
+
+    def __init__(self, scene):
+        self._scene = scene
+        self.image_service = _FakeImageService()
+
+    def estimate_aoi_gps(self, _image, aoi, **_):
+        return self._scene.project(aoi['center'])
+
+
+class _Scene:
+    """Translates pixel clicks into (lat, lon, elev) ground positions.
+
+    The "shadow geometry" is defined directly in metres relative to the
+    anchor; pixels are just keys into a dict of points the test sets up.
+    """
+
+    def __init__(
+        self,
+        points: dict,
+        elevation_source: str = 'terrain',
+        terrain_resolution_m: float = 1.0,
+        effective_agl_m: float = 100.0,
+    ):
+        self._points = points
+        self._source = elevation_source
+        self._res = terrain_resolution_m
+        self._agl = effective_agl_m
+
+    def project(self, pixel) -> Optional[AOIGPSResult]:
+        if pixel not in self._points:
+            return None
+        east_m, north_m, elev_m = self._points[pixel]
+        lat, lon = utm.to_latlon(
+            _ANCHOR_EAST + east_m,
+            _ANCHOR_NORTH + north_m,
+            _ANCHOR_ZONE_NO,
+            _ANCHOR_ZONE_LETTER,
+        )
+        return AOIGPSResult(
+            latitude=lat,
+            longitude=lon,
+            elevation_source=self._source,
+            terrain_elevation_m=elev_m if self._source == 'terrain' else None,
+            effective_agl_m=self._agl,
+            terrain_resolution_m=self._res if self._source == 'terrain' else None,
+        )
+
+
+def _install(monkeypatch, scene: _Scene, sun_elev_deg: float, sun_az_deg: float):
+    """Patch the AOIService class and pysolar wrapper used by the estimator."""
+
+    def fake_aoi_service(_image, *args, **kwargs):
+        return _FakeAOIService(scene)
+
+    def fake_solar(_lat, _lon, _utc):
+        return sun_elev_deg, sun_az_deg
+
+    monkeypatch.setattr(she_module, 'AOIService', fake_aoi_service)
+    monkeypatch.setattr(she_module, 'get_solar_position', fake_solar)
+
+
+# ---------------------------------------------------------------------------
+# Flat-terrain geometry
+# ---------------------------------------------------------------------------
+
+def test_flat_ground_45deg_sun_yields_height_equal_to_shadow(monkeypatch):
+    """alpha=45° -> H = d_h."""
+    # Sun due east (az=90°) -> shadow points due west; base east of tip by 2 m.
+    base = (1, 1)
+    tip = (2, 2)
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (-2.0, 0.0, 100.0),  # 2 m west of base
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence in ('ok', 'warning'), result.rejection_reason
+    assert result.height_m == pytest.approx(2.0, abs=0.02)
+    assert result.elev_delta_m == pytest.approx(0.0, abs=0.01)
+    assert result.horizontal_dist_m == pytest.approx(2.0, abs=0.02)
+
+
+def test_flat_ground_30deg_sun(monkeypatch):
+    """alpha=30°, d_h=sqrt(3) -> H = 1 m."""
+    base = ('b',)
+    tip = ('t',)
+    scene = _Scene({
+        base: (0.0, 0.0, 50.0),
+        tip:  (0.0, -math.sqrt(3.0), 50.0),  # shadow extends south
+    })
+    # Sun due north (az=0) -> shadow points south (expected az 180).
+    _install(monkeypatch, scene, sun_elev_deg=30.0, sun_az_deg=0.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'ok'
+    assert result.height_m == pytest.approx(1.0, abs=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Sloping-terrain correction
+# ---------------------------------------------------------------------------
+
+def test_uphill_slope_adds_to_height(monkeypatch):
+    """Tip uphill (delta_h > 0) -> H exceeds the flat-ground estimate."""
+    base = ('b',)
+    tip = ('t',)
+    # Shadow tip is 4 m west and 1 m higher than base.
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (-4.0, 0.0, 101.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'ok'
+    # H = 1 (slope) + 4 * tan(45) = 5 m
+    assert result.height_m == pytest.approx(5.0, abs=0.02)
+    assert result.elev_delta_m == pytest.approx(1.0, abs=0.01)
+
+
+def test_downhill_slope_subtracts_from_height(monkeypatch):
+    """Tip downhill (delta_h < 0) -> H less than the flat-ground estimate."""
+    base = ('b',)
+    tip = ('t',)
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (-4.0, 0.0, 99.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'ok'
+    # H = -1 + 4 * tan(45) = 3 m
+    assert result.height_m == pytest.approx(3.0, abs=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Confidence gates
+# ---------------------------------------------------------------------------
+
+def test_azimuth_within_5deg_is_ok(monkeypatch):
+    """Drawn line within tolerance of expected shadow azimuth -> ok."""
+    base = ('b',)
+    tip = ('t',)
+    # Sun azimuth 90 -> expected shadow azimuth 270 (west).
+    # Place tip 2 m west, no offset -> measured az ~270.
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (-2.0, 0.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'ok'
+    assert abs(result.delta_az_deg) < 1.0
+
+
+def test_azimuth_between_5_and_15_is_warning(monkeypatch):
+    """8° off expected -> warning, but still computes a height."""
+    base = ('b',)
+    tip = ('t',)
+    # 8° offset from due-west: rotate (-2, 0) by 8° CCW about origin.
+    theta = math.radians(8.0)
+    dx = -2.0 * math.cos(theta) - 0.0 * math.sin(theta)
+    dy = -2.0 * math.sin(theta) + 0.0 * math.cos(theta)
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (dx, dy, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'warning'
+    assert result.height_m is not None
+    assert 5.0 < abs(result.delta_az_deg) <= 15.0
+
+
+def test_azimuth_off_by_90deg_rejects(monkeypatch):
+    """Drawn perpendicular to expected shadow direction -> reject."""
+    base = ('b',)
+    tip = ('t',)
+    # Sun east, expected shadow west; draw tip north of base instead.
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (0.0, 2.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'rejected'
+    assert 'shadow direction' in (result.rejection_reason or '').lower()
+
+
+def test_sun_too_low_rejects(monkeypatch):
+    scene = _Scene({
+        ('b',): (0.0, 0.0, 100.0),
+        ('t',): (-2.0, 0.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=3.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+    assert result.confidence == 'rejected'
+    assert 'too low' in (result.rejection_reason or '').lower()
+
+
+def test_sun_too_high_rejects(monkeypatch):
+    scene = _Scene({
+        ('b',): (0.0, 0.0, 100.0),
+        ('t',): (-2.0, 0.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=88.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+    assert result.confidence == 'rejected'
+    assert 'overhead' in (result.rejection_reason or '').lower()
+
+
+def test_degenerate_clicks_reject(monkeypatch):
+    """Same projected ground point twice -> reject."""
+    p = ('p',)
+    scene = _Scene({p: (0.0, 0.0, 100.0)})
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=p, tip_px=p
+    )
+    assert result.confidence == 'rejected'
+    assert 'same ground point' in (result.rejection_reason or '').lower()
+
+
+def test_reversed_click_order_rejects(monkeypatch):
+    """If base is east of tip but sun is east, the implied shadow goes east -> mismatch."""
+    base = ('b',)
+    tip = ('t',)
+    # Sun east (az=90), expected shadow points west (az=270).
+    # User swapped clicks: "base" is actually the shadow tip, "tip" is the object base.
+    # measured az = base->tip direction = east (az=90) — 180° off expected.
+    scene = _Scene({
+        base: (0.0, 0.0, 100.0),
+        tip:  (2.0, 0.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=base, tip_px=tip
+    )
+    assert result.confidence == 'rejected'
+
+
+# ---------------------------------------------------------------------------
+# Time / EXIF handling
+# ---------------------------------------------------------------------------
+
+def test_unresolvable_time_rejects(monkeypatch):
+    monkeypatch.setattr(
+        she_module.MetaDataHelper,
+        'get_exif_data_piexif',
+        lambda _p: {'0th': {}, 'GPS': {}, 'Exif': {}},
+    )
+    scene = _Scene({
+        ('b',): (0.0, 0.0, 100.0),
+        ('t',): (-2.0, 0.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+    assert result.confidence == 'rejected'
+    assert 'capture time' in (result.rejection_reason or '').lower()
+
+
+def test_aoi_projection_failure_rejects(monkeypatch):
+    """If AOIService can't project (e.g. missing metadata) -> reject."""
+    scene = _Scene({('b',): (0.0, 0.0, 100.0)})  # tip not in scene
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+    assert result.confidence == 'rejected'
+    assert 'project' in (result.rejection_reason or '').lower()
+
+
+def test_flat_terrain_warning_when_no_dem(monkeypatch):
+    """No DEM -> estimator falls back to flat ground and warns."""
+    scene = _Scene(
+        {
+            ('b',): (0.0, 0.0, 0.0),
+            ('t',): (-2.0, 0.0, 0.0),
+        },
+        elevation_source='flat',
+    )
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+    assert result.confidence == 'warning'
+    assert result.height_m == pytest.approx(2.0, abs=0.02)
+    assert any('flat terrain' in w.lower() for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty propagation
+# ---------------------------------------------------------------------------
+
+def test_sigma_is_positive_and_reasonable(monkeypatch):
+    """σ_H should be finite, positive, and small compared to H for a clean case."""
+    scene = _Scene({
+        ('b',): (0.0, 0.0, 100.0),
+        ('t',): (-2.0, 0.0, 100.0),
+    })
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+
+    result = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+    assert result.sigma_m is not None
+    assert 0.0 < result.sigma_m < result.height_m  # noise smaller than signal
+
+
+def test_sigma_grows_toward_zenith(monkeypatch):
+    """sec²α blows up as the sun nears zenith -> absolute σ_H grows there.
+
+    (Counter-intuitive: low sun gives a small absolute σ but a huge
+    *relative* σ because H itself shrinks toward zero. The rejection at
+    α < 5° is about that ratio, not the absolute sigma.)
+    """
+    scene = _Scene({
+        ('b',): (0.0, 0.0, 100.0),
+        ('t',): (-2.0, 0.0, 100.0),
+    })
+
+    _install(monkeypatch, scene, sun_elev_deg=45.0, sun_az_deg=90.0)
+    mid = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+
+    _install(monkeypatch, scene, sun_elev_deg=80.0, sun_az_deg=90.0)
+    high = ShadowHeightEstimator().estimate(
+        {'path': '/fake'}, base_px=('b',), tip_px=('t',)
+    )
+
+    assert high.sigma_m > mid.sigma_m

--- a/app/tests/core/services/shadow/test_solar_position.py
+++ b/app/tests/core/services/shadow/test_solar_position.py
@@ -95,6 +95,52 @@ def test_resolve_utc_rejects_when_nothing_present():
         resolve_capture_utc({'0th': {}, 'GPS': {}, 'Exif': {}})
 
 
+def test_resolve_utc_from_xmp_create_date():
+    """DJI puts the timezone offset in XMP, not in OffsetTimeOriginal."""
+    exif = {'0th': {}, 'GPS': {}, 'Exif': {}}
+    xmp = {'CreateDate': '2026-01-18T12:15:08-08:00'}
+    utc, source = resolve_capture_utc(exif, xmp)
+    assert source == 'xmp_create_date'
+    assert utc == datetime(2026, 1, 18, 20, 15, 8, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_xmp_modify_date_fallback():
+    """If CreateDate is missing, fall through to ModifyDate."""
+    exif = {'0th': {}, 'GPS': {}, 'Exif': {}}
+    xmp = {'ModifyDate': '2026-01-18T12:15:08-08:00'}
+    utc, source = resolve_capture_utc(exif, xmp)
+    assert source == 'xmp_modify_date'
+    assert utc == datetime(2026, 1, 18, 20, 15, 8, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_xmp_z_suffix_works():
+    """ISO 8601 'Z' should be accepted as UTC."""
+    exif = {'0th': {}, 'GPS': {}, 'Exif': {}}
+    utc, _ = resolve_capture_utc(exif, {'CreateDate': '2026-01-18T20:15:08Z'})
+    assert utc == datetime(2026, 1, 18, 20, 15, 8, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_xmp_naive_rejected():
+    """An XMP timestamp without an offset must NOT be silently accepted."""
+    exif = {'0th': {}, 'GPS': {}, 'Exif': {}}
+    with pytest.raises(SolarTimeUnresolvable):
+        resolve_capture_utc(exif, {'CreateDate': '2026-01-18T12:15:08'})
+
+
+def test_resolve_utc_gps_still_wins_over_xmp():
+    exif = {
+        '0th': {},
+        'GPS': {
+            piexif.GPSIFD.GPSDateStamp: b'2025:06:15',
+            piexif.GPSIFD.GPSTimeStamp: ((19, 1), (30, 1), (0, 1)),
+        },
+        'Exif': {},
+    }
+    xmp = {'CreateDate': '2026-01-18T12:15:08-08:00'}
+    _, source = resolve_capture_utc(exif, xmp)
+    assert source == 'gps'
+
+
 def test_get_solar_position_requires_aware_datetime():
     with pytest.raises(ValueError):
         get_solar_position(38.685, -121.082, datetime(2025, 6, 15, 19, 30))

--- a/app/tests/core/services/shadow/test_solar_position.py
+++ b/app/tests/core/services/shadow/test_solar_position.py
@@ -1,0 +1,115 @@
+"""Tests for SolarPosition wrapper + EXIF UTC resolution."""
+
+from datetime import datetime, timezone
+
+import piexif
+import pytest
+
+from core.services.shadow.SolarPosition import (
+    get_solar_position,
+    resolve_capture_utc,
+    SolarTimeUnresolvable,
+)
+
+
+def _make_gps_exif(date_bytes, time_rationals):
+    return {
+        '0th': {},
+        'Exif': {},
+        'GPS': {
+            piexif.GPSIFD.GPSDateStamp: date_bytes,
+            piexif.GPSIFD.GPSTimeStamp: time_rationals,
+        },
+    }
+
+
+def _make_offset_exif(dt_bytes, offset_bytes):
+    return {
+        '0th': {},
+        'GPS': {},
+        'Exif': {
+            piexif.ExifIFD.DateTimeOriginal: dt_bytes,
+            piexif.ExifIFD.OffsetTimeOriginal: offset_bytes,
+        },
+    }
+
+
+def test_resolve_utc_from_gps_stamps():
+    exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (0, 1)))
+    utc, source = resolve_capture_utc(exif)
+    assert source == 'gps'
+    assert utc == datetime(2025, 6, 15, 19, 30, 0, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_from_gps_with_fractional_seconds():
+    # 19h, 30m, 15.5s
+    exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (155, 10)))
+    utc, _ = resolve_capture_utc(exif)
+    assert utc.second == 15
+    assert utc.microsecond == 500_000
+
+
+def test_resolve_utc_from_datetime_with_offset_west():
+    exif = _make_offset_exif(b'2025:06:15 12:30:00', b'-07:00')
+    utc, source = resolve_capture_utc(exif)
+    assert source == 'exif_with_offset'
+    assert utc == datetime(2025, 6, 15, 19, 30, 0, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_from_datetime_with_offset_east():
+    exif = _make_offset_exif(b'2025:06:15 12:30:00', b'+05:30')
+    utc, _ = resolve_capture_utc(exif)
+    assert utc == datetime(2025, 6, 15, 7, 0, 0, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_prefers_gps_over_offset():
+    exif = {
+        '0th': {},
+        'GPS': {
+            piexif.GPSIFD.GPSDateStamp: b'2025:06:15',
+            piexif.GPSIFD.GPSTimeStamp: ((19, 1), (0, 1), (0, 1)),
+        },
+        'Exif': {
+            piexif.ExifIFD.DateTimeOriginal: b'2025:06:15 12:30:00',
+            piexif.ExifIFD.OffsetTimeOriginal: b'-07:00',
+        },
+    }
+    _, source = resolve_capture_utc(exif)
+    assert source == 'gps'
+
+
+def test_resolve_utc_rejects_when_only_naive_datetime():
+    exif = {
+        '0th': {},
+        'GPS': {},
+        'Exif': {
+            piexif.ExifIFD.DateTimeOriginal: b'2025:06:15 12:30:00',
+        },
+    }
+    with pytest.raises(SolarTimeUnresolvable):
+        resolve_capture_utc(exif)
+
+
+def test_resolve_utc_rejects_when_nothing_present():
+    with pytest.raises(SolarTimeUnresolvable):
+        resolve_capture_utc({'0th': {}, 'GPS': {}, 'Exif': {}})
+
+
+def test_get_solar_position_requires_aware_datetime():
+    with pytest.raises(ValueError):
+        get_solar_position(38.685, -121.082, datetime(2025, 6, 15, 19, 30))
+
+
+def test_get_solar_position_returns_sane_values():
+    # El Dorado Hills, CA, summer afternoon — sun should be high and SE-ish.
+    dt = datetime(2025, 6, 15, 19, 30, 0, tzinfo=timezone.utc)
+    elev, az = get_solar_position(38.685, -121.082, dt)
+    assert 60.0 < elev < 80.0
+    assert 120.0 < az < 200.0
+
+
+def test_get_solar_position_below_horizon_at_night():
+    # Same spot, ~06:00 UTC = ~11pm PDT prior day — sun should be below horizon.
+    dt = datetime(2025, 6, 15, 6, 0, 0, tzinfo=timezone.utc)
+    elev, _ = get_solar_position(38.685, -121.082, dt)
+    assert elev < 0.0

--- a/app/tests/core/services/test_camera_model.py
+++ b/app/tests/core/services/test_camera_model.py
@@ -1,0 +1,121 @@
+"""Unit tests for core.services.CameraModel."""
+
+import math
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from core.services.CameraModel import CameraModel
+
+WIDTH = 4000
+HEIGHT = 3000
+FOCAL_MM = 24.0
+SENSOR_W = 23.5
+SENSOR_H = 15.6
+AGL = 100.0
+
+
+def _nadir():
+    return CameraModel(AGL, -90.0, 0.0, FOCAL_MM, SENSOR_W, SENSOR_H, WIDTH, HEIGHT)
+
+
+def _oblique(pitch_deg=-45.0, yaw_deg=0.0):
+    return CameraModel(AGL, pitch_deg, yaw_deg, FOCAL_MM, SENSOR_W, SENSOR_H, WIDTH, HEIGHT)
+
+
+def test_nadir_projects_ground_point_to_centre():
+    cam = _nadir()
+    u, v = cam.project(0.0, 0.0, AGL)
+    assert u == pytest.approx(WIDTH / 2.0, abs=1e-6)
+    assert v == pytest.approx(HEIGHT / 2.0, abs=1e-6)
+
+
+def test_nadir_east_is_right_north_is_up():
+    cam = _nadir()
+    u_east, v_east = cam.project(0.0, 10.0, AGL)
+    u_north, v_north = cam.project(10.0, 0.0, AGL)
+    # East of nadir -> right of centre; North of nadir -> above centre.
+    assert u_east > WIDTH / 2.0
+    assert v_east == pytest.approx(HEIGHT / 2.0, abs=1e-6)
+    assert v_north < HEIGHT / 2.0
+    assert u_north == pytest.approx(WIDTH / 2.0, abs=1e-6)
+
+
+def test_pixel_to_ground_centre():
+    cam = _nadir()
+    north, east, down = cam.pixel_to_ground(WIDTH / 2.0, HEIGHT / 2.0)
+    assert north == pytest.approx(0.0, abs=1e-6)
+    assert east == pytest.approx(0.0, abs=1e-6)
+    assert down == pytest.approx(AGL, abs=1e-6)
+
+
+def test_pixel_to_ground_project_roundtrip():
+    for cam in (_nadir(), _oblique(-50.0, 30.0)):
+        for u, v in [(2500, 1200), (1000, 2000), (2000, 1500)]:
+            ground = cam.pixel_to_ground(u, v)
+            assert ground is not None
+            back = cam.project(*ground)
+            assert back is not None
+            assert back[0] == pytest.approx(u, abs=1e-3)
+            assert back[1] == pytest.approx(v, abs=1e-3)
+
+
+def test_standing_person_at_nadir_head_over_feet():
+    """Straight down on a person: head and feet land on the same pixel."""
+    cam = _nadir()
+    feet = cam.project(0.0, 0.0, AGL)
+    head = cam.project(0.0, 0.0, AGL - 1.8)  # 1.8 m tall
+    assert head[0] == pytest.approx(feet[0], abs=1e-6)
+    assert head[1] == pytest.approx(feet[1], abs=1e-6)
+
+
+def test_oblique_view_foreshortens_standing_person():
+    """At an oblique angle a standing person's head projects above the feet."""
+    cam = _oblique(-45.0, 0.0)
+    # Foot point seen through the centre pixel of a 45-degree oblique frame.
+    foot = cam.pixel_to_ground(WIDTH / 2.0, HEIGHT / 2.0)
+    assert foot is not None
+    feet_px = cam.project(*foot)
+    head_px = cam.project(foot[0], foot[1], foot[2] - 1.8)
+    # Head appears clearly above the feet, with no sideways shift.
+    assert head_px[1] < feet_px[1] - 5.0
+    assert head_px[0] == pytest.approx(feet_px[0], abs=1.0)
+
+
+def test_point_behind_camera_returns_none():
+    cam = _nadir()
+    # A point above the camera (negative down) is behind the optical axis.
+    assert cam.project(0.0, 0.0, -10.0) is None
+
+
+def test_invalid_construction_raises():
+    with pytest.raises(ValueError):
+        CameraModel(0.0, -90.0, 0.0, FOCAL_MM, SENSOR_W, SENSOR_H, WIDTH, HEIGHT)
+    with pytest.raises(ValueError):
+        CameraModel(AGL, -90.0, 0.0, FOCAL_MM, SENSOR_W, SENSOR_H, 0, HEIGHT)
+
+
+def test_from_image_service():
+    service = MagicMock()
+    service.get_camera_intrinsics.return_value = {
+        'focal_length_mm': FOCAL_MM,
+        'sensor_width_mm': SENSOR_W,
+        'sensor_height_mm': SENSOR_H,
+    }
+    service.get_relative_altitude.return_value = AGL
+    service.get_camera_pitch.return_value = -90.0
+    service.get_camera_yaw.return_value = 0.0
+    service.img_array = np.zeros((HEIGHT, WIDTH, 3), dtype=np.uint8)
+
+    cam = CameraModel.from_image_service(service)
+    assert cam is not None
+    u, v = cam.project(0.0, 0.0, AGL)
+    assert u == pytest.approx(WIDTH / 2.0, abs=1e-6)
+    assert v == pytest.approx(HEIGHT / 2.0, abs=1e-6)
+
+
+def test_from_image_service_missing_intrinsics_returns_none():
+    service = MagicMock()
+    service.get_camera_intrinsics.return_value = None
+    assert CameraModel.from_image_service(service) is None

--- a/app/tests/core/services/test_person_model.py
+++ b/app/tests/core/services/test_person_model.py
@@ -1,0 +1,43 @@
+"""Unit tests for core.services.PersonModel."""
+
+import pytest
+
+from core.services.PersonModel import (
+    build_points,
+    build_sitting_points,
+    build_standing_points,
+)
+
+
+def test_standing_points_span_full_height():
+    points = build_standing_points(1.8)
+    zs = [p[2] for p in points]
+    assert min(zs) == pytest.approx(0.0, abs=1e-9)
+    assert max(zs) == pytest.approx(1.8, abs=1e-6)
+
+
+def test_standing_points_shoulder_width():
+    points = build_standing_points(1.8)
+    max_half_width = max(abs(p[0]) for p in points)
+    assert max_half_width == pytest.approx(0.130 * 1.8, rel=0.01)
+
+
+def test_sitting_is_shorter_than_standing():
+    standing = build_standing_points(1.8)
+    sitting = build_sitting_points(1.8)
+    assert max(p[2] for p in sitting) < max(p[2] for p in standing)
+    assert min(p[2] for p in sitting) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_build_points_dispatch():
+    assert build_points(1.8, "standing") == build_standing_points(1.8)
+    assert build_points(1.8, "sitting") == build_sitting_points(1.8)
+    with pytest.raises(ValueError):
+        build_points(1.8, "recumbent")
+
+
+def test_points_are_nonempty_3d_tuples():
+    for pose in ("standing", "sitting"):
+        points = build_points(1.8, pose)
+        assert len(points) > 20
+        assert all(len(p) == 3 for p in points)

--- a/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
@@ -245,6 +245,57 @@ def test_measure_dialog_initialization(app):
     assert dialog is not None
 
 
+def test_measure_dialog_starts_in_length_mode(app):
+    """Shadow checkbox is off and the length-mode groups are visible by default."""
+    mock_image_viewer = MagicMock()
+    mock_image_viewer.canZoom = True
+    mock_image_viewer.canPan = True
+    mock_image_viewer.regionZoomButton = MagicMock()
+
+    dialog = MeasureDialog(None, mock_image_viewer, 5.0, 'm')
+    assert dialog.shadow_mode is False
+    assert dialog.shadow_mode_checkbox.isChecked() is False
+    assert dialog.gsd_group.isVisibleTo(dialog) is True
+    assert dialog.distance_group.isVisibleTo(dialog) is True
+    assert dialog.shadow_group.isVisibleTo(dialog) is False
+
+
+def test_measure_dialog_toggles_into_shadow_mode(app):
+    """Toggling the checkbox swaps which result groups are shown."""
+    mock_image_viewer = MagicMock()
+    mock_image_viewer.canZoom = True
+    mock_image_viewer.canPan = True
+    mock_image_viewer.regionZoomButton = MagicMock()
+
+    dialog = MeasureDialog(None, mock_image_viewer, 5.0, 'm')
+    dialog.shadow_mode_checkbox.setChecked(True)
+
+    assert dialog.shadow_mode is True
+    assert dialog.gsd_group.isVisibleTo(dialog) is False
+    assert dialog.distance_group.isVisibleTo(dialog) is False
+    assert dialog.shadow_group.isVisibleTo(dialog) is True
+    assert "Shadow" in dialog.windowTitle()
+
+
+def test_measure_dialog_toggle_clears_in_flight_measurement(app):
+    """Switching modes mid-measurement should reset state, not carry it across."""
+    mock_image_viewer = MagicMock()
+    mock_image_viewer.canZoom = True
+    mock_image_viewer.canPan = True
+    mock_image_viewer.regionZoomButton = MagicMock()
+    mock_image_viewer.scene = MagicMock()
+
+    dialog = MeasureDialog(None, mock_image_viewer, 5.0, 'm')
+    # Simulate the first click of a length measurement.
+    dialog.first_point = object()
+    dialog.measuring = True
+
+    dialog.shadow_mode_checkbox.setChecked(True)
+
+    assert dialog.first_point is None
+    assert dialog.measuring is False
+
+
 def test_pdf_export_dialog_initialization(app):
     """Test PDFExportDialog initialization."""
     dialog = PDFExportDialog(None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ imagecodecs
 imageio-ffmpeg
 rasterio
 pyproj
+pysolar


### PR DESCRIPTION
This PR adds two related photogrammetry features. They are submitted together because the Person Size Reference rework reuses the `SolarPosition` service introduced by the shadow-measurement work — the two share that code and cannot be cleanly split into independent PRs.

## Person Size Reference — perspective overlay

Reworks the Person Size Reference tool (Ctrl+P). The reference person is now drawn by projecting a 3D body model through a camera model built from the image's metadata pose, instead of a flat top-down silhouette scaled by GSD.

- **Perspective-correct** — silhouettes foreshorten at oblique gimbal angles and toward the frame edges. A standing person near an oblique edge reads as an upright, side-on figure rather than a top-down blob.
- **Standing, lying-down and sitting** poses can be shown at the same time.
- **Shadows** — every shown pose casts a shadow from the true sun position at the image's capture time (EXIF).
- **Rotation control** — a degree spin box to line a pose up with an object in the image; the shadows follow the rotation.
- **DEM/terrain toggle** — places the person and shadows on the DEM terrain surface (a person on high ground is sized larger, one in a valley smaller) and slope-corrects shadow length. Falls back to flat ground, and the toggle disables itself, when no DEM covers the image.

New modules, with unit tests: `CameraModel` (3D world-point → image-pixel projection), `PersonModel` (3D person geometry), `core/services/shadow/PersonShadow` (sun-cast shadow geometry).

## Shadow-based height measurement

Included because the perspective tool above builds on it. Adds shadow-based object height estimation to the Measure dialog: the user clicks an object's base and its shadow tip, and the height is solved from the solar geometry at the image's capture time.

New modules, with unit tests: `core/services/shadow/SolarPosition` (EXIF capture time → sun elevation/azimuth, via `pysolar`), `core/services/shadow/ShadowHeightEstimator`.

## Testing

New unit tests cover `CameraModel`, `PersonModel`, `PersonShadow`, `SolarPosition` and `ShadowHeightEstimator`. The full test suite passes apart from pre-existing end-to-end algorithm tests that require local test imagery not present in this environment — those failures are unrelated to this change.
