### PR TITLE
feat: AOI improvements (run-wide numbers, jump-to-AOI, on-image ruler)

### DIFF
--- a/app/core/controllers/images/viewer/AOIOverlayController.py
+++ b/app/core/controllers/images/viewer/AOIOverlayController.py
@@ -1,0 +1,287 @@
+"""
+AOIOverlayController - Manages the on-image selected-AOI decoration.
+
+Owns the AOISelectionOverlay graphics item and decides when it is shown:
+it appears for the AOI the reviewer last clicked, carries that AOI's
+run-wide number, and shows a real-world ruler when ground sample distance
+is available. The decoration is tied to the AOI circle toggle, so hiding
+the circles also hides the number badge and ruler.
+
+It also handles the ruler's grab handle: a viewport event filter lets the
+reviewer drag the handle to swing the ruler around the AOI centre so it
+aligns with the object being measured. The rotation is clamped to 90
+degrees each way and resets whenever a different AOI is selected.
+"""
+
+import math
+
+from PySide6.QtCore import QObject, QEvent, Qt
+
+from core.services.LoggerService import LoggerService
+from core.views.images.viewer.widgets.AOISelectionOverlay import (
+    AOISelectionOverlay, build_ruler_model, ruler_angle_from_drag,
+)
+
+
+# Grab tolerance for the ruler handle, in screen pixels.
+_HANDLE_GRAB_RADIUS = 16
+
+
+class AOIOverlayController(QObject):
+    """Controller for the selected-AOI on-image overlay (number + ruler)."""
+
+    def __init__(self, parent_viewer):
+        """Initialize the overlay controller.
+
+        Args:
+            parent_viewer: The main Viewer instance.
+        """
+        super().__init__()
+        self.parent = parent_viewer
+        self.logger = LoggerService()
+        # The graphics item is created lazily once the scene is available.
+        self._overlay_item = None
+        # The AOI dict currently decorated, or None when nothing is selected.
+        self._current_aoi = None
+        # Ruler grab-handle drag state.
+        self._dragging = False
+        self._drag_offset = 90.0
+        self._filter_installed = False
+
+    def show_for_aoi(self, aoi):
+        """Decorate the given AOI on the main image.
+
+        A new selection always starts with a horizontal ruler.
+
+        Args:
+            aoi (dict): The AOI dictionary (needs 'center'; 'radius' and
+                'number' are used when present).
+        """
+        self._current_aoi = aoi if isinstance(aoi, dict) else None
+        if self._current_aoi is not None and self._ensure_item():
+            self._overlay_item.reset_ruler_angle()
+        self.refresh()
+
+    def clear(self):
+        """Remove the decoration and forget the current AOI."""
+        self._current_aoi = None
+        self._dragging = False
+        if self._overlay_item is not None:
+            self._overlay_item.set_dragging(False)
+            self._overlay_item.hide()
+
+    def refresh(self):
+        """Redraw the decoration for the current AOI, honoring the toggles.
+
+        Safe to call at any time. The decoration is hidden when there is no
+        selected AOI or when AOI circles are turned off, and the ruler is
+        omitted when no ground sample distance is available for the image.
+        The ruler angle is preserved so a refresh does not undo a rotation.
+        """
+        aoi = self._current_aoi
+        if not aoi or not aoi.get('center'):
+            self._hide_item()
+            return
+
+        # The ruler is tied to the AOI circles: hiding the circles hides it.
+        if not self._aoi_circles_visible():
+            self._hide_item()
+            return
+
+        if not self._ensure_item():
+            return
+
+        radius = aoi.get('radius', 0) or 0
+        ruler_model = build_ruler_model(
+            radius, self._current_gsd_cm(), self._distance_unit()
+        )
+        self._overlay_item.configure(
+            aoi.get('center'), radius, aoi.get('number'), ruler_model
+        )
+        self._overlay_item.show()
+
+    def _hide_item(self):
+        """Hide the overlay item if it exists."""
+        if self._overlay_item is not None:
+            self._overlay_item.hide()
+
+    def _ensure_item(self):
+        """Create the overlay item and attach it to the scene if needed.
+
+        Returns:
+            bool: True when the overlay item is available for use.
+        """
+        if self._overlay_item is not None:
+            return True
+
+        main_image = getattr(self.parent, 'main_image', None)
+        if main_image is None or getattr(main_image, '_is_destroyed', False):
+            return False
+        scene = getattr(main_image, 'scene', None)
+        if scene is None:
+            return False
+
+        self._overlay_item = AOISelectionOverlay()
+        scene.addItem(self._overlay_item)
+        # Repaint crisply whenever the view zooms, since the badge, ticks,
+        # labels and handle are kept at a constant on-screen size.
+        try:
+            main_image.zoomChanged.connect(self._on_zoom_changed)
+        except Exception:
+            pass
+        # Watch the viewport for grab-handle drags. The event filter only
+        # consumes a press that lands on the handle, so panning, region
+        # zoom and AOI clicks elsewhere are unaffected.
+        if not self._filter_installed:
+            try:
+                main_image.viewport().installEventFilter(self)
+                self._filter_installed = True
+            except Exception:
+                pass
+        return True
+
+    def _on_zoom_changed(self, _zoom):
+        """Force a repaint when the view zoom changes."""
+        if self._overlay_item is not None and self._overlay_item.isVisible():
+            self._overlay_item.update()
+
+    # ------------------------------------------------------------------ #
+    #  Grab-handle drag handling
+    # ------------------------------------------------------------------ #
+    def eventFilter(self, obj, event):
+        """Drag the ruler handle when the press lands on it.
+
+        Returns True (consuming the event) only while a handle drag is in
+        progress, so all other viewport interaction is left untouched.
+        """
+        item = self._overlay_item
+        if item is not None and item.isVisible() and item.has_ruler():
+            event_type = event.type()
+            if (event_type == QEvent.MouseButtonPress
+                    and event.button() == Qt.LeftButton):
+                if self._is_on_handle(event):
+                    self._begin_drag(event)
+                    return True
+            elif event_type == QEvent.MouseMove and self._dragging:
+                self._apply_drag(event)
+                return True
+            elif event_type == QEvent.MouseButtonRelease and self._dragging:
+                self._end_drag()
+                return True
+        return super().eventFilter(obj, event)
+
+    def _event_scene_pos(self, event):
+        """Map a viewport mouse event to scene coordinates, or None."""
+        main_image = getattr(self.parent, 'main_image', None)
+        if main_image is None:
+            return None
+        try:
+            return main_image.mapToScene(event.position().toPoint())
+        except Exception:
+            return None
+
+    def _is_on_handle(self, event):
+        """Return True when the mouse event lands on the ruler grab handle."""
+        scene_pos = self._event_scene_pos(event)
+        if scene_pos is None:
+            return False
+        handle = self._overlay_item.handle_scene_pos()
+        zoom = self.parent.main_image.getZoom() or 1.0
+        tolerance = _HANDLE_GRAB_RADIUS / zoom   # screen pixels -> scene units
+        dx = scene_pos.x() - handle.x()
+        dy = scene_pos.y() - handle.y()
+        return (dx * dx + dy * dy) <= tolerance * tolerance
+
+    def _begin_drag(self, event):
+        """Start a handle drag, recording the grab offset to avoid a jump."""
+        dx, dy = self._drag_vector(event)
+        if dx is None:
+            return
+        cursor_angle = math.degrees(math.atan2(dy, dx)) if (dx or dy) else 90.0
+        self._drag_offset = cursor_angle - self._overlay_item.ruler_angle()
+        self._dragging = True
+        self._overlay_item.set_dragging(True)
+
+    def _apply_drag(self, event):
+        """Swing the ruler so its handle follows the cursor."""
+        dx, dy = self._drag_vector(event)
+        if dx is None:
+            return
+        angle = ruler_angle_from_drag(dx, dy, self._drag_offset)
+        self._overlay_item.set_ruler_angle(angle)
+
+    def _end_drag(self):
+        """Finish a handle drag."""
+        self._dragging = False
+        if self._overlay_item is not None:
+            self._overlay_item.set_dragging(False)
+
+    def _drag_vector(self, event):
+        """Return (dx, dy) from the AOI centre to the cursor, or (None, None)."""
+        scene_pos = self._event_scene_pos(event)
+        if scene_pos is None:
+            return None, None
+        center = self._overlay_item.pos()
+        return scene_pos.x() - center.x(), scene_pos.y() - center.y()
+
+    # ------------------------------------------------------------------ #
+    #  Inputs
+    # ------------------------------------------------------------------ #
+    def _aoi_circles_visible(self):
+        """Return True when AOI circles are currently shown on the image."""
+        button = getattr(self.parent, 'showAOIsButton', None)
+        if button is None:
+            return True
+        try:
+            return button.isChecked()
+        except Exception:
+            return True
+
+    def _current_gsd_cm(self):
+        """Return the GSD in cm/px for the current image, or None if unavailable.
+
+        Uses the very same average GSD the Measure tool and the scale bar
+        use -- ImageService.get_average_gsd() with the altitude controller's
+        effective altitude -- so the ruler's distances agree with them. The
+        effective altitude lets the reviewer correct an inaccurate GPS
+        altitude; ignoring it (or applying terrain refinement) made the
+        ruler disagree with the other measurement tools.
+
+        It is read straight from the loaded image's ImageService rather than
+        the status message dict, because that dict is only populated near
+        the end of an image load -- after the gallery has zoomed to the AOI.
+        """
+        service = getattr(self.parent, 'current_image_service', None)
+        if service is None:
+            return None
+        try:
+            return service.get_average_gsd(
+                custom_altitude_ft=self._custom_altitude_ft()
+            )
+        except Exception:
+            return None
+
+    def _custom_altitude_ft(self):
+        """Return the altitude controller's effective altitude (feet), or None.
+
+        The reviewer can correct an inaccurate GPS altitude there; the
+        Measure tool and the person-size reference both honor it, so the
+        ruler must too.
+        """
+        controller = getattr(self.parent, 'altitude_controller', None)
+        if controller is None:
+            return None
+        try:
+            return controller.get_effective_altitude()
+        except Exception:
+            return None
+
+    def _distance_unit(self):
+        """Return the distance-unit preference ('Feet' or 'Meters')."""
+        service = getattr(self.parent, 'settings_service', None)
+        if service is not None:
+            try:
+                return service.get_setting('DistanceUnit', 'Feet')
+            except Exception:
+                pass
+        return getattr(self.parent, 'distance_unit', 'Feet')

--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -31,6 +31,7 @@ from core.controllers.images.viewer.WingtraDataController import WingtraDataCont
 from core.controllers.images.viewer.AlignImageController import AlignImageController
 from core.controllers.images.viewer.WaldoPrePassController import WaldoPrePassController
 from core.controllers.images.viewer.image.ImageLoadController import ImageLoadController
+from core.controllers.images.viewer.AOIOverlayController import AOIOverlayController
 from core.controllers.images.viewer.PixelInfoController import PixelInfoController
 from core.controllers.images.viewer.ThermalDataController import ThermalDataController
 from core.controllers.images.viewer.ThermalHistogramController import ThermalHistogramController
@@ -143,6 +144,13 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self.xml_path = xml_path
         self.xml_service = XmlService(xml_path)
         self.images = self.xml_service.get_images()
+        # Backfill persistent run-wide AOI numbers on legacy result files so
+        # every AOI has a stable identifier the reviewer can return to.
+        if self.xml_service.ensure_aoi_numbers(self.images):
+            try:
+                self.xml_service.save_xml_file(self.xml_path)
+            except Exception as e:
+                self.logger.error(f"Could not persist backfilled AOI numbers: {e}")
         # Settings parsed early so the WALDO pre-pass and source-folder enumeration
         # can both see settings['input_dir'] (the original capture folder).
         self.settings, _ = self.xml_service.get_settings()
@@ -1158,6 +1166,8 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
 
             self.jumpToLine.setValidator(QIntValidator(1, len(self.images), self))
             self.jumpToLine.editingFinished.connect(self._jumpToLine_changed)
+            self.aoiJumpLine.setValidator(QIntValidator(1, 9999999, self))
+            self.aoiJumpLine.editingFinished.connect(self._aoiJumpLine_changed)
             self.thumbnailScrollArea.horizontalScrollBar().valueChanged.connect(self.thumbnail_controller.on_thumbnail_scroll)
 
             # Session variable to store GSD value
@@ -1206,6 +1216,9 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
 
             # Initialize overlay widget
             self.overlay = OverlayWidget(self.main_image, self.scaleBar, self.theme, self.logger)
+
+            # Selected-AOI on-image decoration (number badge + real-world ruler)
+            self.aoi_overlay_controller = AOIOverlayController(self)
 
             # Connect signals
             self.main_image.zoomChanged.connect(self._update_scale_bar)
@@ -1385,6 +1398,9 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         """
         # Simply reload the image with current settings
         self._reload_current_image_preserving_view()
+        # The selected-AOI overlay (number + ruler) follows the circle toggle.
+        if hasattr(self, 'aoi_overlay_controller'):
+            self.aoi_overlay_controller.refresh()
 
     def _reload_current_image_preserving_view(self):
         """Reloads the current image while preserving zoom and pan state.
@@ -1537,6 +1553,18 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             if hasattr(self.thumbnail_controller, 'ui_component') and self.thumbnail_controller.ui_component:
                 self.thumbnail_controller.ui_component.scroll_thumbnail_into_view()
             self.jumpToLine.setText("")
+
+    def _aoiJumpLine_changed(self):
+        """Selects and scrolls to the AOI whose run-wide number was entered."""
+        text = self.aoiJumpLine.text().strip()
+        if text == "":
+            return
+        try:
+            number = int(text)
+        except ValueError:
+            return
+        self.aoiJumpLine.setText("")
+        self.aoi_controller.go_to_aoi_number(number)
 
     def _kmlButton_clicked(self):
         """Handles clicks on the Map Export button to show unified export options."""

--- a/app/core/controllers/images/viewer/aoi/AOIController.py
+++ b/app/core/controllers/images/viewer/aoi/AOIController.py
@@ -302,6 +302,116 @@ class AOIController(TranslationMixin):
                     self.parent.current_image, aoi_index
                 )
 
+        # Update the on-image selected-AOI overlay (number badge + ruler).
+        overlay = getattr(self.parent, 'aoi_overlay_controller', None)
+        if overlay is not None:
+            selected = self.get_selected_aoi()
+            if selected is not None:
+                overlay.show_for_aoi(selected[0])
+            else:
+                overlay.clear()
+
+    def find_aoi_by_number(self, number):
+        """Resolve a run-wide AOI number to its (image_index, aoi_index).
+
+        Args:
+            number (int): The run-wide unique AOI number.
+
+        Returns:
+            tuple | None: (image_index, aoi_index), or None if no AOI in the
+                project carries that number.
+        """
+        for image_index, image in enumerate(getattr(self.parent, 'images', None) or []):
+            for aoi_index, aoi in enumerate(image.get('areas_of_interest', [])):
+                if aoi.get('number') == number:
+                    return (image_index, aoi_index)
+        return None
+
+    def go_to_aoi_number(self, number):
+        """Select and scroll to the AOI with the given run-wide number.
+
+        Works in both gallery mode and single-image mode. Shows a transient
+        status message when no AOI carries the requested number or when the
+        AOI exists but is hidden by the active filter.
+
+        Args:
+            number (int): The run-wide unique AOI number to navigate to.
+
+        Returns:
+            bool: True if the AOI was found and revealed.
+        """
+        location = self.find_aoi_by_number(number)
+        if location is None:
+            self._show_aoi_jump_message(
+                self.tr("No AOI #{number} in this analysis.").format(number=number)
+            )
+            return False
+
+        image_index, aoi_index = location
+
+        # Gallery mode: the gallery controller owns the flattened model and
+        # knows how to reveal a specific row.
+        if (getattr(self.parent, 'gallery_mode', False)
+                and hasattr(self.parent, 'gallery_controller')):
+            if self.parent.gallery_controller.go_to_aoi(image_index, aoi_index):
+                return True
+            self._show_aoi_jump_message(
+                self.tr("AOI #{number} is hidden by the current filter.").format(number=number)
+            )
+            return False
+
+        # Single-image mode: load the parent image, then select the AOI.
+        if self.parent.current_image != image_index:
+            self.parent.current_image = image_index
+            self.parent._load_image()
+        if not self._select_and_reveal_aoi(aoi_index):
+            self._show_aoi_jump_message(
+                self.tr("AOI #{number} is hidden by the current filter.").format(number=number)
+            )
+            return False
+        return True
+
+    def _select_and_reveal_aoi(self, aoi_index):
+        """Select an AOI in single-image mode and zoom the main image to it.
+
+        Args:
+            aoi_index (int): Index of the AOI within the current image.
+
+        Returns:
+            bool: True if the AOI is visible (not filtered out) and was selected.
+        """
+        visible_index = self.aoi_index_to_visible_index.get(aoi_index)
+        if visible_index is None and self.ui_component is not None:
+            # The visible-index map can be stale (for example right after a
+            # new AOI was created); rebuild the AOI list once and retry.
+            self.ui_component.refresh_aoi_display()
+            visible_index = self.aoi_index_to_visible_index.get(aoi_index)
+        if visible_index is None:
+            return False
+        self.select_aoi(aoi_index, visible_index)
+        try:
+            image = self.parent.images[self.parent.current_image]
+            aois = image.get('areas_of_interest', [])
+            if 0 <= aoi_index < len(aois):
+                center = aois[aoi_index].get('center')
+                if center and hasattr(self.parent, 'main_image'):
+                    self.parent.main_image.zoomToArea(center, 6)
+        except Exception as e:
+            self.logger.error(f"Error zooming to AOI during jump: {e}")
+        return True
+
+    def _show_aoi_jump_message(self, message):
+        """Show a transient status message about an AOI jump.
+
+        Args:
+            message (str): The already-translated message to display.
+        """
+        status_controller = getattr(self.parent, 'status_controller', None)
+        if status_controller is not None and hasattr(status_controller, 'show_toast'):
+            status_controller.show_toast(message, 3000, color="#FFA500")
+        else:
+            self.logger.info(message)
+
     def find_aoi_at_position(self, x, y):
         """Find the AOI at the given cursor position.
 
@@ -1446,6 +1556,24 @@ class AOIController(TranslationMixin):
             filters = dialog.get_filters()
             self.set_filters(filters)
 
+    def _next_aoi_number(self):
+        """Return the next unused run-wide AOI number.
+
+        User-created AOIs get a number one past the current maximum so the
+        identifier never collides with an existing AOI or one that was
+        previously deleted.
+
+        Returns:
+            int: The number to assign to a newly created AOI.
+        """
+        highest = 0
+        for image in getattr(self.parent, 'images', None) or []:
+            for aoi in image.get('areas_of_interest', []):
+                number = aoi.get('number')
+                if isinstance(number, int) and number > highest:
+                    highest = number
+        return highest + 1
+
     def create_aoi_from_circle(self, center_x, center_y, radius):
         """Create a new AOI from a user-drawn circle.
 
@@ -1489,6 +1617,7 @@ class AOIController(TranslationMixin):
                 'center': (center_x, center_y),
                 'radius': radius,
                 'area': aoi_area,
+                'number': self._next_aoi_number(),
                 'flagged': False,
                 'user_comment': '',
                 'user_created': True  # Mark as manually created
@@ -1509,6 +1638,7 @@ class AOIController(TranslationMixin):
                 aoi_xml.set('center', str((center_x, center_y)))
                 aoi_xml.set('radius', str(radius))
                 aoi_xml.set('area', str(aoi_area))
+                aoi_xml.set('number', str(new_aoi['number']))
                 aoi_xml.set('flagged', 'False')
                 aoi_xml.set('user_created', 'True')
 

--- a/app/core/controllers/images/viewer/aoi/AOIUIComponent.py
+++ b/app/core/controllers/images/viewer/aoi/AOIUIComponent.py
@@ -261,6 +261,19 @@ class AOIUIComponent(TranslationMixin):
         info_layout.setContentsMargins(4, 2, 4, 2)
         info_layout.setSpacing(2)
 
+        # Run-wide AOI number badge — the stable identifier the reviewer can
+        # return to regardless of the current sort order or view mode.
+        number = area_of_interest.get('number')
+        if number is not None:
+            number_label = QLabel(f"#{number}")
+            number_label.setStyleSheet(
+                "QLabel { color: #4FC3F7; font-size: 10px; font-weight: bold; }"
+            )
+            info_layout.addWidget(number_label)
+            number_separator = QLabel("|")
+            number_separator.setStyleSheet("QLabel { color: #666; font-size: 10px; }")
+            info_layout.addWidget(number_separator)
+
         coord_label = QLabel(coord_text)
         coord_label.setAlignment(Qt.AlignCenter)
         coord_label.setStyleSheet("""

--- a/app/core/controllers/images/viewer/gallery/AOIGalleryModel.py
+++ b/app/core/controllers/images/viewer/gallery/AOIGalleryModel.py
@@ -503,8 +503,11 @@ class AOIGalleryModel(QAbstractListModel):
     def _get_display_text(self, image_idx, aoi_idx, aoi_data):
         """Get display text for an AOI item."""
         try:
+            number = aoi_data.get('number')
+            aoi_label = f"AOI #{number}" if number is not None else f"AOI {aoi_idx}"
+
             if not self.viewer or image_idx >= len(self.viewer.images):
-                return f"AOI {aoi_idx}"
+                return aoi_label
 
             image = self.viewer.images[image_idx]
             image_name = image.get('name', f'Image {image_idx}')
@@ -512,12 +515,13 @@ class AOIGalleryModel(QAbstractListModel):
             # Get confidence if available
             confidence = aoi_data.get('confidence')
             if confidence is not None:
-                return f"{image_name}\nAOI {aoi_idx} - {confidence:.1%}"
+                return f"{image_name}\n{aoi_label} - {confidence:.1%}"
             else:
-                return f"{image_name}\nAOI {aoi_idx}"
+                return f"{image_name}\n{aoi_label}"
 
         except Exception:
-            return f"AOI {aoi_idx}"
+            number = aoi_data.get('number') if isinstance(aoi_data, dict) else None
+            return f"AOI #{number}" if number is not None else f"AOI {aoi_idx}"
 
     def _get_tooltip_text(self, image_idx, aoi_idx, aoi_data):
         """Get tooltip text with detailed AOI information."""
@@ -528,7 +532,9 @@ class AOIGalleryModel(QAbstractListModel):
             image = self.viewer.images[image_idx]
             image_name = image.get('name', f'Image {image_idx}')
 
-            lines = [f"Image: {image_name}", f"AOI Index: {aoi_idx}"]
+            number = aoi_data.get('number')
+            aoi_line = f"AOI #{number}" if number is not None else f"AOI Index: {aoi_idx}"
+            lines = [f"Image: {image_name}", aoi_line]
 
             # Add AOI details
             center = aoi_data.get('center')

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -790,6 +790,31 @@ class GalleryController:
             self.logger.error(f"Error handling AOI click: {e}")
             self.logger.error(traceback.format_exc())
 
+    def go_to_aoi(self, image_index, aoi_index):
+        """Select and reveal a specific AOI in the gallery by its location.
+
+        Args:
+            image_index (int): Index of the parent image.
+            aoi_index (int): Index of the AOI within that image.
+
+        Returns:
+            bool: True if the AOI is present in the (possibly filtered)
+                gallery and was revealed; False if it is filtered out.
+        """
+        if not self.model:
+            return False
+        row = self.model.aoi_to_row.get((image_index, aoi_index))
+        if row is None:
+            # The model can be stale (for example right after a new AOI was
+            # created); rebuild the gallery once and retry before reporting
+            # the AOI as filtered out.
+            self.load_all_aois()
+            row = self.model.aoi_to_row.get((image_index, aoi_index))
+        if row is None:
+            return False
+        self._select_and_activate_aoi(row)
+        return True
+
     def navigate_gallery_aoi(self, direction):
         """Navigate to the next or previous AOI in the gallery.
 
@@ -854,6 +879,11 @@ class GalleryController:
                 # self.logger.info(f"Successfully zoomed to AOI at {center}")
             else:
                 self.logger.warning("Viewer does not have zoomToArea method")
+
+            # Show the on-image number badge + ruler for this AOI.
+            overlay = getattr(self.parent, 'aoi_overlay_controller', None)
+            if overlay is not None:
+                overlay.show_for_aoi(aoi_data)
 
         except Exception as e:
             self.logger.error(f"Error zooming to AOI: {e}")

--- a/app/core/controllers/images/viewer/gallery/GalleryUIComponent.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryUIComponent.py
@@ -97,6 +97,11 @@ class AOIGalleryDelegate(QStyledItemDelegate):
             painter.setPen(QPen(QColor(100, 100, 100), 1))
             painter.drawRect(thumbnail_rect)
 
+            # Draw the run-wide AOI number badge in the top-left corner.
+            number = aoi_data.get('number')
+            if number is not None:
+                self._draw_number_badge(painter, thumbnail_rect, number)
+
             # Draw bottom-right icon cluster: flag | comment | location.
             # Positions are reflowed from the original flag/location pair so
             # the new comment icon can slot between them without overlap.
@@ -135,6 +140,35 @@ class AOIGalleryDelegate(QStyledItemDelegate):
             # Fallback to default rendering on error
             pass
 
+        painter.restore()
+
+    def _draw_number_badge(self, painter, thumbnail_rect, number):
+        """Draw the run-wide AOI number badge in the thumbnail's top-left corner.
+
+        Args:
+            painter: The active QPainter.
+            thumbnail_rect: The thumbnail's QRect.
+            number: The AOI's run-wide unique number.
+        """
+        painter.save()
+        text = f"#{number}"
+        font = QFont()
+        font.setPointSize(9)
+        font.setBold(True)
+        painter.setFont(font)
+        metrics = QFontMetrics(font)
+        padding_x, padding_y = 5, 2
+        badge_rect = QRect(
+            thumbnail_rect.left() + 4,
+            thumbnail_rect.top() + 4,
+            metrics.horizontalAdvance(text) + padding_x * 2,
+            metrics.height() + padding_y * 2,
+        )
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 180))
+        painter.drawRoundedRect(badge_rect, 4, 4)
+        painter.setPen(QPen(QColor(255, 255, 255)))
+        painter.drawText(badge_rect, Qt.AlignCenter, text)
         painter.restore()
 
     def _get_confidence_color(self, confidence):

--- a/app/core/controllers/images/viewer/image/ImageLoadController.py
+++ b/app/core/controllers/images/viewer/image/ImageLoadController.py
@@ -56,6 +56,12 @@ class ImageLoadController(TranslationMixin):
 
             image = self.parent.images[self.parent.current_image]
 
+            # A freshly loaded image invalidates the previous image's
+            # selected-AOI overlay; the gallery re-shows it after zooming.
+            overlay = getattr(self.parent, 'aoi_overlay_controller', None)
+            if overlay is not None:
+                overlay.clear()
+
             # Always sync the active thumbnail/index
             self._sync_thumbnail_state(image)
 

--- a/app/core/services/AnalyzeService.py
+++ b/app/core/services/AnalyzeService.py
@@ -183,6 +183,9 @@ class AnalyzeService(QObject):
             file_path = os.path.join(self.output, "ADIAT_Data.xml")
             self.xmlService.xml_path = file_path
 
+            # Assign persisted run-wide unique AOI numbers before serialisation.
+            self.assign_aoi_numbers(self.images_with_aois)
+
             for img in self.images_with_aois:
                 self.xmlService.add_image_to_xml(img)
 
@@ -205,6 +208,24 @@ class AnalyzeService(QObject):
         except Exception as e:
             self.logger.error(traceback.format_exc())
             self.logger.error(f"An error occurred during processing: {e}")
+
+    @staticmethod
+    def assign_aoi_numbers(images_with_aois):
+        """Assign run-wide unique AOI numbers across all analyzed images.
+
+        Numbers are 1-based and increase in image order, then in the order
+        AOIs appear within each image, matching the sequence the viewer
+        displays them. The number is persisted with each AOI so reviewers
+        can track a specific AOI across sort changes and view switches.
+
+        Args:
+            images_with_aois: List of image dicts, each carrying an 'aois' list.
+        """
+        aoi_number = 1
+        for image in images_with_aois or []:
+            for aoi in image.get('aois', []):
+                aoi['number'] = aoi_number
+                aoi_number += 1
 
     @staticmethod
     def _resolve_algorithm_service_class(algorithm):

--- a/app/core/services/XmlService.py
+++ b/app/core/services/XmlService.py
@@ -163,6 +163,15 @@ class XmlService:
                         'radius': int(area_of_interest_xml.get('radius', "0")),
                         'xml': area_of_interest_xml  # Store XML element reference for updating
                     }
+                    # Load the persisted run-wide unique AOI number when present.
+                    # Legacy result files omit it; XmlService.ensure_aoi_numbers
+                    # backfills numbers the first time such a file is opened.
+                    number_attr = area_of_interest_xml.get('number')
+                    if number_attr is not None:
+                        try:
+                            area_of_interest['number'] = int(number_attr)
+                        except (ValueError, TypeError):
+                            pass
                     # Add optional fields if they exist (for backward compatibility)
                     if area_of_interest_xml.get('contour'):
                         area_of_interest['contour'] = literal_eval(area_of_interest_xml.get('contour'))
@@ -203,6 +212,48 @@ class XmlService:
                 images.append(image)
 
         return images
+
+    def ensure_aoi_numbers(self, images):
+        """Backfill run-wide unique AOI numbers onto legacy result files.
+
+        Every AOI carries a persistent 'number' that is unique across the
+        whole run, letting reviewers track a specific AOI even after the
+        gallery is re-sorted or filtered. Result files produced before this
+        feature lack the number; this method walks every AOI in
+        viewer/display order and assigns one to any AOI missing it. AOIs
+        that already have a number keep it, so numbers stay stable across
+        sessions and survive AOI deletion. New numbers are written onto
+        both the AOI dict and its backing XML element; the caller is
+        responsible for saving the file.
+
+        Args:
+            images: The images list returned by get_images().
+
+        Returns:
+            bool: True if at least one number was assigned, meaning the
+                file should be saved to persist the change.
+        """
+        highest = 0
+        for image in images or []:
+            for aoi in image.get('areas_of_interest', []):
+                number = aoi.get('number')
+                if isinstance(number, int) and number > highest:
+                    highest = number
+
+        next_number = highest + 1
+        changed = False
+        for image in images or []:
+            for aoi in image.get('areas_of_interest', []):
+                if isinstance(aoi.get('number'), int):
+                    continue
+                aoi['number'] = next_number
+                xml_element = aoi.get('xml')
+                if xml_element is not None:
+                    xml_element.set('number', str(next_number))
+                next_number += 1
+                changed = True
+
+        return changed
 
     def add_settings_to_xml(self, **kwargs):
         """
@@ -287,6 +338,9 @@ class XmlService:
             area_xml.set('center', str(area['center']))
             area_xml.set('radius', str(area['radius']))
             area_xml.set('area', str(area['area']))
+            # Persist the run-wide unique AOI number when present
+            if area.get('number') is not None:
+                area_xml.set('number', str(area['number']))
             # Add flagged status if present
             if 'flagged' in area:
                 area_xml.set('flagged', str(area['flagged']))

--- a/app/core/views/images/viewer/ui/Viewer_ui.py
+++ b/app/core/views/images/viewer/ui/Viewer_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'Viewer.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.1
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -400,6 +400,21 @@ class Ui_Viewer(object):
 
         self.ButtonLayout.addWidget(self.jumpToLine)
 
+        self.aoiJumpLabel = QLabel(self.imageWidget)
+        self.aoiJumpLabel.setObjectName(u"aoiJumpLabel")
+        self.aoiJumpLabel.setFont(font2)
+
+        self.ButtonLayout.addWidget(self.aoiJumpLabel)
+
+        self.aoiJumpLine = QLineEdit(self.imageWidget)
+        self.aoiJumpLine.setObjectName(u"aoiJumpLine")
+        sizePolicy4.setHeightForWidth(self.aoiJumpLine.sizePolicy().hasHeightForWidth())
+        self.aoiJumpLine.setSizePolicy(sizePolicy4)
+        self.aoiJumpLine.setMinimumSize(QSize(50, 0))
+        self.aoiJumpLine.setMaximumSize(QSize(50, 16777215))
+
+        self.ButtonLayout.addWidget(self.aoiJumpLine)
+
         self.previousImageButton = QPushButton(self.imageWidget)
         self.previousImageButton.setObjectName(u"previousImageButton")
         self.previousImageButton.setFont(font2)
@@ -690,6 +705,15 @@ class Ui_Viewer(object):
         self.jumpToLine.setToolTip(QCoreApplication.translate("Viewer", u"Enter an image number (1 to total) and press Enter.\n"
 "Quickly navigate to any image in the analysis results.\n"
 "Example: Type \"25\" and press Enter to jump to image #25", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self.aoiJumpLabel.setToolTip(QCoreApplication.translate("Viewer", u"Jump to a specific AOI by its run-wide number.\n"
+"Enter an AOI number and press Enter to select and scroll to it.", None))
+#endif // QT_CONFIG(tooltip)
+        self.aoiJumpLabel.setText(QCoreApplication.translate("Viewer", u"Go to AOI #:", None))
+#if QT_CONFIG(tooltip)
+        self.aoiJumpLine.setToolTip(QCoreApplication.translate("Viewer", u"Enter an AOI number and press Enter.\n"
+"Selects that AOI and scrolls it into view in the gallery or single-image list.", None))
 #endif // QT_CONFIG(tooltip)
         self.previousImageButton.setText(QCoreApplication.translate("Viewer", u"Previous Image", None))
         self.previousImageButton.setProperty(u"iconName", QCoreApplication.translate("Viewer", u"previous.png", None))

--- a/app/core/views/images/viewer/widgets/AOISelectionOverlay.py
+++ b/app/core/views/images/viewer/widgets/AOISelectionOverlay.py
@@ -1,0 +1,428 @@
+"""
+AOISelectionOverlay - On-image decoration for the currently selected AOI.
+
+Draws, on top of the main image, the run-wide AOI number next to the
+selected AOI's circle and a horizontal real-world ruler beneath it. The
+ruler is calibrated in feet or metres (per the distance-unit preference)
+with a major tick every whole unit, a medium tick every half unit and a
+minor tick every quarter unit.
+
+The ruler can be swung around the AOI centre with a grab handle so it
+aligns with the object being measured; the rotation is clamped to 90
+degrees each way from horizontal and is not persisted.
+
+The geometry that drives the ruler is produced by the pure helpers in
+this module (build_ruler_model / compute_ruler_ticks / ruler_angle_from_drag)
+so it can be unit tested without a running Qt scene.
+"""
+
+import math
+
+from PySide6.QtCore import Qt, QRectF, QPointF
+from PySide6.QtGui import QColor, QFont, QPen, QPainter
+from PySide6.QtWidgets import QGraphicsItem, QStyleOptionGraphicsItem
+
+
+# Screen-constant decoration sizes, in device pixels. They are divided by
+# the current zoom in paint() so the decoration keeps a stable on-screen
+# size while the ruler's length still tracks the AOI circle.
+_RULER_GAP = 7            # gap between the circle bottom and the ruler baseline
+_RULER_STRIP_HEIGHT = 47  # height of the dark contrast strip behind the ruler
+_TICK_MAJOR = 11          # major tick length (every whole unit)
+_TICK_MEDIUM = 7          # medium tick length (every half unit)
+_TICK_MINOR = 4           # minor tick length (every quarter unit)
+_NUMBER_FONT_PT = 10
+_TICK_LABEL_FONT_PT = 7
+_READOUT_FONT_PT = 8
+_HANDLE_RADIUS = 6        # grab-handle dot radius
+
+# The ruler may be swung this many degrees each way from horizontal.
+_MAX_RULER_ANGLE = 90.0
+
+# Feet are the only sub-metre unit ADIAT exposes; everything else is metres.
+_FEET_ALIASES = ('feet', 'ft', 'foot', 'imperial')
+_FOOT_IN_METERS = 0.3048
+
+
+def _is_feet(distance_unit):
+    """Return True when the distance-unit preference selects feet."""
+    return str(distance_unit or '').strip().lower() in _FEET_ALIASES
+
+
+def compute_ruler_ticks(width_units):
+    """Compute ruler tick positions for a ruler ``width_units`` long.
+
+    Ticks are placed every quarter unit and classified so the renderer can
+    size them: a major tick on every whole unit, a medium tick on every
+    half unit and a minor tick on every remaining quarter unit.
+
+    Args:
+        width_units (float): Ruler length in real-world units (feet or
+            metres). Values <= 0 yield no ticks.
+
+    Returns:
+        list[tuple[float, str]]: (position_in_units, kind) pairs ordered
+            from the ruler's left end, where kind is 'major', 'medium' or
+            'minor'.
+    """
+    if width_units is None or width_units <= 0:
+        return []
+
+    # Step in quarter units; a small epsilon keeps a tick that lands
+    # exactly on the ruler end from being dropped by float rounding.
+    quarter_count = int(math.floor(width_units / 0.25 + 1e-9))
+    ticks = []
+    for index in range(0, quarter_count + 1):
+        position = index * 0.25
+        if index % 4 == 0:
+            kind = 'major'
+        elif index % 2 == 0:
+            kind = 'medium'
+        else:
+            kind = 'minor'
+        ticks.append((position, kind))
+    return ticks
+
+
+def build_ruler_model(radius_px, gsd_cm_per_px, distance_unit):
+    """Build the real-world ruler description for one AOI.
+
+    The ruler measures the AOI's width (its diameter) and is calibrated in
+    the unit chosen in preferences. When no ground sample distance is
+    available the AOI cannot be measured, so None is returned and the
+    caller omits the ruler.
+
+    Args:
+        radius_px (float): AOI radius in image pixels.
+        gsd_cm_per_px (float | None): Ground sample distance in
+            centimetres per pixel, or None when it cannot be computed.
+        distance_unit (str): Distance-unit preference ('Feet'/'Meters';
+            legacy 'ft'/'m' are also accepted).
+
+    Returns:
+        dict | None: None when the ruler cannot be built. Otherwise a dict
+            with keys 'width_units', 'unit_label', 'pixels_per_unit',
+            'ticks' and 'width_text'.
+    """
+    if not gsd_cm_per_px or gsd_cm_per_px <= 0 or not radius_px or radius_px <= 0:
+        return None
+
+    use_feet = _is_feet(distance_unit)
+    unit_in_meters = _FOOT_IN_METERS if use_feet else 1.0
+    unit_label = 'ft' if use_feet else 'm'
+
+    meters_per_pixel = gsd_cm_per_px / 100.0
+    diameter_meters = (2.0 * radius_px) * meters_per_pixel
+    width_units = diameter_meters / unit_in_meters
+    pixels_per_unit = unit_in_meters / meters_per_pixel
+
+    return {
+        'width_units': width_units,
+        'unit_label': unit_label,
+        'pixels_per_unit': pixels_per_unit,
+        'ticks': compute_ruler_ticks(width_units),
+        'width_text': f"{width_units:.2f} {unit_label}",
+    }
+
+
+def ruler_angle_from_drag(dx, dy, offset=90.0):
+    """Map a handle-drag vector to a clamped ruler angle in degrees.
+
+    The drag vector runs from the AOI centre to the cursor. ``offset`` is
+    recorded when the handle is first grabbed (cursor angle minus the
+    current ruler angle) so the ruler does not jump at the start of a
+    drag. The result is clamped to +/- 90 degrees of horizontal.
+
+    Args:
+        dx (float): Cursor x minus AOI centre x, in scene units.
+        dy (float): Cursor y minus AOI centre y, in scene units.
+        offset (float): Grab offset in degrees.
+
+    Returns:
+        float: The ruler angle in degrees, within [-90, 90].
+    """
+    if dx == 0 and dy == 0:
+        return 0.0
+    angle = math.degrees(math.atan2(dy, dx)) - offset
+    while angle > 180.0:
+        angle -= 360.0
+    while angle < -180.0:
+        angle += 360.0
+    return max(-_MAX_RULER_ANGLE, min(_MAX_RULER_ANGLE, angle))
+
+
+class AOISelectionOverlay(QGraphicsItem):
+    """QGraphicsItem that decorates the selected AOI on the main image.
+
+    The item is positioned at the AOI centre in scene (image-pixel)
+    coordinates. The ruler's length tracks the AOI circle because it is
+    drawn in scene units, while text, ticks, the number badge and the
+    grab handle are counter-scaled by the current zoom so they keep a
+    constant on-screen size. The ruler is drawn rotated by the current
+    ruler angle; mouse interaction is handled by AOIOverlayController.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._radius = 0.0
+        self._number = None
+        self._ruler = None
+        self._ruler_angle = 0.0     # degrees, [-90, 90]
+        self._dragging = False      # True while the handle is being dragged
+        self._last_lod = 1.0        # scene-to-device scale from the last paint
+        self.setZValue(1000)        # above the image pixmap
+        # Mouse handling is done by a viewport event filter, not the item,
+        # so the item never blocks panning or region-zoom.
+        self.setAcceptedMouseButtons(Qt.NoButton)
+        self.hide()
+
+    def configure(self, center, radius, number, ruler_model):
+        """Set what to draw and move the item onto the AOI.
+
+        The ruler angle is intentionally left untouched so a refresh
+        (e.g. a circle-toggle) keeps the user's rotation; it is reset
+        separately via reset_ruler_angle() when a new AOI is selected.
+
+        Args:
+            center (tuple): AOI centre (x, y) in image pixels.
+            radius (float): AOI radius in image pixels.
+            number (int | None): Run-wide AOI number, or None to omit it.
+            ruler_model (dict | None): Result of build_ruler_model(), or
+                None to omit the ruler (e.g. when no scale is available).
+        """
+        self.prepareGeometryChange()
+        self._radius = float(radius or 0.0)
+        self._number = number
+        self._ruler = ruler_model
+        if center is not None:
+            self.setPos(float(center[0]), float(center[1]))
+        self.update()
+
+    # ------------------------------------------------------------------ #
+    #  Ruler rotation
+    # ------------------------------------------------------------------ #
+    def ruler_angle(self):
+        """Return the current ruler angle in degrees."""
+        return self._ruler_angle
+
+    def set_ruler_angle(self, degrees):
+        """Set the ruler angle, clamped to +/- 90 degrees, and repaint."""
+        self._ruler_angle = max(-_MAX_RULER_ANGLE,
+                                min(_MAX_RULER_ANGLE, float(degrees)))
+        self.update()
+
+    def reset_ruler_angle(self):
+        """Return the ruler to horizontal (called when a new AOI is selected)."""
+        self.set_ruler_angle(0.0)
+
+    def set_dragging(self, dragging):
+        """Flag whether the grab handle is being dragged (for highlighting)."""
+        self._dragging = bool(dragging)
+        self.update()
+
+    def has_ruler(self):
+        """Return True when a ruler (and therefore a grab handle) is shown."""
+        return self._ruler is not None
+
+    def handle_scene_pos(self):
+        """Return the grab handle's current position in scene coordinates."""
+        return self.mapToScene(self._handle_item_pos())
+
+    # ------------------------------------------------------------------ #
+    #  Geometry helpers
+    # ------------------------------------------------------------------ #
+    def _screen(self, distance):
+        """Convert a screen-pixel distance to item units at the last zoom."""
+        lod = self._last_lod if self._last_lod > 1e-9 else 1.0
+        return distance / lod
+
+    @staticmethod
+    def _rotate_point(x, y, degrees):
+        """Rotate (x, y) about the origin by ``degrees`` (clockwise, y-down)."""
+        radians = math.radians(degrees)
+        cos_a, sin_a = math.cos(radians), math.sin(radians)
+        return QPointF(x * cos_a - y * sin_a, x * sin_a + y * cos_a)
+
+    def _handle_item_pos(self):
+        """Return the grab handle position in item coordinates."""
+        if self._radius <= 0:
+            return QPointF(0.0, 0.0)
+        baseline_y = self._radius + self._screen(_RULER_GAP)
+        return self._rotate_point(self._radius, baseline_y, self._ruler_angle)
+
+    def boundingRect(self):
+        """Return a generous item-local bounding rectangle.
+
+        The square margin covers the ruler at every rotation and the
+        screen-constant decorations across the zoom range an AOI is
+        realistically reviewed at.
+        """
+        if self._radius <= 0:
+            return QRectF()
+        margin = self._radius + 420.0
+        return QRectF(-margin, -margin, 2.0 * margin, 2.0 * margin)
+
+    # ------------------------------------------------------------------ #
+    #  Painting
+    # ------------------------------------------------------------------ #
+    def paint(self, painter, option, widget=None):
+        """Render the number badge and (rotated) ruler for the selected AOI."""
+        if self._number is None and self._ruler is None:
+            return
+
+        lod = QStyleOptionGraphicsItem.levelOfDetailFromTransform(
+            painter.worldTransform()
+        )
+        if not lod or lod <= 1e-9:
+            lod = 1.0
+        self._last_lod = lod
+
+        painter.setRenderHint(QPainter.Antialiasing, True)
+        if self._ruler is not None:
+            # The ruler swings around the AOI centre; the number badge does
+            # not, so only the ruler is drawn inside the rotated frame.
+            painter.save()
+            painter.rotate(self._ruler_angle)
+            self._paint_ruler(painter, lod)
+            painter.restore()
+        if self._number is not None:
+            self._paint_number(painter, lod)
+
+    def _paint_number(self, painter, lod):
+        """Draw the run-wide AOI number badge just outside the circle."""
+        text = f"#{self._number}"
+        # Anchor at roughly 45 degrees up-and-right on the circle.
+        diagonal = 0.7071
+        painter.save()
+        painter.translate(self._radius * diagonal, -self._radius * diagonal)
+        painter.scale(1.0 / lod, 1.0 / lod)  # 1 unit == 1 screen pixel here
+
+        font = QFont()
+        font.setPointSize(_NUMBER_FONT_PT)
+        font.setBold(True)
+        painter.setFont(font)
+        metrics = painter.fontMetrics()
+        pad_x, pad_y = 6, 3
+        badge = QRectF(
+            0.0,
+            -(metrics.height() + 2 * pad_y),
+            metrics.horizontalAdvance(text) + 2 * pad_x,
+            metrics.height() + 2 * pad_y,
+        )
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 205))
+        painter.drawRoundedRect(badge, 4.0, 4.0)
+        painter.setPen(QPen(QColor(255, 255, 255)))
+        painter.drawText(badge, Qt.AlignCenter, text)
+        painter.restore()
+
+    def _paint_ruler(self, painter, lod):
+        """Draw the real-world ruler (and grab handle) beneath the AOI circle.
+
+        Runs inside a frame already rotated by the ruler angle.
+        """
+        ruler = self._ruler
+        pixels_per_unit = ruler['pixels_per_unit']
+        radius = self._radius
+
+        def screen(distance):
+            """Convert a screen-pixel distance to scene units at this zoom."""
+            return distance / lod
+
+        x_left = -radius
+        x_right = radius
+        baseline_y = radius + screen(_RULER_GAP)
+
+        # Dark translucent strip so the ruler stays legible on any image.
+        strip = QRectF(
+            x_left - screen(8),
+            baseline_y - screen(3),
+            (x_right - x_left) + screen(16),
+            screen(_RULER_STRIP_HEIGHT),
+        )
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QColor(0, 0, 0, 150))
+        painter.drawRoundedRect(strip, screen(3), screen(3))
+
+        # Baseline and ticks use a cosmetic pen so they stay 1px on screen.
+        pen = QPen(QColor(255, 255, 255))
+        pen.setCosmetic(True)
+        painter.setPen(pen)
+        painter.drawLine(QPointF(x_left, baseline_y), QPointF(x_right, baseline_y))
+
+        tick_length = {
+            'major': screen(_TICK_MAJOR),
+            'medium': screen(_TICK_MEDIUM),
+            'minor': screen(_TICK_MINOR),
+        }
+        for position, kind in ruler['ticks']:
+            tick_x = x_left + position * pixels_per_unit
+            painter.drawLine(
+                QPointF(tick_x, baseline_y),
+                QPointF(tick_x, baseline_y + tick_length[kind]),
+            )
+
+        # Whole-unit labels under the major ticks.
+        label_y = baseline_y + screen(_TICK_MAJOR + 2)
+        for position, kind in ruler['ticks']:
+            if kind != 'major':
+                continue
+            tick_x = x_left + position * pixels_per_unit
+            self._draw_label(
+                painter, lod, tick_x, label_y,
+                str(int(round(position))), _TICK_LABEL_FONT_PT,
+            )
+
+        # Total width readout centred under the ruler.
+        self._draw_label(
+            painter, lod, 0.0, baseline_y + screen(30),
+            ruler['width_text'], _READOUT_FONT_PT, bold=True,
+        )
+
+        # Grab handle at the ruler's right end.
+        self._paint_handle(painter, QPointF(x_right, baseline_y), screen(_HANDLE_RADIUS))
+
+    def _paint_handle(self, painter, center, handle_radius):
+        """Draw the circular grab handle used to rotate the ruler."""
+        outline = QPen(QColor(0, 0, 0, 220))
+        outline.setCosmetic(True)
+        painter.setPen(outline)
+        fill = QColor(90, 200, 255) if self._dragging else QColor(255, 255, 255)
+        painter.setBrush(fill)
+        painter.drawEllipse(center, handle_radius, handle_radius)
+
+    def _draw_label(self, painter, lod, item_x, item_y, text, point_size, bold=False):
+        """Draw screen-constant, upright white text centred on a point.
+
+        The text is counter-rotated by the ruler angle so it stays
+        readable even when the ruler is swung.
+
+        Args:
+            painter: Active QPainter (already rotated by the ruler angle).
+            lod: Current level of detail (scene-to-device scale).
+            item_x: Anchor x in the rotated frame; text is centred on it.
+            item_y: Anchor y in the rotated frame; the text top sits here.
+            text: The string to draw.
+            point_size: Font point size at 100% zoom.
+            bold: Whether to embolden the text.
+        """
+        painter.save()
+        painter.translate(item_x, item_y)
+        painter.rotate(-self._ruler_angle)   # keep text upright
+        painter.scale(1.0 / lod, 1.0 / lod)
+
+        font = QFont()
+        font.setPointSize(point_size)
+        font.setBold(bold)
+        painter.setFont(font)
+        metrics = painter.fontMetrics()
+        width = metrics.horizontalAdvance(text)
+        height = metrics.height()
+        box = QRectF(-width / 2.0, 0.0, width, height)
+
+        # Dark drop shadow then white text for contrast on bright imagery.
+        painter.setPen(QPen(QColor(0, 0, 0, 210)))
+        painter.drawText(box.translated(1.0, 1.0), Qt.AlignCenter, text)
+        painter.setPen(QPen(QColor(255, 255, 255)))
+        painter.drawText(box, Qt.AlignCenter, text)
+        painter.restore()

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -102,6 +102,25 @@ def app():
     return QApplication.instance() or QApplication([])
 
 
+@pytest.fixture(scope='session', autouse=True)
+def _prime_qt_and_qtawesome():
+    """Ensure a QApplication exists and qtawesome icon fonts are registered.
+
+    qtawesome registers its bundled icon fonts on first use; when that first
+    use happens before any QApplication exists the fonts never register and
+    later 'fa6s.*' icon lookups raise "Invalid font prefix". Warming
+    qtawesome here, with the application created, keeps icon-dependent tests
+    independent of collection order.
+    """
+    application = QApplication.instance() or QApplication([])
+    try:
+        import qtawesome
+        qtawesome.icon('fa6s.flag')
+    except Exception:
+        pass
+    return application
+
+
 @pytest.fixture(scope='function')
 def main_window(qtbot):
     if not _MAIN_WINDOW_AVAILABLE:

--- a/app/tests/core/controllers/images/viewer/aoi/test_aoi_controller.py
+++ b/app/tests/core/controllers/images/viewer/aoi/test_aoi_controller.py
@@ -389,3 +389,96 @@ def test_toggle_flag_ignores_invalid_index(controller):
     controller.toggle_aoi_flag_by_index(-1)
     controller.toggle_aoi_flag_by_index(None)
     controller.save_flagged_aoi_to_xml.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# find_aoi_by_number / go_to_aoi_number
+# ---------------------------------------------------------------------------
+
+def test_find_aoi_by_number_found(controller):
+    controller.parent.images = [
+        {"areas_of_interest": [_aoi(number=1), _aoi(number=2)]},
+        {"areas_of_interest": [_aoi(number=3)]},
+    ]
+    assert controller.find_aoi_by_number(1) == (0, 0)
+    assert controller.find_aoi_by_number(2) == (0, 1)
+    assert controller.find_aoi_by_number(3) == (1, 0)
+
+
+def test_find_aoi_by_number_missing(controller):
+    controller.parent.images = [{"areas_of_interest": [_aoi(number=1)]}]
+    assert controller.find_aoi_by_number(99) is None
+
+
+def test_find_aoi_by_number_no_images(controller):
+    controller.parent.images = []
+    assert controller.find_aoi_by_number(1) is None
+
+
+def test_go_to_aoi_number_not_found(controller):
+    controller.parent.images = [{"areas_of_interest": [_aoi(number=1)]}]
+    assert controller.go_to_aoi_number(999) is False
+
+
+def test_go_to_aoi_number_single_image_selects(controller):
+    controller.parent.images = [
+        {"areas_of_interest": [_aoi(number=1)]},
+        {"areas_of_interest": [_aoi(number=2, center=(40, 60))]},
+    ]
+    controller.parent.gallery_mode = False
+    controller.parent.current_image = 0
+    controller.aoi_index_to_visible_index = {0: 0}
+    controller.select_aoi = MagicMock()
+
+    result = controller.go_to_aoi_number(2)
+
+    assert result is True
+    # The parent image is loaded and the AOI selected.
+    assert controller.parent.current_image == 1
+    controller.parent._load_image.assert_called_once()
+    controller.select_aoi.assert_called_once_with(0, 0)
+
+
+def test_go_to_aoi_number_single_image_filtered_out(controller):
+    controller.parent.images = [{"areas_of_interest": [_aoi(number=1)]}]
+    controller.parent.gallery_mode = False
+    controller.parent.current_image = 0
+    controller.aoi_index_to_visible_index = {}  # AOI hidden by the active filter
+    controller.select_aoi = MagicMock()
+
+    assert controller.go_to_aoi_number(1) is False
+    controller.select_aoi.assert_not_called()
+
+
+def test_go_to_aoi_number_gallery_delegates(controller):
+    controller.parent.images = [{"areas_of_interest": [_aoi(number=5)]}]
+    controller.parent.gallery_mode = True
+    controller.parent.gallery_controller.go_to_aoi.return_value = True
+
+    assert controller.go_to_aoi_number(5) is True
+    controller.parent.gallery_controller.go_to_aoi.assert_called_once_with(0, 0)
+
+
+def test_go_to_aoi_number_gallery_filtered_out(controller):
+    controller.parent.images = [{"areas_of_interest": [_aoi(number=5)]}]
+    controller.parent.gallery_mode = True
+    controller.parent.gallery_controller.go_to_aoi.return_value = False
+
+    assert controller.go_to_aoi_number(5) is False
+
+
+def test_go_to_aoi_number_single_image_rebuilds_stale_map(controller):
+    """A freshly created AOI is found after the stale visible-index map rebuilds."""
+    controller.parent.images = [{"areas_of_interest": [_aoi(number=1)]}]
+    controller.parent.gallery_mode = False
+    controller.parent.current_image = 0
+    controller.aoi_index_to_visible_index = {}  # stale: missing the new AOI
+    controller.select_aoi = MagicMock()
+
+    def rebuild():
+        controller.aoi_index_to_visible_index = {0: 0}
+    controller.ui_component.refresh_aoi_display = MagicMock(side_effect=rebuild)
+
+    assert controller.go_to_aoi_number(1) is True
+    controller.ui_component.refresh_aoi_display.assert_called_once()
+    controller.select_aoi.assert_called_once_with(0, 0)

--- a/app/tests/core/controllers/images/viewer/gallery/test_gallery_aoi_numbers.py
+++ b/app/tests/core/controllers/images/viewer/gallery/test_gallery_aoi_numbers.py
@@ -1,0 +1,86 @@
+"""Tests for run-wide AOI number rendering in the gallery view.
+
+Covers AOIGalleryModel display/tooltip text and the AOIGalleryDelegate
+number badge introduced by the AOI improvements feature.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from PySide6.QtCore import QRect
+from PySide6.QtGui import QPixmap, QPainter
+
+
+@pytest.fixture
+def gallery_model(app):
+    """An AOIGalleryModel with the background thumbnail loader patched out."""
+    with patch(
+        "core.controllers.images.viewer.gallery.AOIGalleryModel.ThumbnailLoader"
+    ):
+        from core.controllers.images.viewer.gallery.AOIGalleryModel import AOIGalleryModel
+        model = AOIGalleryModel()
+    viewer = MagicMock()
+    viewer.images = [{'name': 'DJI_0001.JPG'}, {'name': 'DJI_0002.JPG'}]
+    model.viewer = viewer
+    yield model
+    # AOIGalleryModel is a QObject; the patched ThumbnailLoader mock records
+    # the bound-method slots connected to it, forming a reference cycle.
+    # Break it on teardown so the model is freed while QApplication is alive.
+    model.thumbnail_loader = None
+    model.viewer = None
+
+
+# ---------------------------------------------------------------------------
+# AOIGalleryModel display / tooltip text
+# ---------------------------------------------------------------------------
+
+def test_display_text_uses_aoi_number(gallery_model):
+    """The gallery display text shows the run-wide AOI number."""
+    text = gallery_model._get_display_text(0, 3, {'number': 42})
+    assert 'AOI #42' in text
+    assert 'DJI_0001.JPG' in text
+
+
+def test_display_text_falls_back_without_number(gallery_model):
+    """Display text falls back to the AOI index when no number is present."""
+    text = gallery_model._get_display_text(0, 3, {})
+    assert 'AOI 3' in text
+
+
+def test_display_text_keeps_confidence(gallery_model):
+    """Display text keeps the confidence readout alongside the number."""
+    text = gallery_model._get_display_text(1, 0, {'number': 7, 'confidence': 0.5})
+    assert 'AOI #7' in text
+    assert '%' in text
+
+
+def test_tooltip_text_uses_aoi_number(gallery_model):
+    """The gallery tooltip shows the run-wide AOI number."""
+    text = gallery_model._get_tooltip_text(0, 3, {'number': 42, 'center': (10, 20)})
+    assert 'AOI #42' in text
+
+
+def test_tooltip_text_falls_back_without_number(gallery_model):
+    """Tooltip falls back to the AOI index when no number is present."""
+    text = gallery_model._get_tooltip_text(0, 3, {'center': (10, 20)})
+    assert 'AOI Index: 3' in text
+
+
+# ---------------------------------------------------------------------------
+# AOIGalleryDelegate number badge
+# ---------------------------------------------------------------------------
+
+def test_delegate_draws_number_badge(app):
+    """The gallery delegate's number badge renders without error."""
+    from core.controllers.images.viewer.gallery.GalleryUIComponent import AOIGalleryDelegate
+
+    # Bypass __init__ (which loads qtawesome icons) — the badge helper only
+    # needs a painter, a rect and a number, so this keeps the test
+    # independent of qtawesome font state and test ordering.
+    delegate = AOIGalleryDelegate.__new__(AOIGalleryDelegate)
+    pixmap = QPixmap(200, 200)
+    painter = QPainter(pixmap)
+    try:
+        delegate._draw_number_badge(painter, QRect(0, 0, 180, 180), 123)
+    finally:
+        painter.end()

--- a/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
+++ b/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
@@ -260,3 +260,40 @@ def test_clear_cache_clears_aoi_cache(controller):
     controller._aoi_service_cache = {0: MagicMock(), 1: MagicMock()}
     controller.clear_cache()
     assert controller._aoi_service_cache == {}
+
+
+# ---------------------------------------------------------------------------
+# go_to_aoi
+# ---------------------------------------------------------------------------
+
+def test_go_to_aoi_found(controller):
+    controller.model.aoi_to_row = {(0, 0): 5, (1, 2): 9}
+    controller.load_all_aois = MagicMock()
+    controller._select_and_activate_aoi = MagicMock()
+
+    assert controller.go_to_aoi(1, 2) is True
+    controller._select_and_activate_aoi.assert_called_once_with(9)
+    controller.load_all_aois.assert_not_called()
+
+
+def test_go_to_aoi_not_in_gallery(controller):
+    controller.model.aoi_to_row = {(0, 0): 5}
+    controller.load_all_aois = MagicMock()
+    controller._select_and_activate_aoi = MagicMock()
+
+    assert controller.go_to_aoi(3, 3) is False
+    controller._select_and_activate_aoi.assert_not_called()
+
+
+def test_go_to_aoi_rebuilds_stale_model(controller):
+    """A stale gallery model is rebuilt once before the AOI is reported missing."""
+    controller.model.aoi_to_row = {}
+
+    def populate():
+        controller.model.aoi_to_row = {(2, 1): 7}
+    controller.load_all_aois = MagicMock(side_effect=populate)
+    controller._select_and_activate_aoi = MagicMock()
+
+    assert controller.go_to_aoi(2, 1) is True
+    controller.load_all_aois.assert_called_once()
+    controller._select_and_activate_aoi.assert_called_once_with(7)

--- a/app/tests/core/controllers/images/viewer/test_aoi_overlay_controller.py
+++ b/app/tests/core/controllers/images/viewer/test_aoi_overlay_controller.py
@@ -1,0 +1,106 @@
+"""Unit tests for AOIOverlayController — selected-AOI overlay lifecycle."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture
+def overlay_controller():
+    """An AOIOverlayController with the graphics item patched to a mock."""
+    with patch(
+        "core.controllers.images.viewer.AOIOverlayController.AOISelectionOverlay"
+    ):
+        from core.controllers.images.viewer.AOIOverlayController import AOIOverlayController
+        parent = MagicMock()
+        parent.main_image._is_destroyed = False
+        parent.current_image_service.get_average_gsd.return_value = 2.5
+        parent.altitude_controller.get_effective_altitude.return_value = None
+        parent.showAOIsButton.isChecked.return_value = True
+        parent.settings_service.get_setting.return_value = 'Feet'
+        # Yield inside the patch context so the lazily-created overlay item
+        # (built in _ensure_item during the test) is the mocked class.
+        controller = AOIOverlayController(parent)
+        yield controller
+        # The controller is a QObject and the MagicMock parent records the
+        # calls it receives (installEventFilter(self), connect(...)), forming
+        # a reference cycle. Break it on teardown so the QObject is freed by
+        # refcounting while QApplication is alive -- a late cycle collection
+        # during interpreter shutdown would segfault.
+        parent.reset_mock()
+        controller.parent = None
+
+
+def _aoi(**extra):
+    aoi = {'center': (100, 120), 'radius': 60, 'number': 9}
+    aoi.update(extra)
+    return aoi
+
+
+def test_show_for_aoi_configures_and_shows(overlay_controller):
+    overlay_controller.show_for_aoi(_aoi())
+    item = overlay_controller._overlay_item
+    assert item is not None
+    item.configure.assert_called_once()
+    item.show.assert_called_once()
+
+
+def test_show_for_aoi_passes_ruler_model_when_gsd_available(overlay_controller):
+    overlay_controller.show_for_aoi(_aoi())
+    # configure(center, radius, number, ruler_model)
+    args = overlay_controller._overlay_item.configure.call_args.args
+    assert args[0] == (100, 120)
+    assert args[2] == 9
+    assert args[3] is not None  # ruler model built from the 2.50 cm/px GSD
+
+
+def test_ruler_omitted_when_gsd_missing(overlay_controller):
+    overlay_controller.parent.current_image_service = None
+    overlay_controller.show_for_aoi(_aoi())
+    args = overlay_controller._overlay_item.configure.call_args.args
+    assert args[3] is None  # no GSD -> no ruler, but the badge still shows
+
+
+def test_refresh_hides_when_circles_off(overlay_controller):
+    overlay_controller.show_for_aoi(_aoi())
+    item = overlay_controller._overlay_item
+    overlay_controller.parent.showAOIsButton.isChecked.return_value = False
+
+    overlay_controller.refresh()
+    item.hide.assert_called()
+
+
+def test_clear_hides_and_forgets_aoi(overlay_controller):
+    overlay_controller.show_for_aoi(_aoi())
+    item = overlay_controller._overlay_item
+
+    overlay_controller.clear()
+    assert overlay_controller._current_aoi is None
+    item.hide.assert_called()
+
+
+def test_show_for_aoi_ignores_non_dict(overlay_controller):
+    overlay_controller.show_for_aoi("not an aoi")
+    assert overlay_controller._current_aoi is None
+
+
+def test_show_for_aoi_resets_ruler_angle(overlay_controller):
+    """Selecting an AOI starts its ruler horizontal (rotation is not kept)."""
+    overlay_controller.show_for_aoi(_aoi())
+    overlay_controller._overlay_item.reset_ruler_angle.assert_called_once()
+
+
+def test_current_gsd_cm_uses_average_gsd_with_altitude(overlay_controller):
+    """The ruler GSD matches the Measure tool: average GSD + corrected altitude."""
+    overlay_controller.parent.altitude_controller.get_effective_altitude.return_value = 180.0
+    overlay_controller.parent.current_image_service.get_average_gsd.return_value = 2.5
+
+    assert overlay_controller._current_gsd_cm() == 2.5
+    # The user-corrected altitude is forwarded, exactly as the Measure tool does.
+    overlay_controller.parent.current_image_service.get_average_gsd.assert_called_with(
+        custom_altitude_ft=180.0
+    )
+
+
+def test_current_gsd_cm_none_without_service(overlay_controller):
+    overlay_controller.parent.current_image_service = None
+    assert overlay_controller._current_gsd_cm() is None

--- a/app/tests/core/services/test_analyze_service.py
+++ b/app/tests/core/services/test_analyze_service.py
@@ -367,3 +367,33 @@ def test_generate_thumbnail_swallows_exceptions():
     AnalyzeService._generate_main_image_thumbnail(
         None, image_path="/input/test.jpg", output_dir="/no/such/path"
     )
+
+
+# ---------------------------------------------------------------------------
+# assign_aoi_numbers
+# ---------------------------------------------------------------------------
+
+def test_assign_aoi_numbers_sequential_across_images():
+    """AOI numbers run 1..N across images in order, then within each image."""
+    images_with_aois = [
+        {"path": "a.jpg", "aois": [{"center": (1, 1)}, {"center": (2, 2)}]},
+        {"path": "b.jpg", "aois": [{"center": (3, 3)}]},
+        {"path": "c.jpg", "aois": [{"center": (4, 4)}, {"center": (5, 5)}]},
+    ]
+    AnalyzeService.assign_aoi_numbers(images_with_aois)
+
+    numbers = [aoi["number"] for img in images_with_aois for aoi in img["aois"]]
+    assert numbers == [1, 2, 3, 4, 5]
+
+
+def test_assign_aoi_numbers_handles_empty_and_missing_aois():
+    """assign_aoi_numbers tolerates empty input and images with no AOIs."""
+    AnalyzeService.assign_aoi_numbers([])
+    AnalyzeService.assign_aoi_numbers(None)
+
+    images_with_aois = [
+        {"path": "a.jpg", "aois": []},
+        {"path": "b.jpg", "aois": [{"center": (1, 1)}]},
+    ]
+    AnalyzeService.assign_aoi_numbers(images_with_aois)
+    assert images_with_aois[1]["aois"][0]["number"] == 1

--- a/app/tests/core/services/test_xml_service.py
+++ b/app/tests/core/services/test_xml_service.py
@@ -177,3 +177,111 @@ def test_malformed_fov_corners_treated_as_unrefined(tmp_path):
     images = XmlService(xml_path).get_images()
     assert "fov_alignment" not in images[0]
     assert len(images[0]["areas_of_interest"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Run-wide AOI numbers
+# ---------------------------------------------------------------------------
+
+def test_aoi_number_round_trips_through_xml(tmp_path):
+    """A persisted AOI 'number' survives add_image_to_xml -> save -> reload."""
+    service = XmlService()
+    service.add_image_to_xml({
+        "path": "img.jpg",
+        "aois": [
+            {"center": (10, 10), "radius": 5, "area": 20, "number": 1},
+            {"center": (30, 30), "radius": 6, "area": 25, "number": 2},
+        ],
+    })
+    out_path = tmp_path / "numbered.xml"
+    service.save_xml_file(out_path)
+
+    aois = XmlService(out_path).get_images()[0]["areas_of_interest"]
+    assert aois[0]["number"] == 1
+    assert aois[1]["number"] == 2
+
+
+def test_add_image_to_xml_omits_number_when_absent(tmp_path):
+    """AOIs without a number must not gain a 'number' attribute."""
+    service = XmlService()
+    service.add_image_to_xml({
+        "path": "img.jpg",
+        "aois": [{"center": (10, 10), "radius": 5, "area": 20}],
+    })
+    out_path = tmp_path / "unnumbered.xml"
+    service.save_xml_file(out_path)
+
+    assert "number" not in XmlService(out_path).get_images()[0]["areas_of_interest"][0]
+
+
+def test_legacy_xml_loads_without_number(sample_xml):
+    """Legacy result files (no 'number' attribute) load with no 'number' key."""
+    images = XmlService(sample_xml).get_images()
+    for image in images:
+        for aoi in image["areas_of_interest"]:
+            assert "number" not in aoi
+
+
+def test_ensure_aoi_numbers_backfills_legacy_file(sample_xml):
+    """ensure_aoi_numbers assigns sequential numbers to an unnumbered file."""
+    service = XmlService(sample_xml)
+    images = service.get_images()
+
+    assert service.ensure_aoi_numbers(images) is True
+    assert images[0]["areas_of_interest"][0]["number"] == 1
+    assert images[1]["areas_of_interest"][0]["number"] == 2
+
+
+def test_ensure_aoi_numbers_is_idempotent(sample_xml):
+    """A second ensure_aoi_numbers pass changes nothing and returns False."""
+    service = XmlService(sample_xml)
+    images = service.get_images()
+    service.ensure_aoi_numbers(images)
+
+    assert service.ensure_aoi_numbers(images) is False
+    assert images[0]["areas_of_interest"][0]["number"] == 1
+    assert images[1]["areas_of_interest"][0]["number"] == 2
+
+
+def test_ensure_aoi_numbers_persists_to_xml(tmp_path, sample_xml):
+    """Backfilled numbers are written to the XML elements and survive reload."""
+    service = XmlService(sample_xml)
+    images = service.get_images()
+    service.ensure_aoi_numbers(images)
+
+    out_path = tmp_path / "backfilled.xml"
+    service.save_xml_file(out_path)
+
+    reloaded = XmlService(out_path).get_images()
+    assert reloaded[0]["areas_of_interest"][0]["number"] == 1
+    assert reloaded[1]["areas_of_interest"][0]["number"] == 2
+
+
+def test_ensure_aoi_numbers_fills_gaps_above_existing_max(tmp_path):
+    """Partially numbered files keep existing numbers; gaps get max+1 upward."""
+    xml_content = """
+    <data>
+        <images>
+            <image path="a.jpg">
+                <areas_of_interest center="(10,10)" radius="5" area="20" number="7"/>
+                <areas_of_interest center="(20,20)" radius="5" area="20"/>
+            </image>
+            <image path="b.jpg">
+                <areas_of_interest center="(30,30)" radius="5" area="20"/>
+            </image>
+        </images>
+    </data>
+    """.strip()
+    xml_path = tmp_path / "partial.xml"
+    with open(xml_path, "w") as f:
+        f.write(xml_content)
+
+    service = XmlService(xml_path)
+    images = service.get_images()
+    assert service.ensure_aoi_numbers(images) is True
+
+    # The already-numbered AOI keeps its number.
+    assert images[0]["areas_of_interest"][0]["number"] == 7
+    # Unnumbered AOIs get unique numbers above the existing maximum.
+    assert images[0]["areas_of_interest"][1]["number"] == 8
+    assert images[1]["areas_of_interest"][0]["number"] == 9

--- a/app/tests/core/views/images/viewer/widgets/test_aoi_selection_overlay.py
+++ b/app/tests/core/views/images/viewer/widgets/test_aoi_selection_overlay.py
@@ -1,0 +1,210 @@
+"""Tests for the selected-AOI on-image overlay (number badge + ruler)."""
+
+import pytest
+from PySide6.QtGui import QPixmap, QPainter
+from PySide6.QtWidgets import QStyleOptionGraphicsItem
+
+from core.views.images.viewer.widgets.AOISelectionOverlay import (
+    AOISelectionOverlay, build_ruler_model, compute_ruler_ticks,
+    ruler_angle_from_drag,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_ruler_ticks
+# ---------------------------------------------------------------------------
+
+def test_compute_ruler_ticks_empty_for_non_positive_width():
+    assert compute_ruler_ticks(0) == []
+    assert compute_ruler_ticks(-1) == []
+    assert compute_ruler_ticks(None) == []
+
+
+def test_compute_ruler_ticks_classifies_one_unit():
+    """A 1-unit ruler has major ends, a medium centre and minor quarters."""
+    assert compute_ruler_ticks(1.0) == [
+        (0.0, 'major'),
+        (0.25, 'minor'),
+        (0.5, 'medium'),
+        (0.75, 'minor'),
+        (1.0, 'major'),
+    ]
+
+
+def test_compute_ruler_ticks_stops_at_width():
+    """Ticks never run past the ruler's end."""
+    positions = [pos for pos, _ in compute_ruler_ticks(2.6)]
+    assert max(positions) == 2.5
+    assert all(pos <= 2.6 for pos in positions)
+
+
+def test_compute_ruler_ticks_major_on_whole_units():
+    ticks = dict(compute_ruler_ticks(3.0))
+    assert ticks[0.0] == 'major'
+    assert ticks[1.0] == 'major'
+    assert ticks[2.0] == 'major'
+    assert ticks[3.0] == 'major'
+    assert ticks[1.5] == 'medium'
+    assert ticks[2.25] == 'minor'
+
+
+# ---------------------------------------------------------------------------
+# build_ruler_model
+# ---------------------------------------------------------------------------
+
+def test_build_ruler_model_none_without_gsd():
+    """No ground sample distance means the ruler cannot be built."""
+    assert build_ruler_model(100, None, 'Feet') is None
+    assert build_ruler_model(100, 0, 'Feet') is None
+
+
+def test_build_ruler_model_none_without_radius():
+    assert build_ruler_model(0, 2.5, 'Feet') is None
+
+
+def test_build_ruler_model_feet():
+    """A 100 px radius at 2 cm/px is a 4 m (~13.12 ft) wide AOI."""
+    model = build_ruler_model(100, 2.0, 'Feet')
+    assert model['unit_label'] == 'ft'
+    assert model['width_units'] == pytest.approx(13.123, abs=0.01)
+    # 0.3048 m per foot / 0.02 m per px == 15.24 px per foot.
+    assert model['pixels_per_unit'] == pytest.approx(15.24, abs=0.01)
+    assert model['width_text'] == '13.12 ft'
+    assert model['ticks'][0] == (0.0, 'major')
+
+
+def test_build_ruler_model_meters():
+    """The same AOI is 4.00 m wide when the preference is metric."""
+    model = build_ruler_model(100, 2.0, 'Meters')
+    assert model['unit_label'] == 'm'
+    assert model['width_units'] == pytest.approx(4.0, abs=1e-6)
+    assert model['pixels_per_unit'] == pytest.approx(50.0, abs=1e-6)
+    assert model['width_text'] == '4.00 m'
+
+
+def test_build_ruler_model_accepts_legacy_unit_strings():
+    """Legacy 'ft'/'m' unit strings work like 'Feet'/'Meters'."""
+    assert build_ruler_model(100, 2.0, 'ft')['unit_label'] == 'ft'
+    assert build_ruler_model(100, 2.0, 'm')['unit_label'] == 'm'
+
+
+def test_build_ruler_model_ruler_spans_the_diameter():
+    """width_units * pixels_per_unit equals the AOI diameter in pixels."""
+    model = build_ruler_model(80, 3.3, 'Feet')
+    diameter_px = model['width_units'] * model['pixels_per_unit']
+    assert diameter_px == pytest.approx(160.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# AOISelectionOverlay graphics item
+# ---------------------------------------------------------------------------
+
+def test_overlay_item_hidden_until_configured(app):
+    item = AOISelectionOverlay()
+    assert not item.isVisible()
+    assert item.boundingRect().isEmpty()
+
+
+def test_overlay_item_paints_number_and_ruler(app):
+    """A configured overlay paints without error and has a bounding rect."""
+    item = AOISelectionOverlay()
+    item.configure((100.0, 120.0), 80, 7, build_ruler_model(80, 2.5, 'Feet'))
+
+    assert item.boundingRect().width() > 0
+    assert item.pos().x() == 100.0 and item.pos().y() == 120.0
+
+    pixmap = QPixmap(400, 400)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
+def test_overlay_item_paints_number_only_without_ruler(app):
+    """With no ruler model the overlay still paints the number badge."""
+    item = AOISelectionOverlay()
+    item.configure((50.0, 50.0), 40, 12, None)
+
+    pixmap = QPixmap(200, 200)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
+# ---------------------------------------------------------------------------
+# ruler_angle_from_drag
+# ---------------------------------------------------------------------------
+
+def test_ruler_angle_from_drag_zero_below_centre():
+    """A cursor straight below the AOI keeps the ruler horizontal."""
+    assert ruler_angle_from_drag(0.0, 10.0) == pytest.approx(0.0)
+
+
+def test_ruler_angle_from_drag_clamps_to_90():
+    """Dragging far to either side clamps the ruler to +/- 90 degrees."""
+    assert ruler_angle_from_drag(10.0, 0.0) == pytest.approx(-90.0)
+    assert ruler_angle_from_drag(-10.0, 0.0) == pytest.approx(90.0)
+
+
+def test_ruler_angle_from_drag_respects_grab_offset():
+    """The grab offset keeps the ruler from jumping when the handle is seized."""
+    # Offset equal to the cursor angle -> the ruler holds at 0.
+    assert ruler_angle_from_drag(10.0, 10.0, offset=45.0) == pytest.approx(0.0)
+
+
+def test_ruler_angle_from_drag_handles_zero_vector():
+    assert ruler_angle_from_drag(0.0, 0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# AOISelectionOverlay ruler rotation
+# ---------------------------------------------------------------------------
+
+def test_overlay_item_set_ruler_angle_clamps(app):
+    item = AOISelectionOverlay()
+    item.set_ruler_angle(45.0)
+    assert item.ruler_angle() == 45.0
+    item.set_ruler_angle(200.0)
+    assert item.ruler_angle() == 90.0
+    item.set_ruler_angle(-200.0)
+    assert item.ruler_angle() == -90.0
+    item.reset_ruler_angle()
+    assert item.ruler_angle() == 0.0
+
+
+def test_overlay_item_configure_keeps_ruler_angle(app):
+    """A refresh (configure) must not undo the user's rotation."""
+    item = AOISelectionOverlay()
+    item.set_ruler_angle(30.0)
+    item.configure((10.0, 10.0), 50, 1, build_ruler_model(50, 2.0, 'Feet'))
+    assert item.ruler_angle() == 30.0
+
+
+def test_overlay_item_handle_moves_with_angle(app):
+    """The grab handle's scene position changes as the ruler is rotated."""
+    item = AOISelectionOverlay()
+    item.configure((100.0, 100.0), 70, 4, build_ruler_model(70, 3.0, 'Meters'))
+
+    item.set_ruler_angle(0.0)
+    handle_flat = item.handle_scene_pos()
+    item.set_ruler_angle(90.0)
+    handle_rotated = item.handle_scene_pos()
+    assert handle_flat != handle_rotated
+
+
+def test_overlay_item_paints_rotated_ruler(app):
+    """A rotated ruler paints without error."""
+    item = AOISelectionOverlay()
+    item.configure((100.0, 100.0), 70, 4, build_ruler_model(70, 3.0, 'Meters'))
+    item.set_ruler_angle(60.0)
+    item.set_dragging(True)
+
+    pixmap = QPixmap(400, 400)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()

--- a/resources/views/images/viewer/Viewer.ui
+++ b/resources/views/images/viewer/Viewer.ui
@@ -766,6 +766,48 @@ Example: Type &quot;25&quot; and press Enter to jump to image #25</string>
               </widget>
              </item>
              <item>
+              <widget class="QLabel" name="aoiJumpLabel">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Jump to a specific AOI by its run-wide number.
+Enter an AOI number and press Enter to select and scroll to it.</string>
+               </property>
+               <property name="text">
+                <string>Go to AOI #:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="aoiJumpLine">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>50</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>50</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>Enter an AOI number and press Enter.
+Selects that AOI and scrolls it into view in the gallery or single-image list.</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QPushButton" name="previousImageButton">
                <property name="font">
                 <font>


### PR DESCRIPTION
## Summary

Adds four reviewer-facing capabilities to the image results viewer so it is
easier to track which AOIs have been reviewed during an analysis, even after
switching between gallery and single-image views or changing the sort order.

## Changes

**Persisted run-wide unique AOI numbers** — every AOI carries a stable
`number`, unique across the whole run, saved in `ADIAT_Data.xml`.
`AnalyzeService` assigns them at analysis time and
`XmlService.ensure_aoi_numbers()` backfills legacy result files on first
open. The attribute is additive, so older result files remain fully
readable.

**AOI number badges on thumbnails** — gallery and single-image AOI
thumbnails show the number, which also appears in the gallery
display/tooltip text.

**"Go to AOI #" jump box** — a small input beside the image jump box
selects and scrolls to any AOI by number, in both gallery and single-image
modes, with a clear status message when the number is missing or filtered
out.

**Selected-AOI on-image overlay** — clicking an AOI draws its number next
to the circle plus a horizontal real-world ruler beneath it, calibrated in
feet or metres per the distance-unit preference, with major/medium/minor
ticks every unit/half/quarter. The ruler has a grab handle that swings it
+/-90 degrees to align with the object being measured, uses the same GSD
pipeline as the Measure tool so the readings agree, and follows the
AOI-circle toggle.

## Implementation notes

- New `AOISelectionOverlay` (`QGraphicsItem`) and `AOIOverlayController`.
- The ruler-handle drag uses a viewport event filter, so it never
  interferes with panning or region-zoom.
- Orchestration stays in controllers, the overlay widget under `views/`,
  persistence in `XmlService`.
- The `Viewer.ui` change is regenerated into `Viewer_ui.py` via
  `pyside6-uic`.
- User-facing strings use `self.tr()` / `.ui` and are translation-ready.

## Testing

- Unit and pytest-qt coverage for AOI numbering, XML round-trip and legacy
  backfill, jump-to-AOI navigation, the ruler geometry/handle math, and the
  overlay lifecycle.
- A `conftest.py` fixture primes qtawesome so icon-dependent tests are
  independent of collection order.
- `flake8` clean on the changed files; targeted and domain test suites
  pass.
