### PR TITLE
feat: Grid Review Mode — systematic cell-by-cell image review

### DIFF
--- a/app/core/controllers/images/viewer/UIStyleController.py
+++ b/app/core/controllers/images/viewer/UIStyleController.py
@@ -169,6 +169,15 @@ class UIStyleController:
                 "rotateActive"
             )
 
+    def update_grid_review_button_style(self):
+        """Update the grid review button styling based on the mode state."""
+        if hasattr(self.parent, 'gridReviewButton') and hasattr(self.parent, 'grid_review_controller'):
+            self.update_toolbutton_style(
+                self.parent.gridReviewButton,
+                self.parent.grid_review_controller.active,
+                "buttonActive"
+            )
+
     def update_gallery_mode_button_style(self):
         """Update the Gallery Mode button styling based on its checked state."""
         if hasattr(self.parent, 'galleryModeButton'):

--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -31,6 +31,7 @@ from core.controllers.images.viewer.WingtraDataController import WingtraDataCont
 from core.controllers.images.viewer.AlignImageController import AlignImageController
 from core.controllers.images.viewer.WaldoPrePassController import WaldoPrePassController
 from core.controllers.images.viewer.image.ImageLoadController import ImageLoadController
+from core.controllers.images.viewer.grid.GridReviewController import GridReviewController
 from core.controllers.images.viewer.AOIOverlayController import AOIOverlayController
 from core.controllers.images.viewer.PixelInfoController import PixelInfoController
 from core.controllers.images.viewer.ThermalDataController import ThermalDataController
@@ -231,6 +232,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self.color_histogram_controller = ColorHistogramController(self)
         self.pixel_info_controller = PixelInfoController(self)
         self.image_load_controller = ImageLoadController(self)
+        self.grid_review_controller = GridReviewController(self)
         self.altitude_controller = AltitudeController(self)
         self.wingtra_controller = WingtraDataController(self)
         self.align_image_controller = AlignImageController(self)
@@ -271,7 +273,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self.messages = StatusDict(callback=self.status_controller.message_listener,
                                    key_order=["GPS Coordinates", "Relative Altitude",
                                               "Gimbal Orientation", "Estimated Average GSD",
-                                              "Temperature", "Color Values"])
+                                              "Temperature", "Color Values", "Grid Review"])
 
         # Apply icons
         self._apply_icons()
@@ -413,6 +415,10 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         # Clean up neighbor tracking controller
         if hasattr(self, 'neighbor_tracking_controller'):
             self.neighbor_tracking_controller.cleanup()
+
+        # Persist any unsaved grid review marks
+        if hasattr(self, 'grid_review_controller'):
+            self.grid_review_controller.cleanup()
 
         event.accept()
 
@@ -575,6 +581,9 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
 
     def _on_gallery_mode_clicked(self):
         """Handle Gallery Mode button click - update styling and toggle gallery mode."""
+        # Gallery and grid review are mutually exclusive single-surface modes
+        if hasattr(self, 'grid_review_controller'):
+            self.grid_review_controller.deactivate()
         # The button's checked state drives the gallery mode
         if hasattr(self, 'galleryModeButton'):
             should_be_in_gallery_mode = self.galleryModeButton.isChecked()
@@ -819,6 +828,12 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
                 # This allows text input in dialogs to work properly on macOS
                 super().keyPressEvent(e)
                 return
+
+        # Grid review mode gets first claim on keys: while active it owns
+        # Space/arrows/X/Esc (and S toggles it from anywhere). It returns
+        # False for everything else so all bindings below are unaffected.
+        if hasattr(self, 'grid_review_controller') and self.grid_review_controller.handle_key(e):
+            return
 
         if e.key() == Qt.Key_Right:
             if self.gallery_mode and hasattr(self, 'gallery_controller'):

--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -579,6 +579,10 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         if hasattr(self, 'image_gallery_splitter'):
             self.gallery_controller.save_splitter_position(self.image_gallery_splitter)
 
+    def _on_grid_review_clicked(self):
+        """Handle Grid Review button click - toggle the sweep mode."""
+        self.grid_review_controller.toggle_mode()
+
     def _on_gallery_mode_clicked(self):
         """Handle Gallery Mode button click - update styling and toggle gallery mode."""
         # Gallery and grid review are mutually exclusive single-surface modes
@@ -1145,6 +1149,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             self.zipButton.clicked.connect(self._zipButton_clicked)
             self.measureButton.clicked.connect(self._open_measure_dialog)
             self.personOverlayButton.clicked.connect(self._open_person_reference_dialog)
+            self.gridReviewButton.clicked.connect(self._on_grid_review_clicked)
             self.adjustmentsButton.clicked.connect(self._open_image_adjustment_dialog)
             self.magnifyButton.clicked.connect(self._magnifyButton_clicked)
             self.GPSMapButton.clicked.connect(self._gps_map_button_clicked)
@@ -1156,6 +1161,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             self.ui_style_controller.update_person_overlay_button_style()
             self.ui_style_controller.update_gps_map_button_style()
             self.ui_style_controller.update_rotate_image_button_style()
+            self.ui_style_controller.update_grid_review_button_style()
 
             # Connect the Gallery Mode button
             if hasattr(self, 'galleryModeButton'):
@@ -2086,6 +2092,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self.zipButton.setIcon(IconHelper.create_icon('fa5s.file-archive', self.theme))
         self.measureButton.setIcon(IconHelper.create_icon('fa6s.ruler', self.theme))
         self.personOverlayButton.setIcon(IconHelper.create_icon('fa6s.person', self.theme))
+        self.gridReviewButton.setIcon(IconHelper.create_icon('fa6s.border-all', self.theme))
         self.adjustmentsButton.setIcon(IconHelper.create_icon('fa6s.sliders', self.theme))
         self.previousImageButton.setIcon(IconHelper.create_icon('fa6s.arrow-left', self.theme))
         self.nextImageButton.setIcon(IconHelper.create_icon('fa6s.arrow-right', self.theme))

--- a/app/core/controllers/images/viewer/grid/GridReviewController.py
+++ b/app/core/controllers/images/viewer/grid/GridReviewController.py
@@ -240,9 +240,12 @@ class GridReviewController(TranslationMixin, QObject):
         )
         if dialog.exec():
             rows, cols, _ = dialog.values()
-            self._apply_grid_size(rows, cols)
+            if dialog.apply_to_all():
+                self._apply_grid_to_all(rows, cols)
+            else:
+                self._apply_grid_size(rows, cols)
             # Pick up a focus-guide toggle even when the grid size is
-            # unchanged (_apply_grid_size may have returned without redraw).
+            # unchanged (the apply path may have returned without redraw).
             image = self._current_image()
             if self.active and image is not None and self._overlay_item is not None:
                 self._refresh_overlay(image)
@@ -285,6 +288,70 @@ class GridReviewController(TranslationMixin, QObject):
         self._refresh_overlay(image)
         self._zoom_to_cell(self.current_cell)
         self._update_status()
+
+    @staticmethod
+    def _has_conflicting_progress(image, rows, cols):
+        """True when an image has reviewed cells recorded at a different size."""
+        grid = image.get('grid_review')
+        return bool(grid and grid['reviewed'] and (grid['rows'], grid['cols']) != (rows, cols))
+
+    def _apply_grid_to_all(self, rows, cols):
+        """Apply the chosen grid size to every image in the dataset.
+
+        Images with no review progress (and images already at this size)
+        take the new grid directly. Images already reviewed at a different
+        size would lose their cell mapping if resized, so the reviewer is
+        asked whether to reset those too or leave them at their own size.
+        The whole dataset is written once at the end.
+        """
+        images = getattr(self.parent, 'images', None)
+        if not images:
+            return
+        rows = max(1, int(rows))
+        cols = max(1, int(cols))
+
+        conflicting = [img for img in images
+                       if self._has_conflicting_progress(img, rows, cols)]
+        reset_conflicting = False
+        if conflicting:
+            from PySide6.QtWidgets import QMessageBox
+            reply = QMessageBox.question(
+                self.parent,
+                self.tr("Apply Grid to All Images"),
+                self.tr(
+                    "{n} image(s) already have review progress recorded at a "
+                    "different grid size.\n\nReset their progress and apply "
+                    "{rows}×{cols} to them too?\n\n"
+                    "Yes resets them; No keeps them at their current size."
+                ).format(n=len(conflicting), rows=rows, cols=cols),
+                QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
+                QMessageBox.No,
+            )
+            if reply == QMessageBox.Cancel:
+                return
+            reset_conflicting = (reply == QMessageBox.Yes)
+
+        for img in images:
+            if not reset_conflicting and self._has_conflicting_progress(img, rows, cols):
+                continue  # keep a started image at its own size
+            grid = img.get('grid_review')
+            if grid and (grid['rows'], grid['cols']) == (rows, cols):
+                reviewed = grid['reviewed']  # same size -> progress still valid
+            else:
+                reviewed = set()
+            img['grid_review'] = {'rows': rows, 'cols': cols, 'reviewed': reviewed}
+            image_xml = img.get('xml')
+            if image_xml is not None:
+                self.parent.xml_service.set_image_grid_review(image_xml, rows, cols, reviewed)
+
+        self._save_pending = True
+        self._flush_save()
+
+        # Re-grid the current view so the change is visible immediately.
+        if self.active:
+            image = self._current_image()
+            if image is not None:
+                self._begin_image_sweep(image)
 
     # ------------------------------------------------------------------ #
     #  Sweep logic

--- a/app/core/controllers/images/viewer/grid/GridReviewController.py
+++ b/app/core/controllers/images/viewer/grid/GridReviewController.py
@@ -15,8 +15,9 @@ the viewer's next/previous-image handlers, and progress display through
 the status bar message dict.
 
 Keyboard contract (keys are consumed only while the mode is active,
-except S which toggles the mode):
+except S/Shift+S which work from anywhere in the viewer):
     S            toggle grid review mode
+    Shift+S      open the grid settings dialog
     Space        mark current cell reviewed and advance (serpentine)
     Backspace /
     Shift+Space  step back one cell (no unmarking)
@@ -94,6 +95,9 @@ class GridReviewController(TranslationMixin, QObject):
 
         if key == Qt.Key_S and modifiers == Qt.NoModifier:
             self.toggle_mode()
+            return True
+        if key == Qt.Key_S and modifiers == Qt.ShiftModifier:
+            self.open_settings_dialog()
             return True
 
         if not self.active:
@@ -199,6 +203,80 @@ class GridReviewController(TranslationMixin, QObject):
     def cleanup(self):
         """Persist any pending marks; called from Viewer.closeEvent."""
         self._flush_save()
+
+    # ------------------------------------------------------------------ #
+    #  Settings dialog
+    # ------------------------------------------------------------------ #
+    def open_settings_dialog(self):
+        """Open the grid settings dialog and apply accepted values."""
+        # Imported here rather than at module top: the dialog pulls in the
+        # generated UI module, which the headless controller tests don't need.
+        from core.views.images.viewer.dialogs.GridReviewDialog import GridReviewDialog
+
+        suggestion = self._suggest_dims()
+        person_px = None
+        if suggestion is not None:
+            main_image = self.parent.main_image
+            cell_w = main_image.sceneRect().width() / suggestion[1]
+            try:
+                gsd_cm = self.parent._get_current_image_gsd()
+            except Exception:
+                gsd_cm = None
+            person_px = GridReviewService.person_screen_px(
+                gsd_cm, cell_w, main_image.viewport().width()
+            )
+
+        dialog = GridReviewDialog(
+            self.parent,
+            settings_service=getattr(self.parent, 'settings_service', None),
+            current_rows=self._rows,
+            current_cols=self._cols,
+            auto_mark=self._auto_mark_enabled(),
+            suggestion=suggestion,
+            person_px=person_px,
+        )
+        if dialog.exec():
+            rows, cols, _ = dialog.values()
+            self._apply_grid_size(rows, cols)
+
+    def _apply_grid_size(self, rows, cols):
+        """Resize the active sweep's grid when that is safe.
+
+        An image whose sweep already has marked cells keeps its stored
+        grid — resizing would silently remap the persisted cell indices.
+        The accepted size still becomes the default for unstarted images
+        (the dialog wrote it to settings).
+        """
+        if not self.active:
+            return
+        image = self._current_image()
+        if image is None:
+            return
+
+        grid = image.get('grid_review')
+        if grid and grid['reviewed']:
+            if (int(rows), int(cols)) != (grid['rows'], grid['cols']):
+                status = getattr(self.parent, 'status_controller', None)
+                if status is not None:
+                    status.show_toast(
+                        self.tr("This image keeps its existing grid — the new size applies to unstarted images."),
+                        3500
+                    )
+            return
+
+        if grid:
+            # A stored but unmarked grid is safe to discard.
+            image['grid_review'] = None
+            image_xml = image.get('xml')
+            if image_xml is not None:
+                self.parent.xml_service.clear_image_grid_review(image_xml)
+
+        self._rows = max(1, int(rows))
+        self._cols = max(1, int(cols))
+        self.current_cell = GridReviewService.serpentine_order(self._rows, self._cols)[0]
+        self._refresh_overlay(image)
+        self._zoom_to_cell(self.current_cell)
+        self._update_status()
 
     # ------------------------------------------------------------------ #
     #  Sweep logic

--- a/app/core/controllers/images/viewer/grid/GridReviewController.py
+++ b/app/core/controllers/images/viewer/grid/GridReviewController.py
@@ -1,0 +1,494 @@
+"""
+GridReviewController - Orchestrates the viewer's grid review mode.
+
+Grid review is a systematic human sweep for subjects the detection
+algorithms miss (e.g. people in natural-tone clothing): the image is
+divided into a grid, the reviewer steps cell-by-cell at a constant zoom
+with the keyboard, each visited cell is marked reviewed, and progress is
+persisted per image so a sweep can be resumed across sessions.
+
+The controller owns the runtime state (mode active, current cell) and
+coordinates the pieces that already exist elsewhere: cell math and
+progress in GridReviewService, the painted grid in GridOverlayItem,
+persistence via XmlService grid_* attributes on <image>, navigation via
+the viewer's next/previous-image handlers, and progress display through
+the status bar message dict.
+
+Keyboard contract (keys are consumed only while the mode is active,
+except S which toggles the mode):
+    S            toggle grid review mode
+    Space        mark current cell reviewed and advance (serpentine)
+    Backspace /
+    Shift+Space  step back one cell (no unmarking)
+    Arrows       move one cell directionally without marking
+    X            toggle reviewed state of the current cell
+    Esc          exit the mode and restore the full-image view
+"""
+
+from PySide6.QtCore import QObject, Qt, QRectF, QTimer
+
+from core.services.GridReviewService import GridReviewService
+from core.services.LoggerService import LoggerService
+from core.views.images.viewer.widgets.GridOverlayItem import GridOverlayItem
+from helpers.TranslationMixin import TranslationMixin
+
+# Fraction of the cell size shown beyond each cell edge when zoomed to a
+# cell, so the reviewer sees slivers of the neighboring cells and objects
+# straddling a boundary are not missed.
+_CELL_ZOOM_MARGIN = 0.08
+
+# Delay before persisting marked cells to the result XML. Saving rewrites
+# the whole file (which can be large), so rapid Space presses are coalesced;
+# the save is always flushed on image change, mode exit and window close.
+_SAVE_DEBOUNCE_MS = 2000
+
+_DEFAULT_GRID_SIZE = 4
+_DEFAULT_MIN_PERSON_PX = 60
+
+
+class GridReviewController(TranslationMixin, QObject):
+    """Controller for the grid review sweep in the results viewer."""
+
+    def __init__(self, parent_viewer):
+        """Initialize the grid review controller.
+
+        Args:
+            parent_viewer: The main Viewer instance.
+        """
+        super().__init__()
+        self.parent = parent_viewer
+        self.logger = LoggerService()
+        self.active = False
+        # Row-major index of the cell being reviewed, or None when inactive.
+        self.current_cell = None
+        # Grid dimensions for the current image's sweep. Mirrors the stored
+        # grid when one exists; otherwise the suggestion/settings default.
+        self._rows = _DEFAULT_GRID_SIZE
+        self._cols = _DEFAULT_GRID_SIZE
+        # The painted grid; created lazily once the image scene exists.
+        self._overlay_item = None
+        self._save_timer = QTimer(self)
+        self._save_timer.setSingleShot(True)
+        self._save_timer.setInterval(_SAVE_DEBOUNCE_MS)
+        self._save_timer.timeout.connect(self._flush_save)
+        self._save_pending = False
+
+    # ------------------------------------------------------------------ #
+    #  Keyboard handling
+    # ------------------------------------------------------------------ #
+    def handle_key(self, e):
+        """Handle a viewer key press.
+
+        Called first from Viewer.keyPressEvent. Returns True when the key
+        was consumed so every existing binding keeps working while the
+        mode is inactive.
+
+        Args:
+            e (QKeyEvent): The key event.
+
+        Returns:
+            bool: True when the event was handled.
+        """
+        key = e.key()
+        modifiers = e.modifiers()
+
+        if key == Qt.Key_S and modifiers == Qt.NoModifier:
+            self.toggle_mode()
+            return True
+
+        if not self.active:
+            return False
+
+        if key == Qt.Key_Space and modifiers == Qt.ShiftModifier:
+            self._retreat()
+            return True
+        if key == Qt.Key_Space and modifiers == Qt.NoModifier:
+            self._advance(mark=self._auto_mark_enabled())
+            return True
+        if key == Qt.Key_Backspace and modifiers == Qt.NoModifier:
+            self._retreat()
+            return True
+        if key in (Qt.Key_Right, Qt.Key_Left, Qt.Key_Up, Qt.Key_Down) and modifiers == Qt.NoModifier:
+            self._move_directional(key)
+            return True
+        if key == Qt.Key_X and modifiers == Qt.NoModifier:
+            self._toggle_current_reviewed()
+            return True
+        if key == Qt.Key_Escape and modifiers == Qt.NoModifier:
+            self.deactivate()
+            return True
+
+        return False
+
+    # ------------------------------------------------------------------ #
+    #  Mode lifecycle
+    # ------------------------------------------------------------------ #
+    def toggle_mode(self):
+        """Toggle grid review mode on or off."""
+        if self.active:
+            self.deactivate()
+        else:
+            self.activate()
+
+    def activate(self):
+        """Enter grid review mode on the current image.
+
+        Refused while the gallery is showing: the sweep is a single-image
+        workflow and needs the main image canvas.
+        """
+        if self.active:
+            return
+        if getattr(self.parent, 'gallery_mode', False):
+            status = getattr(self.parent, 'status_controller', None)
+            if status is not None:
+                status.show_toast(
+                    self.tr("Grid review works in single-image mode — exit the gallery first."),
+                    3000, "#B71C1C"
+                )
+            return
+        image = self._current_image()
+        if image is None:
+            return
+
+        self.active = True
+        self._begin_image_sweep(image)
+        self._sync_button_state()
+
+    def deactivate(self):
+        """Exit grid review mode, persist pending marks and restore the view."""
+        if not self.active:
+            self._sync_button_state()
+            return
+
+        self.active = False
+        self.current_cell = None
+        self._flush_save()
+        if self._overlay_item is not None:
+            self._overlay_item.hide()
+
+        main_image = getattr(self.parent, 'main_image', None)
+        if main_image is not None and not getattr(main_image, '_is_destroyed', True):
+            main_image.resetZoom()
+
+        self.parent.messages['Grid Review'] = None
+        self._sync_button_state()
+
+    def on_image_loaded(self):
+        """React to the viewer finishing an image load.
+
+        While the mode is active the freshly loaded image joins the sweep:
+        the grid is reconfigured for its dimensions and the view zooms to
+        its first unreviewed cell (overriding the zoom reset that just ran
+        in ImageLoadController.load_image). When inactive the grid just
+        stays hidden.
+        """
+        # An image change always flushes marks made on the previous image.
+        self._flush_save()
+
+        if not self.active:
+            if self._overlay_item is not None:
+                self._overlay_item.hide()
+            return
+
+        image = self._current_image()
+        if image is None:
+            self.deactivate()
+            return
+        self._begin_image_sweep(image)
+
+    def cleanup(self):
+        """Persist any pending marks; called from Viewer.closeEvent."""
+        self._flush_save()
+
+    # ------------------------------------------------------------------ #
+    #  Sweep logic
+    # ------------------------------------------------------------------ #
+    def _begin_image_sweep(self, image):
+        """Configure the grid for *image* and move to its first open cell."""
+        self._rows, self._cols = self._grid_dims_for_image(image)
+        reviewed = self._reviewed_cells(image)
+
+        order = GridReviewService.serpentine_order(self._rows, self._cols)
+        self.current_cell = next((c for c in order if c not in reviewed), order[0])
+
+        self._refresh_overlay(image)
+        self._zoom_to_cell(self.current_cell)
+        self._update_status()
+
+    def _advance(self, mark=True):
+        """Mark the current cell (optionally) and step forward in scan order.
+
+        Stepping past the last cell saves the image's sweep and moves on to
+        the next image; on_image_loaded then resumes at that image's first
+        unreviewed cell.
+        """
+        if self.current_cell is None:
+            return
+        if mark:
+            self._set_reviewed(self.current_cell, True)
+
+        order = GridReviewService.serpentine_order(self._rows, self._cols)
+        position = order.index(self.current_cell)
+        if position + 1 < len(order):
+            self.current_cell = order[position + 1]
+            self._on_cell_changed()
+        else:
+            status = getattr(self.parent, 'status_controller', None)
+            if status is not None:
+                status.show_toast(self.tr("Image fully reviewed — advancing"), 1500)
+            self._flush_save()
+            self.parent._nextImageButton_clicked()
+
+    def _retreat(self):
+        """Step back one cell in scan order without changing marks."""
+        if self.current_cell is None:
+            return
+        order = GridReviewService.serpentine_order(self._rows, self._cols)
+        position = order.index(self.current_cell)
+        if position > 0:
+            self.current_cell = order[position - 1]
+            self._on_cell_changed()
+
+    def _move_directional(self, key):
+        """Move one cell in the arrow direction, clamped at the grid edges."""
+        if self.current_cell is None:
+            return
+        row, col = divmod(self.current_cell, self._cols)
+        if key == Qt.Key_Right:
+            col = min(col + 1, self._cols - 1)
+        elif key == Qt.Key_Left:
+            col = max(col - 1, 0)
+        elif key == Qt.Key_Down:
+            row = min(row + 1, self._rows - 1)
+        elif key == Qt.Key_Up:
+            row = max(row - 1, 0)
+        target = row * self._cols + col
+        if target != self.current_cell:
+            self.current_cell = target
+            self._on_cell_changed()
+
+    def _toggle_current_reviewed(self):
+        """Toggle the reviewed state of the current cell."""
+        if self.current_cell is None:
+            return
+        image = self._current_image()
+        if image is None:
+            return
+        currently = self.current_cell in self._reviewed_cells(image)
+        self._set_reviewed(self.current_cell, not currently)
+
+    def _on_cell_changed(self):
+        """Update overlay highlight, zoom and status after a cell move."""
+        if self._overlay_item is not None:
+            self._overlay_item.set_current_index(self.current_cell)
+        self._zoom_to_cell(self.current_cell)
+        self._update_status()
+
+    # ------------------------------------------------------------------ #
+    #  Reviewed-state bookkeeping and persistence
+    # ------------------------------------------------------------------ #
+    def _set_reviewed(self, cell_index, reviewed):
+        """Record a cell's reviewed state in memory, XML and the overlay."""
+        image = self._current_image()
+        if image is None:
+            return
+
+        grid = image.get('grid_review')
+        if not grid:
+            grid = {'rows': self._rows, 'cols': self._cols, 'reviewed': set()}
+            image['grid_review'] = grid
+
+        if reviewed:
+            grid['reviewed'].add(cell_index)
+        else:
+            grid['reviewed'].discard(cell_index)
+
+        image_xml = image.get('xml')
+        if image_xml is not None:
+            self.parent.xml_service.set_image_grid_review(
+                image_xml, grid['rows'], grid['cols'], grid['reviewed']
+            )
+            self._save_pending = True
+            self._save_timer.start()
+
+        if self._overlay_item is not None:
+            self._overlay_item.set_reviewed(grid['reviewed'])
+        self._update_status()
+
+    def _flush_save(self):
+        """Write the result XML now if any marks are waiting."""
+        self._save_timer.stop()
+        if not self._save_pending:
+            return
+        self._save_pending = False
+        try:
+            self.parent.xml_service.save_xml_file(self.parent.xml_path)
+        except Exception as e:
+            self.logger.error(f"Grid review: could not save result file: {e}")
+
+    # ------------------------------------------------------------------ #
+    #  Grid geometry and view
+    # ------------------------------------------------------------------ #
+    def _grid_dims_for_image(self, image):
+        """Determine the grid for an image: stored > GSD suggestion > settings."""
+        grid = image.get('grid_review')
+        if grid:
+            return (grid['rows'], grid['cols'])
+
+        suggestion = self._suggest_dims()
+        if suggestion is not None:
+            return suggestion
+
+        return self._default_dims()
+
+    def _suggest_dims(self):
+        """Suggest grid dimensions from the current image's GSD, or None."""
+        try:
+            gsd_cm = self.parent._get_current_image_gsd()
+        except Exception:
+            gsd_cm = None
+        main_image = getattr(self.parent, 'main_image', None)
+        if gsd_cm is None or main_image is None or getattr(main_image, '_is_destroyed', True):
+            return None
+
+        scene_rect = main_image.sceneRect()
+        viewport = main_image.viewport()
+        return GridReviewService.suggest_grid(
+            scene_rect.width(), scene_rect.height(), gsd_cm,
+            viewport.width(), viewport.height(),
+            min_person_px=self._min_person_px()
+        )
+
+    def _default_dims(self):
+        """Read the default grid size from settings."""
+        rows = self._int_setting('GridReviewRows', _DEFAULT_GRID_SIZE)
+        cols = self._int_setting('GridReviewCols', _DEFAULT_GRID_SIZE)
+        return (max(1, rows), max(1, cols))
+
+    def _min_person_px(self):
+        return self._int_setting('GridReviewMinPersonPx', _DEFAULT_MIN_PERSON_PX)
+
+    def _auto_mark_enabled(self):
+        service = getattr(self.parent, 'settings_service', None)
+        if service is None:
+            return True
+        try:
+            return service.get_bool_setting('GridReviewAutoMark', True)
+        except Exception:
+            return True
+
+    def _int_setting(self, name, default):
+        service = getattr(self.parent, 'settings_service', None)
+        if service is None:
+            return default
+        try:
+            return int(service.get_setting(name, default))
+        except (TypeError, ValueError):
+            return default
+
+    def _refresh_overlay(self, image):
+        """(Re)configure the painted grid for the current image."""
+        if not self._ensure_overlay():
+            return
+        scene_rect = self.parent.main_image.sceneRect()
+        self._overlay_item.configure(
+            scene_rect.width(), scene_rect.height(),
+            self._rows, self._cols,
+            self._reviewed_cells(image), self.current_cell
+        )
+        self._overlay_item.show()
+
+    def _ensure_overlay(self):
+        """Create the grid graphics item in the image scene when needed.
+
+        Returns:
+            bool: True when the overlay item is available for use.
+        """
+        if self._overlay_item is not None:
+            return True
+
+        main_image = getattr(self.parent, 'main_image', None)
+        if main_image is None or getattr(main_image, '_is_destroyed', False):
+            return False
+        scene = getattr(main_image, 'scene', None)
+        if scene is None:
+            return False
+
+        self._overlay_item = GridOverlayItem()
+        scene.addItem(self._overlay_item)
+        return True
+
+    def _zoom_to_cell(self, cell_index):
+        """Frame a cell in the view, with a margin of neighboring context."""
+        main_image = getattr(self.parent, 'main_image', None)
+        if main_image is None or getattr(main_image, '_is_destroyed', True):
+            return
+        scene_rect = main_image.sceneRect()
+        rects = GridReviewService.cell_rects(
+            scene_rect.width(), scene_rect.height(), self._rows, self._cols
+        )
+        if cell_index is None or not (0 <= cell_index < len(rects)):
+            return
+        x, y, w, h = rects[cell_index]
+        margin_x = w * _CELL_ZOOM_MARGIN
+        margin_y = h * _CELL_ZOOM_MARGIN
+        main_image.zoomToRect(QRectF(x - margin_x, y - margin_y,
+                                     w + (2 * margin_x), h + (2 * margin_y)))
+
+    # ------------------------------------------------------------------ #
+    #  Progress display
+    # ------------------------------------------------------------------ #
+    def _update_status(self):
+        """Publish cell/image/run progress to the status bar."""
+        if not self.active:
+            return
+        image = self._current_image()
+        if image is None:
+            return
+
+        default_rows, default_cols = self._default_dims()
+        total_cells = self._rows * self._cols
+        order = GridReviewService.serpentine_order(self._rows, self._cols)
+        cell_number = order.index(self.current_cell) + 1 if self.current_cell in order else 0
+
+        run_reviewed, run_total = GridReviewService.run_progress(
+            self.parent.images, default_rows, default_cols
+        )
+        run_percent = int(round(100.0 * run_reviewed / run_total)) if run_total else 0
+
+        self.parent.messages['Grid Review'] = self.tr(
+            "cell {cell}/{cells} — image {image}/{images} — run {percent}% reviewed"
+        ).format(
+            cell=cell_number, cells=total_cells,
+            image=self.parent.current_image + 1, images=len(self.parent.images),
+            percent=run_percent
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Helpers
+    # ------------------------------------------------------------------ #
+    def _current_image(self):
+        """Return the current image dict, or None when unavailable."""
+        images = getattr(self.parent, 'images', None)
+        index = getattr(self.parent, 'current_image', None)
+        if not images or index is None or not (0 <= index < len(images)):
+            return None
+        return images[index]
+
+    @staticmethod
+    def _reviewed_cells(image):
+        """Return the reviewed-cell set for an image (empty when none)."""
+        grid = image.get('grid_review') if image else None
+        return grid['reviewed'] if grid else set()
+
+    def _sync_button_state(self):
+        """Mirror the mode state onto the toolbar button, when it exists."""
+        button = getattr(self.parent, 'gridReviewButton', None)
+        if button is not None:
+            try:
+                button.setChecked(self.active)
+            except Exception:
+                pass
+        style = getattr(self.parent, 'ui_style_controller', None)
+        if style is not None and hasattr(style, 'update_grid_review_button_style'):
+            style.update_grid_review_button_style()

--- a/app/core/controllers/images/viewer/grid/GridReviewController.py
+++ b/app/core/controllers/images/viewer/grid/GridReviewController.py
@@ -45,6 +45,8 @@ _SAVE_DEBOUNCE_MS = 2000
 
 _DEFAULT_GRID_SIZE = 4
 _DEFAULT_MIN_PERSON_PX = 60
+# Focus-guide subdivisions per side inside the active cell (3 -> nine).
+_DEFAULT_SUBDIVISIONS = 3
 
 
 class GridReviewController(TranslationMixin, QObject):
@@ -232,12 +234,18 @@ class GridReviewController(TranslationMixin, QObject):
             current_rows=self._rows,
             current_cols=self._cols,
             auto_mark=self._auto_mark_enabled(),
+            sub_guide=self._sub_guide_enabled(),
             suggestion=suggestion,
             person_px=person_px,
         )
         if dialog.exec():
             rows, cols, _ = dialog.values()
             self._apply_grid_size(rows, cols)
+            # Pick up a focus-guide toggle even when the grid size is
+            # unchanged (_apply_grid_size may have returned without redraw).
+            image = self._current_image()
+            if self.active and image is not None and self._overlay_item is not None:
+                self._refresh_overlay(image)
 
     def _apply_grid_size(self, rows, cols):
         """Resize the active sweep's grid when that is safe.
@@ -455,6 +463,20 @@ class GridReviewController(TranslationMixin, QObject):
         except Exception:
             return True
 
+    def _sub_guide_enabled(self):
+        """Whether the in-cell focus guide is shown (defaults on)."""
+        service = getattr(self.parent, 'settings_service', None)
+        if service is None:
+            return True
+        try:
+            return service.get_bool_setting('GridReviewSubGuide', True)
+        except Exception:
+            return True
+
+    def _subdivisions(self):
+        """Focus-guide subdivisions per side (1 = guide off)."""
+        return _DEFAULT_SUBDIVISIONS if self._sub_guide_enabled() else 1
+
     def _int_setting(self, name, default):
         service = getattr(self.parent, 'settings_service', None)
         if service is None:
@@ -472,7 +494,8 @@ class GridReviewController(TranslationMixin, QObject):
         self._overlay_item.configure(
             scene_rect.width(), scene_rect.height(),
             self._rows, self._cols,
-            self._reviewed_cells(image), self.current_cell
+            self._reviewed_cells(image), self.current_cell,
+            self._subdivisions()
         )
         self._overlay_item.show()
 

--- a/app/core/controllers/images/viewer/image/ImageLoadController.py
+++ b/app/core/controllers/images/viewer/image/ImageLoadController.py
@@ -131,6 +131,12 @@ class ImageLoadController(TranslationMixin):
             if hasattr(self.parent, '_update_person_overlay_button_enabled'):
                 self.parent._update_person_overlay_button_enabled()
 
+            # Grid review joins the new image last: when active it re-zooms
+            # to the image's first unreviewed cell, overriding the zoom
+            # reset performed above.
+            if hasattr(self.parent, 'grid_review_controller'):
+                self.parent.grid_review_controller.on_image_loaded()
+
         except Exception as e:
             self._handle_load_error(e, image)
 

--- a/app/core/controllers/images/viewer/status/StatusController.py
+++ b/app/core/controllers/images/viewer/status/StatusController.py
@@ -48,6 +48,7 @@ class StatusController(TranslationMixin):
             "Temperature": self.tr("Temperature"),
             "Color Values": self.tr("Color Values"),
             "Drone Orientation": self.tr("Drone Orientation"),
+            "Grid Review": self.tr("Grid Review"),
         }
 
         # GPS Coordinates first (with hyperlink)

--- a/app/core/services/GridReviewService.py
+++ b/app/core/services/GridReviewService.py
@@ -1,0 +1,233 @@
+import math
+
+
+class GridReviewService:
+    """Pure-logic helpers for the viewer's grid review mode.
+
+    Grid review overlays an N x M grid on an image so a reviewer can sweep
+    every cell systematically at a fixed zoom. This service holds all the
+    Qt-free math and (de)serialization: cell geometry, scan ordering,
+    GSD-based grid-size suggestion, reviewed-cell persistence format, and
+    progress computation. State itself lives on the image dicts/XML managed
+    by XmlService; runtime orchestration lives in GridReviewController.
+
+    Cells are identified by their row-major index (0 = top-left, increasing
+    left-to-right then top-to-bottom) regardless of the scan order used for
+    navigation, so persisted indices stay valid if scan order ever changes.
+    """
+
+    @staticmethod
+    def cell_rects(width, height, rows, cols):
+        """Compute the pixel rectangle of every grid cell.
+
+        Uses the same ceil-then-clamp tiling convention as
+        AlgorithmService.split_image so grid cells line up with algorithm
+        segments when the counts match. Cells tile the image exactly: no
+        gaps, no overlaps; the last row/column absorbs the remainder.
+
+        Args:
+            width: Image width in pixels.
+            height: Image height in pixels.
+            rows: Number of grid rows (>= 1).
+            cols: Number of grid columns (>= 1).
+
+        Returns:
+            List of (x, y, w, h) tuples in row-major order.
+        """
+        rows = max(1, int(rows))
+        cols = max(1, int(cols))
+        row_height = math.ceil(height / rows)
+        col_width = math.ceil(width / cols)
+
+        rects = []
+        for i in range(rows):
+            y = i * row_height
+            h = max(0, min((i + 1) * row_height, height) - y)
+            for j in range(cols):
+                x = j * col_width
+                w = max(0, min((j + 1) * col_width, width) - x)
+                rects.append((x, y, w, h))
+        return rects
+
+    @staticmethod
+    def serpentine_order(rows, cols):
+        """Compute the boustrophedon scan sequence over a grid.
+
+        Row 0 runs left-to-right, row 1 right-to-left, and so on — the
+        same systematic sweep pattern a human searcher uses, minimizing
+        the jump between consecutive cells.
+
+        Args:
+            rows: Number of grid rows.
+            cols: Number of grid columns.
+
+        Returns:
+            List of row-major cell indices in scan order.
+        """
+        rows = max(1, int(rows))
+        cols = max(1, int(cols))
+        order = []
+        for i in range(rows):
+            row = range(i * cols, (i + 1) * cols)
+            if i % 2 == 1:
+                row = reversed(row)
+            order.extend(row)
+        return order
+
+    @staticmethod
+    def suggest_grid(image_w, image_h, gsd_cm, viewport_w, viewport_h,
+                     min_person_px=60, person_height_cm=180, min_n=2, max_n=12):
+        """Suggest a grid size so a person is comfortably visible per cell.
+
+        When one cell fills the viewport, a person of person_height_cm
+        should span at least min_person_px on screen. Coarser GSD (fewer
+        image pixels per person) therefore yields smaller cells / more of
+        them.
+
+        Args:
+            image_w: Image width in pixels.
+            image_h: Image height in pixels.
+            gsd_cm: Ground sample distance in cm/pixel, or None if unknown.
+            viewport_w: Viewer viewport width in screen pixels.
+            viewport_h: Viewer viewport height in screen pixels.
+            min_person_px: Minimum on-screen person height in pixels.
+            person_height_cm: Assumed person height in cm.
+            min_n: Minimum rows/cols in the suggestion.
+            max_n: Maximum rows/cols in the suggestion.
+
+        Returns:
+            (rows, cols) tuple, or None when gsd/viewport data is unusable.
+        """
+        if gsd_cm is None or gsd_cm <= 0:
+            return None
+        if not image_w or not image_h or image_w <= 0 or image_h <= 0:
+            return None
+        if not viewport_w or not viewport_h or viewport_w <= 0 or viewport_h <= 0:
+            return None
+
+        person_image_px = person_height_cm / gsd_cm
+        if person_image_px <= 0:
+            return None
+
+        max_cell_w = viewport_w * person_image_px / min_person_px
+        max_cell_h = viewport_h * person_image_px / min_person_px
+
+        cols = min(max(math.ceil(image_w / max_cell_w), min_n), max_n)
+        rows = min(max(math.ceil(image_h / max_cell_h), min_n), max_n)
+        return (rows, cols)
+
+    @staticmethod
+    def person_screen_px(gsd_cm, cell_w, viewport_w, person_height_cm=180):
+        """Compute a person's on-screen height when one cell fills the view.
+
+        Used by the grid settings dialog to annotate its suggestion
+        ("person is approximately N px on screen at cell zoom").
+
+        Args:
+            gsd_cm: Ground sample distance in cm/pixel, or None.
+            cell_w: Cell width in image pixels.
+            viewport_w: Viewport width in screen pixels.
+            person_height_cm: Assumed person height in cm.
+
+        Returns:
+            On-screen person height in pixels, or None when inputs are unusable.
+        """
+        if gsd_cm is None or gsd_cm <= 0 or not cell_w or cell_w <= 0:
+            return None
+        if not viewport_w or viewport_w <= 0:
+            return None
+        person_image_px = person_height_cm / gsd_cm
+        return person_image_px * (viewport_w / cell_w)
+
+    @staticmethod
+    def parse_reviewed(attr):
+        """Parse a persisted reviewed-cells attribute string.
+
+        Tolerant of junk: non-integer tokens and negative values are
+        skipped silently so a hand-edited or corrupted attribute never
+        breaks loading.
+
+        Args:
+            attr: Attribute string like "0,1,5", or None/empty.
+
+        Returns:
+            Set of reviewed row-major cell indices.
+        """
+        reviewed = set()
+        if not attr:
+            return reviewed
+        for token in str(attr).split(','):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                index = int(token)
+            except ValueError:
+                continue
+            if index >= 0:
+                reviewed.add(index)
+        return reviewed
+
+    @staticmethod
+    def serialize_reviewed(cells):
+        """Serialize reviewed cell indices for XML persistence.
+
+        Args:
+            cells: Iterable of row-major cell indices.
+
+        Returns:
+            Sorted comma-separated string like "0,1,5".
+        """
+        return ','.join(str(index) for index in sorted(set(cells)))
+
+    @staticmethod
+    def image_progress(image, default_rows, default_cols):
+        """Compute review progress for one image.
+
+        Images with no stored grid count against the default grid size
+        with zero cells reviewed, so run-level percentages stay meaningful
+        before a sweep starts.
+
+        Args:
+            image: Image dict from XmlService.get_images().
+            default_rows: Grid rows assumed for images without stored grids.
+            default_cols: Grid cols assumed for images without stored grids.
+
+        Returns:
+            (reviewed_count, total_cells) tuple.
+        """
+        grid = image.get('grid_review') if image else None
+        if grid:
+            total = grid['rows'] * grid['cols']
+            # Clamp to the valid range in case a stale attribute carries
+            # indices from a larger grid.
+            reviewed = len({c for c in grid['reviewed'] if 0 <= c < total})
+        else:
+            total = max(1, int(default_rows)) * max(1, int(default_cols))
+            reviewed = 0
+        return (reviewed, total)
+
+    @staticmethod
+    def run_progress(images, default_rows, default_cols):
+        """Compute review progress across a whole run.
+
+        Hidden images are excluded — they are out of the review scope by
+        definition.
+
+        Args:
+            images: Images list from XmlService.get_images().
+            default_rows: Grid rows assumed for images without stored grids.
+            default_cols: Grid cols assumed for images without stored grids.
+
+        Returns:
+            (reviewed_count, total_cells) tuple across all visible images.
+        """
+        reviewed_sum = 0
+        total_sum = 0
+        for image in images or []:
+            if image.get('hidden'):
+                continue
+            reviewed, total = GridReviewService.image_progress(image, default_rows, default_cols)
+            reviewed_sum += reviewed
+            total_sum += total
+        return (reviewed_sum, total_sum)

--- a/app/core/services/XmlService.py
+++ b/app/core/services/XmlService.py
@@ -4,6 +4,7 @@ from ast import literal_eval
 from datetime import datetime
 import uuid
 import xml.etree.ElementTree as ET
+from core.services.GridReviewService import GridReviewService
 from core.services.LoggerService import LoggerService
 
 
@@ -155,7 +156,15 @@ class XmlService:
                 if fov_alignment is not None:
                     image['fov_alignment'] = fov_alignment
 
+                # Load grid review state if present (None when absent/malformed)
+                image['grid_review'] = self._parse_grid_review(image_xml)
+
                 areas_of_interest = []
+                # NOTE: every child element of <image> is treated as an AOI here,
+                # in this and every shipped version of ADIAT. New per-image state
+                # MUST be stored as attributes on <image> (like 'hidden',
+                # 'bearing*', 'fov_*', 'grid_*'), never as child elements, or old
+                # builds will mis-parse it as an AOI.
                 for area_of_interest_xml in image_xml:
                     area_of_interest = {
                         'area': float(area_of_interest_xml.get('area', "0")),
@@ -632,6 +641,79 @@ class XmlService:
 
         except Exception as e:
             self.logger.error(f"Error setting image FOV alignment: {e}")
+            return False
+
+    @staticmethod
+    def _parse_grid_review(image_xml):
+        """Parse grid review attributes from an <image> element.
+
+        Args:
+            image_xml: The <image> ElementTree element.
+
+        Returns:
+            dict with 'rows' (int), 'cols' (int) and 'reviewed' (set of
+            row-major cell indices), or None when the image has no usable
+            grid review state.
+        """
+        rows_attr = image_xml.get('grid_rows')
+        cols_attr = image_xml.get('grid_cols')
+        if rows_attr is None or cols_attr is None:
+            return None
+
+        try:
+            rows = int(rows_attr)
+            cols = int(cols_attr)
+        except (ValueError, TypeError):
+            # Malformed grid dimensions - treat the image as unreviewed.
+            return None
+
+        if rows < 1 or cols < 1:
+            return None
+
+        reviewed = GridReviewService.parse_reviewed(image_xml.get('grid_reviewed'))
+        return {'rows': rows, 'cols': cols, 'reviewed': reviewed}
+
+    def set_image_grid_review(self, image_xml, rows, cols, reviewed_cells):
+        """Store grid review state for an image as <image> attributes.
+
+        Grid state is stored as attributes (never child elements) so old
+        ADIAT builds, which treat every <image> child as an AOI, keep
+        loading these files correctly.
+
+        Args:
+            image_xml: The <image> ElementTree element to update.
+            rows (int): Number of grid rows.
+            cols (int): Number of grid columns.
+            reviewed_cells: Iterable of reviewed row-major cell indices.
+
+        Returns:
+            bool: True on success, False otherwise.
+        """
+        try:
+            image_xml.set('grid_rows', str(int(rows)))
+            image_xml.set('grid_cols', str(int(cols)))
+            image_xml.set('grid_reviewed', GridReviewService.serialize_reviewed(reviewed_cells))
+            return True
+        except Exception as e:
+            self.logger.error(f"Error setting image grid review state: {e}")
+            return False
+
+    def clear_image_grid_review(self, image_xml):
+        """Remove any grid review attributes from an <image> element.
+
+        Args:
+            image_xml: The <image> ElementTree element to update.
+
+        Returns:
+            bool: True on success, False otherwise.
+        """
+        try:
+            for attr in ('grid_rows', 'grid_cols', 'grid_reviewed'):
+                if attr in image_xml.attrib:
+                    del image_xml.attrib[attr]
+            return True
+        except Exception as e:
+            self.logger.error(f"Error clearing image grid review state: {e}")
             return False
 
     def clear_image_fov_alignment(self, image_path):

--- a/app/core/views/images/viewer/dialogs/GridReviewDialog.py
+++ b/app/core/views/images/viewer/dialogs/GridReviewDialog.py
@@ -1,0 +1,75 @@
+"""
+GridReviewDialog - Settings dialog for the viewer's grid review mode.
+
+Lets the reviewer pick the review grid size (rows x columns), toggle
+auto-marking on advance, and apply a GSD-based suggestion sized so a
+person remains comfortably visible when one cell fills the viewport.
+Accepted values are persisted to QSettings as the defaults for images
+that have no stored grid yet; images with a sweep already in progress
+keep their own grid (stored in the result XML).
+"""
+
+from PySide6.QtWidgets import QDialog
+
+from core.views.images.viewer.ui.GridReviewDialog_ui import Ui_GridReviewDialog
+from helpers.TranslationMixin import TranslationMixin
+
+
+class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
+    """Dialog for grid review preferences and the GSD-based suggestion."""
+
+    def __init__(self, parent=None, settings_service=None, current_rows=4,
+                 current_cols=4, auto_mark=True, suggestion=None, person_px=None):
+        """Initialize the dialog.
+
+        Args:
+            parent: Parent widget.
+            settings_service: SettingsService used to persist accepted values.
+            current_rows: Grid rows preloaded into the spinbox.
+            current_cols: Grid columns preloaded into the spinbox.
+            auto_mark: Initial auto-mark checkbox state.
+            suggestion: Optional (rows, cols) GSD-based suggestion.
+            person_px: Optional on-screen person height (pixels) at cell
+                zoom for the suggested grid, shown next to the suggestion.
+        """
+        super().__init__(parent)
+        self.setupUi(self)
+        self._apply_translations()
+        self.settings_service = settings_service
+        self._suggestion = suggestion
+
+        self.rowsSpinBox.setValue(int(current_rows))
+        self.colsSpinBox.setValue(int(current_cols))
+        self.autoMarkCheckBox.setChecked(bool(auto_mark))
+
+        if suggestion is not None:
+            rows, cols = suggestion
+            if person_px is not None:
+                text = self.tr(
+                    "Suggested: {rows}×{cols} (person ≈ {px} px on screen at cell zoom)"
+                ).format(rows=rows, cols=cols, px=int(round(person_px)))
+            else:
+                text = self.tr("Suggested: {rows}×{cols}").format(rows=rows, cols=cols)
+            self.suggestionLabel.setText(text)
+            self.useSuggestionButton.setEnabled(True)
+            self.useSuggestionButton.clicked.connect(self._use_suggestion)
+
+    def _use_suggestion(self):
+        """Copy the GSD-based suggestion into the spinboxes."""
+        rows, cols = self._suggestion
+        self.rowsSpinBox.setValue(rows)
+        self.colsSpinBox.setValue(cols)
+
+    def values(self):
+        """Return the chosen (rows, cols, auto_mark)."""
+        return (self.rowsSpinBox.value(), self.colsSpinBox.value(),
+                self.autoMarkCheckBox.isChecked())
+
+    def accept(self):
+        """Persist the chosen values as defaults, then close."""
+        if self.settings_service is not None:
+            rows, cols, auto_mark = self.values()
+            self.settings_service.set_setting('GridReviewRows', rows)
+            self.settings_service.set_setting('GridReviewCols', cols)
+            self.settings_service.set_setting('GridReviewAutoMark', auto_mark)
+        super().accept()

--- a/app/core/views/images/viewer/dialogs/GridReviewDialog.py
+++ b/app/core/views/images/viewer/dialogs/GridReviewDialog.py
@@ -72,6 +72,14 @@ class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
         """Return the chosen focus-guide toggle state."""
         return self.subGuideCheckBox.isChecked()
 
+    def apply_to_all(self):
+        """Return True when the grid size should apply to every image.
+
+        This is a one-shot action, not a saved preference, so it is not
+        persisted; it always starts unchecked when the dialog opens.
+        """
+        return self.applyAllCheckBox.isChecked()
+
     def accept(self):
         """Persist the chosen values as defaults, then close."""
         if self.settings_service is not None:

--- a/app/core/views/images/viewer/dialogs/GridReviewDialog.py
+++ b/app/core/views/images/viewer/dialogs/GridReviewDialog.py
@@ -19,7 +19,8 @@ class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
     """Dialog for grid review preferences and the GSD-based suggestion."""
 
     def __init__(self, parent=None, settings_service=None, current_rows=4,
-                 current_cols=4, auto_mark=True, suggestion=None, person_px=None):
+                 current_cols=4, auto_mark=True, sub_guide=True,
+                 suggestion=None, person_px=None):
         """Initialize the dialog.
 
         Args:
@@ -28,6 +29,7 @@ class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
             current_rows: Grid rows preloaded into the spinbox.
             current_cols: Grid columns preloaded into the spinbox.
             auto_mark: Initial auto-mark checkbox state.
+            sub_guide: Initial state of the in-cell 3x3 focus-guide toggle.
             suggestion: Optional (rows, cols) GSD-based suggestion.
             person_px: Optional on-screen person height (pixels) at cell
                 zoom for the suggested grid, shown next to the suggestion.
@@ -41,6 +43,7 @@ class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
         self.rowsSpinBox.setValue(int(current_rows))
         self.colsSpinBox.setValue(int(current_cols))
         self.autoMarkCheckBox.setChecked(bool(auto_mark))
+        self.subGuideCheckBox.setChecked(bool(sub_guide))
 
         if suggestion is not None:
             rows, cols = suggestion
@@ -65,6 +68,10 @@ class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
         return (self.rowsSpinBox.value(), self.colsSpinBox.value(),
                 self.autoMarkCheckBox.isChecked())
 
+    def sub_guide_enabled(self):
+        """Return the chosen focus-guide toggle state."""
+        return self.subGuideCheckBox.isChecked()
+
     def accept(self):
         """Persist the chosen values as defaults, then close."""
         if self.settings_service is not None:
@@ -72,4 +79,5 @@ class GridReviewDialog(TranslationMixin, QDialog, Ui_GridReviewDialog):
             self.settings_service.set_setting('GridReviewRows', rows)
             self.settings_service.set_setting('GridReviewCols', cols)
             self.settings_service.set_setting('GridReviewAutoMark', auto_mark)
+            self.settings_service.set_setting('GridReviewSubGuide', self.sub_guide_enabled())
         super().accept()

--- a/app/core/views/images/viewer/dialogs/HelpDialog.py
+++ b/app/core/views/images/viewer/dialogs/HelpDialog.py
@@ -251,7 +251,7 @@ class HelpDialog(TranslationMixin, QDialog):
                     </tr>
                     <tr>
                         <td>Shift + S</td>
-                        <td>Open Grid Review settings (grid size, auto-mark, GSD-based suggestion)</td>
+                        <td>Open Grid Review settings (grid size, auto-mark, 3×3 focus guide, GSD-based suggestion)</td>
                     </tr>
                     <tr>
                         <td>Shift + O</td>

--- a/app/core/views/images/viewer/dialogs/HelpDialog.py
+++ b/app/core/views/images/viewer/dialogs/HelpDialog.py
@@ -242,6 +242,18 @@ class HelpDialog(TranslationMixin, QDialog):
                         <td>Track selected AOI across neighboring images (shows where AOI appears in flight path)</td>
                     </tr>
                     <tr>
+                        <td>S</td>
+                        <td>Toggle Grid Review Mode — sweep the image cell by cell at a fixed zoom.
+                            While active: Space marks the cell reviewed and advances (rolling into the
+                            next image), arrow keys move without marking, X toggles the current cell,
+                            Backspace steps back, Esc exits. Reviewed cells are saved with the results.
+                            (The grid does not appear in the north-oriented R view.)</td>
+                    </tr>
+                    <tr>
+                        <td>Shift + S</td>
+                        <td>Open Grid Review settings (grid size, auto-mark, GSD-based suggestion)</td>
+                    </tr>
+                    <tr>
                         <td>Shift + O</td>
                         <td>Override altitude for all images (manually set custom
                             AGL altitude for GSD calculations)</td>

--- a/app/core/views/images/viewer/dialogs/HelpDialog.py
+++ b/app/core/views/images/viewer/dialogs/HelpDialog.py
@@ -251,7 +251,8 @@ class HelpDialog(TranslationMixin, QDialog):
                     </tr>
                     <tr>
                         <td>Shift + S</td>
-                        <td>Open Grid Review settings (grid size, auto-mark, 3×3 focus guide, GSD-based suggestion)</td>
+                        <td>Open Grid Review settings (grid size, auto-mark, 3×3 focus guide,
+                            GSD-based suggestion, and "apply this grid size to all images")</td>
                     </tr>
                     <tr>
                         <td>Shift + O</td>

--- a/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
+++ b/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
@@ -76,6 +76,11 @@ class Ui_GridReviewDialog(object):
 
         self.verticalLayout.addWidget(self.subGuideCheckBox)
 
+        self.applyAllCheckBox = QCheckBox(GridReviewDialog)
+        self.applyAllCheckBox.setObjectName(u"applyAllCheckBox")
+
+        self.verticalLayout.addWidget(self.applyAllCheckBox)
+
         self.suggestionLayout = QHBoxLayout()
         self.suggestionLayout.setObjectName(u"suggestionLayout")
         self.suggestionLabel = QLabel(GridReviewDialog)
@@ -122,6 +127,10 @@ class Ui_GridReviewDialog(object):
         self.subGuideCheckBox.setToolTip(QCoreApplication.translate("GridReviewDialog", u"Draw a 3\u00d73 guide inside the active cell to focus your scan. Visual only \u2014 it does not change what gets reviewed.", None))
 #endif // QT_CONFIG(tooltip)
         self.subGuideCheckBox.setText(QCoreApplication.translate("GridReviewDialog", u"Show 3\u00d73 focus guide inside each cell", None))
+#if QT_CONFIG(tooltip)
+        self.applyAllCheckBox.setToolTip(QCoreApplication.translate("GridReviewDialog", u"Apply the chosen rows and columns to every image in this dataset, not just the current one. Images you have already started reviewing keep their progress unless you confirm a reset.", None))
+#endif // QT_CONFIG(tooltip)
+        self.applyAllCheckBox.setText(QCoreApplication.translate("GridReviewDialog", u"Apply this grid size to all images", None))
         self.suggestionLabel.setText(QCoreApplication.translate("GridReviewDialog", u"No grid suggestion available (image GSD unknown).", None))
         self.useSuggestionButton.setText(QCoreApplication.translate("GridReviewDialog", u"Use Suggestion", None))
     # retranslateUi

--- a/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
+++ b/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'GridReviewDialog.ui'
+##
+## Created by: Qt User Interface Compiler version 6.9.2
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractButton, QApplication, QCheckBox, QDialog,
+    QDialogButtonBox, QFormLayout, QHBoxLayout, QLabel,
+    QPushButton, QSizePolicy, QSpacerItem, QSpinBox,
+    QVBoxLayout, QWidget)
+
+class Ui_GridReviewDialog(object):
+    def setupUi(self, GridReviewDialog):
+        if not GridReviewDialog.objectName():
+            GridReviewDialog.setObjectName(u"GridReviewDialog")
+        GridReviewDialog.resize(380, 260)
+        self.verticalLayout = QVBoxLayout(GridReviewDialog)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.descriptionLabel = QLabel(GridReviewDialog)
+        self.descriptionLabel.setObjectName(u"descriptionLabel")
+        self.descriptionLabel.setWordWrap(True)
+
+        self.verticalLayout.addWidget(self.descriptionLabel)
+
+        self.formLayout = QFormLayout()
+        self.formLayout.setObjectName(u"formLayout")
+        self.rowsLabel = QLabel(GridReviewDialog)
+        self.rowsLabel.setObjectName(u"rowsLabel")
+
+        self.formLayout.setWidget(0, QFormLayout.ItemRole.LabelRole, self.rowsLabel)
+
+        self.rowsSpinBox = QSpinBox(GridReviewDialog)
+        self.rowsSpinBox.setObjectName(u"rowsSpinBox")
+        self.rowsSpinBox.setMinimum(1)
+        self.rowsSpinBox.setMaximum(12)
+        self.rowsSpinBox.setValue(4)
+
+        self.formLayout.setWidget(0, QFormLayout.ItemRole.FieldRole, self.rowsSpinBox)
+
+        self.colsLabel = QLabel(GridReviewDialog)
+        self.colsLabel.setObjectName(u"colsLabel")
+
+        self.formLayout.setWidget(1, QFormLayout.ItemRole.LabelRole, self.colsLabel)
+
+        self.colsSpinBox = QSpinBox(GridReviewDialog)
+        self.colsSpinBox.setObjectName(u"colsSpinBox")
+        self.colsSpinBox.setMinimum(1)
+        self.colsSpinBox.setMaximum(12)
+        self.colsSpinBox.setValue(4)
+
+        self.formLayout.setWidget(1, QFormLayout.ItemRole.FieldRole, self.colsSpinBox)
+
+
+        self.verticalLayout.addLayout(self.formLayout)
+
+        self.autoMarkCheckBox = QCheckBox(GridReviewDialog)
+        self.autoMarkCheckBox.setObjectName(u"autoMarkCheckBox")
+        self.autoMarkCheckBox.setChecked(True)
+
+        self.verticalLayout.addWidget(self.autoMarkCheckBox)
+
+        self.suggestionLayout = QHBoxLayout()
+        self.suggestionLayout.setObjectName(u"suggestionLayout")
+        self.suggestionLabel = QLabel(GridReviewDialog)
+        self.suggestionLabel.setObjectName(u"suggestionLabel")
+        self.suggestionLabel.setWordWrap(True)
+
+        self.suggestionLayout.addWidget(self.suggestionLabel)
+
+        self.useSuggestionButton = QPushButton(GridReviewDialog)
+        self.useSuggestionButton.setObjectName(u"useSuggestionButton")
+        self.useSuggestionButton.setEnabled(False)
+
+        self.suggestionLayout.addWidget(self.useSuggestionButton)
+
+
+        self.verticalLayout.addLayout(self.suggestionLayout)
+
+        self.verticalSpacer = QSpacerItem(20, 10, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout.addItem(self.verticalSpacer)
+
+        self.buttonBox = QDialogButtonBox(GridReviewDialog)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setOrientation(Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+
+        self.verticalLayout.addWidget(self.buttonBox)
+
+
+        self.retranslateUi(GridReviewDialog)
+        self.buttonBox.accepted.connect(GridReviewDialog.accept)
+        self.buttonBox.rejected.connect(GridReviewDialog.reject)
+
+        QMetaObject.connectSlotsByName(GridReviewDialog)
+    # setupUi
+
+    def retranslateUi(self, GridReviewDialog):
+        GridReviewDialog.setWindowTitle(QCoreApplication.translate("GridReviewDialog", u"Grid Review Settings", None))
+        self.descriptionLabel.setText(QCoreApplication.translate("GridReviewDialog", u"Choose how many cells the review grid divides each image into. Smaller cells mean a higher zoom per cell.", None))
+        self.rowsLabel.setText(QCoreApplication.translate("GridReviewDialog", u"Rows", None))
+        self.colsLabel.setText(QCoreApplication.translate("GridReviewDialog", u"Columns", None))
+        self.autoMarkCheckBox.setText(QCoreApplication.translate("GridReviewDialog", u"Mark cells reviewed when advancing (Space)", None))
+        self.suggestionLabel.setText(QCoreApplication.translate("GridReviewDialog", u"No grid suggestion available (image GSD unknown).", None))
+        self.useSuggestionButton.setText(QCoreApplication.translate("GridReviewDialog", u"Use Suggestion", None))
+    # retranslateUi
+

--- a/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
+++ b/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
@@ -70,6 +70,12 @@ class Ui_GridReviewDialog(object):
 
         self.verticalLayout.addWidget(self.autoMarkCheckBox)
 
+        self.subGuideCheckBox = QCheckBox(GridReviewDialog)
+        self.subGuideCheckBox.setObjectName(u"subGuideCheckBox")
+        self.subGuideCheckBox.setChecked(True)
+
+        self.verticalLayout.addWidget(self.subGuideCheckBox)
+
         self.suggestionLayout = QHBoxLayout()
         self.suggestionLayout.setObjectName(u"suggestionLayout")
         self.suggestionLabel = QLabel(GridReviewDialog)
@@ -112,6 +118,10 @@ class Ui_GridReviewDialog(object):
         self.rowsLabel.setText(QCoreApplication.translate("GridReviewDialog", u"Rows", None))
         self.colsLabel.setText(QCoreApplication.translate("GridReviewDialog", u"Columns", None))
         self.autoMarkCheckBox.setText(QCoreApplication.translate("GridReviewDialog", u"Mark cells reviewed when advancing (Space)", None))
+#if QT_CONFIG(tooltip)
+        self.subGuideCheckBox.setToolTip(QCoreApplication.translate("GridReviewDialog", u"Draw a 3\u00d73 guide inside the active cell to focus your scan. Visual only \u2014 it does not change what gets reviewed.", None))
+#endif // QT_CONFIG(tooltip)
+        self.subGuideCheckBox.setText(QCoreApplication.translate("GridReviewDialog", u"Show 3\u00d73 focus guide inside each cell", None))
         self.suggestionLabel.setText(QCoreApplication.translate("GridReviewDialog", u"No grid suggestion available (image GSD unknown).", None))
         self.useSuggestionButton.setText(QCoreApplication.translate("GridReviewDialog", u"Use Suggestion", None))
     # retranslateUi

--- a/app/core/views/images/viewer/ui/Viewer_ui.py
+++ b/app/core/views/images/viewer/ui/Viewer_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'Viewer.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.10.2
+## Created by: Qt User Interface Compiler version 6.9.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -213,6 +213,13 @@ class Ui_Viewer(object):
         self.personOverlayButton.setIconSize(QSize(25, 25))
 
         self.horizontalLayout_5.addWidget(self.personOverlayButton)
+
+        self.gridReviewButton = QToolButton(self.mainHeaderWidget)
+        self.gridReviewButton.setObjectName(u"gridReviewButton")
+        self.gridReviewButton.setIconSize(QSize(25, 25))
+        self.gridReviewButton.setCheckable(True)
+
+        self.horizontalLayout_5.addWidget(self.gridReviewButton)
 
         self.magnifyButton = QToolButton(self.mainHeaderWidget)
         self.magnifyButton.setObjectName(u"magnifyButton")
@@ -632,6 +639,11 @@ class Ui_Viewer(object):
 #endif // QT_CONFIG(tooltip)
         self.personOverlayButton.setText(QCoreApplication.translate("Viewer", u"...", None))
         self.personOverlayButton.setProperty(u"iconName", QCoreApplication.translate("Viewer", u"person.png", None))
+#if QT_CONFIG(tooltip)
+        self.gridReviewButton.setToolTip(QCoreApplication.translate("Viewer", u"Toggle Grid Review Mode (S) \u2014 sweep the image cell by cell; Shift+S for grid settings", None))
+#endif // QT_CONFIG(tooltip)
+        self.gridReviewButton.setText(QCoreApplication.translate("Viewer", u"...", None))
+        self.gridReviewButton.setProperty(u"iconName", QCoreApplication.translate("Viewer", u"grid.png", None))
 #if QT_CONFIG(tooltip)
         self.magnifyButton.setToolTip(QCoreApplication.translate("Viewer", u"Toggle Magnifying Glass (Middle Mouse)", None))
 #endif // QT_CONFIG(tooltip)

--- a/app/core/views/images/viewer/widgets/GridOverlayItem.py
+++ b/app/core/views/images/viewer/widgets/GridOverlayItem.py
@@ -3,16 +3,19 @@ GridOverlayItem - On-image grid decoration for grid review mode.
 
 Draws the review grid on top of the main image: thin cell borders, a
 translucent green tint over cells already reviewed, and a highlighted
-border around the cell the reviewer is currently sweeping. The item
-lives in the image scene in image-pixel coordinates, so it pans and
-zooms with the photo for free; line widths are cosmetic (constant
+border around the cell the reviewer is currently sweeping. Inside the
+active cell it can also draw an N x N focus guide (3x3 by default) in
+the grid-line color — a purely visual aid that breaks the cell into
+sub-regions so the reviewer scans each in turn before advancing. The
+item lives in the image scene in image-pixel coordinates, so it pans
+and zooms with the photo for free; line widths are cosmetic (constant
 on-screen thickness at any zoom).
 
 Cell geometry comes from GridReviewService.cell_rects so the painted
 grid always matches the persisted reviewed-cell indices.
 """
 
-from PySide6.QtCore import Qt, QRectF
+from PySide6.QtCore import Qt, QRectF, QLineF
 from PySide6.QtGui import QColor, QPen, QBrush
 from PySide6.QtWidgets import QGraphicsItem
 
@@ -27,6 +30,10 @@ _REVIEWED_FILL = QColor(0, 200, 83, 50)
 _CURRENT_BORDER_COLOR = QColor(255, 179, 0)   # amber
 _CURRENT_BORDER_WIDTH = 3       # cosmetic px
 
+# Focus-guide subdivisions per side inside the active cell (3 -> nine
+# sub-regions). 1 disables the guide.
+_DEFAULT_SUBDIVISIONS = 3
+
 
 class GridOverlayItem(QGraphicsItem):
     """QGraphicsItem that paints the review grid over the main image."""
@@ -38,6 +45,7 @@ class GridOverlayItem(QGraphicsItem):
         self._rects = []            # (x, y, w, h) per cell, row-major
         self._reviewed = set()      # row-major indices
         self._current_index = None  # row-major index or None
+        self._subdivisions = _DEFAULT_SUBDIVISIONS  # focus guide per side
         # Below the selected-AOI decoration (1000) but above the pixmap
         # and the AOI circles.
         self.setZValue(950)
@@ -46,7 +54,8 @@ class GridOverlayItem(QGraphicsItem):
         self.setAcceptedMouseButtons(Qt.NoButton)
         self.hide()
 
-    def configure(self, image_w, image_h, rows, cols, reviewed, current_index):
+    def configure(self, image_w, image_h, rows, cols, reviewed, current_index,
+                  subdivisions=_DEFAULT_SUBDIVISIONS):
         """Set the grid to draw.
 
         Args:
@@ -56,6 +65,8 @@ class GridOverlayItem(QGraphicsItem):
             cols: Number of grid columns.
             reviewed: Set of reviewed row-major cell indices.
             current_index: Row-major index of the active cell, or None.
+            subdivisions: Focus-guide subdivisions per side inside the
+                active cell (3 -> nine sub-regions; 1 disables the guide).
         """
         self.prepareGeometryChange()
         self._image_w = int(image_w or 0)
@@ -66,6 +77,7 @@ class GridOverlayItem(QGraphicsItem):
             self._rects = []
         self._reviewed = set(reviewed or ())
         self._current_index = current_index
+        self._subdivisions = max(1, int(subdivisions))
         self.update()
 
     def set_reviewed(self, reviewed):
@@ -76,6 +88,11 @@ class GridOverlayItem(QGraphicsItem):
     def set_current_index(self, current_index):
         """Update only the active-cell highlight."""
         self._current_index = current_index
+        self.update()
+
+    def set_subdivisions(self, subdivisions):
+        """Update only the focus-guide subdivision count (1 disables it)."""
+        self._subdivisions = max(1, int(subdivisions))
         self.update()
 
     def cell_rect(self, index):
@@ -108,9 +125,21 @@ class GridOverlayItem(QGraphicsItem):
         for rect in self._rects:
             painter.drawRect(QRectF(*rect))
 
-        # Active-cell highlight on top.
+        # Active cell: optional focus guide, then the highlight border.
         current_rect = self.cell_rect(self._current_index)
         if current_rect is not None:
+            x, y, w, h = current_rect
+
+            # Focus guide: an N x N subdivision drawn inside the active cell
+            # in the grid-line color. Purely a visual scan aid, no state.
+            if self._subdivisions > 1:
+                painter.setPen(grid_pen)
+                for k in range(1, self._subdivisions):
+                    gx = x + (w * k / self._subdivisions)
+                    painter.drawLine(QLineF(gx, y, gx, y + h))
+                    gy = y + (h * k / self._subdivisions)
+                    painter.drawLine(QLineF(x, gy, x + w, gy))
+
             current_pen = QPen(_CURRENT_BORDER_COLOR)
             current_pen.setWidth(_CURRENT_BORDER_WIDTH)
             current_pen.setCosmetic(True)

--- a/app/core/views/images/viewer/widgets/GridOverlayItem.py
+++ b/app/core/views/images/viewer/widgets/GridOverlayItem.py
@@ -1,0 +1,118 @@
+"""
+GridOverlayItem - On-image grid decoration for grid review mode.
+
+Draws the review grid on top of the main image: thin cell borders, a
+translucent green tint over cells already reviewed, and a highlighted
+border around the cell the reviewer is currently sweeping. The item
+lives in the image scene in image-pixel coordinates, so it pans and
+zooms with the photo for free; line widths are cosmetic (constant
+on-screen thickness at any zoom).
+
+Cell geometry comes from GridReviewService.cell_rects so the painted
+grid always matches the persisted reviewed-cell indices.
+"""
+
+from PySide6.QtCore import Qt, QRectF
+from PySide6.QtGui import QColor, QPen, QBrush
+from PySide6.QtWidgets import QGraphicsItem
+
+from core.services.GridReviewService import GridReviewService
+
+
+# Painting constants. Colors are chosen to read over both dark forest and
+# bright snow imagery without obscuring detail underneath.
+_GRID_LINE_COLOR = QColor(255, 255, 255, 140)
+_GRID_LINE_WIDTH = 1            # cosmetic px
+_REVIEWED_FILL = QColor(0, 200, 83, 50)
+_CURRENT_BORDER_COLOR = QColor(255, 179, 0)   # amber
+_CURRENT_BORDER_WIDTH = 3       # cosmetic px
+
+
+class GridOverlayItem(QGraphicsItem):
+    """QGraphicsItem that paints the review grid over the main image."""
+
+    def __init__(self):
+        super().__init__()
+        self._image_w = 0
+        self._image_h = 0
+        self._rects = []            # (x, y, w, h) per cell, row-major
+        self._reviewed = set()      # row-major indices
+        self._current_index = None  # row-major index or None
+        # Below the selected-AOI decoration (1000) but above the pixmap
+        # and the AOI circles.
+        self.setZValue(950)
+        # The grid is purely visual; never block panning, region zoom or
+        # AOI clicks underneath it.
+        self.setAcceptedMouseButtons(Qt.NoButton)
+        self.hide()
+
+    def configure(self, image_w, image_h, rows, cols, reviewed, current_index):
+        """Set the grid to draw.
+
+        Args:
+            image_w: Image width in pixels.
+            image_h: Image height in pixels.
+            rows: Number of grid rows.
+            cols: Number of grid columns.
+            reviewed: Set of reviewed row-major cell indices.
+            current_index: Row-major index of the active cell, or None.
+        """
+        self.prepareGeometryChange()
+        self._image_w = int(image_w or 0)
+        self._image_h = int(image_h or 0)
+        if self._image_w > 0 and self._image_h > 0:
+            self._rects = GridReviewService.cell_rects(self._image_w, self._image_h, rows, cols)
+        else:
+            self._rects = []
+        self._reviewed = set(reviewed or ())
+        self._current_index = current_index
+        self.update()
+
+    def set_reviewed(self, reviewed):
+        """Update only the reviewed-cell set."""
+        self._reviewed = set(reviewed or ())
+        self.update()
+
+    def set_current_index(self, current_index):
+        """Update only the active-cell highlight."""
+        self._current_index = current_index
+        self.update()
+
+    def cell_rect(self, index):
+        """Return the (x, y, w, h) rect of a cell, or None when out of range."""
+        if index is None or not (0 <= index < len(self._rects)):
+            return None
+        return self._rects[index]
+
+    def boundingRect(self):
+        return QRectF(0, 0, self._image_w, self._image_h)
+
+    def paint(self, painter, option, widget=None):
+        if not self._rects:
+            return
+
+        # Reviewed-cell tint first so the grid lines stay visible above it.
+        painter.setPen(Qt.NoPen)
+        painter.setBrush(QBrush(_REVIEWED_FILL))
+        for index in self._reviewed:
+            rect = self.cell_rect(index)
+            if rect is not None:
+                painter.drawRect(QRectF(*rect))
+
+        # Cell borders.
+        grid_pen = QPen(_GRID_LINE_COLOR)
+        grid_pen.setWidth(_GRID_LINE_WIDTH)
+        grid_pen.setCosmetic(True)
+        painter.setPen(grid_pen)
+        painter.setBrush(Qt.NoBrush)
+        for rect in self._rects:
+            painter.drawRect(QRectF(*rect))
+
+        # Active-cell highlight on top.
+        current_rect = self.cell_rect(self._current_index)
+        if current_rect is not None:
+            current_pen = QPen(_CURRENT_BORDER_COLOR)
+            current_pen.setWidth(_CURRENT_BORDER_WIDTH)
+            current_pen.setCosmetic(True)
+            painter.setPen(current_pen)
+            painter.drawRect(QRectF(*current_rect))

--- a/app/core/views/images/viewer/widgets/QtImageViewer.py
+++ b/app/core/views/images/viewer/widgets/QtImageViewer.py
@@ -422,6 +422,23 @@ class QtImageViewer(TranslationMixin, QGraphicsView):
         else:
             self.zoomStack.clear()
 
+    def zoomToRect(self, rect):
+        """Zoom/pan so *rect* (scene coordinates) fills the view.
+
+        Used by grid review mode to frame one grid cell. The rect replaces
+        the whole zoom stack, so a subsequent resetZoom/zoom-out returns to
+        the full image rather than stepping back through prior cells.
+        """
+        if not self.hasImage() or self._recursion_guard or self._is_destroyed:
+            return
+
+        validated_rect = self._validate_zoom_rect(QRectF(rect))
+        if validated_rect is None:
+            return
+
+        self.zoomStack = [validated_rect]
+        self.updateViewer()
+
     def _zoomInAtPos(self, scene_pos, factor=None):
         """Zoom in so that *scene_pos* stays centred on screen."""
         if not self.canZoom or self.thumbnail or not self.hasImage() or self._is_destroyed:

--- a/app/tests/core/controllers/images/viewer/grid/test_grid_review_controller.py
+++ b/app/tests/core/controllers/images/viewer/grid/test_grid_review_controller.py
@@ -169,6 +169,21 @@ def test_escape_deactivates_and_restores_view(controller):
     assert controller.parent.messages['Grid Review'] is None
 
 
+def test_sub_guide_setting_controls_subdivisions(controller):
+    """The focus guide maps to 3 subdivisions when on, 1 when off."""
+    controller.parent.settings_service.get_bool_setting.return_value = True
+    assert controller._subdivisions() == 3
+    controller.parent.settings_service.get_bool_setting.return_value = False
+    assert controller._subdivisions() == 1
+
+
+def test_activate_configures_overlay_with_subdivisions(controller):
+    """The overlay is configured with the focus-guide subdivision count."""
+    controller.activate()
+    subdivisions = controller._overlay_item.configure.call_args.args[6]
+    assert subdivisions == 3
+
+
 def test_status_message_reports_progress(controller):
     controller.activate()
     message = controller.parent.messages['Grid Review']

--- a/app/tests/core/controllers/images/viewer/grid/test_grid_review_controller.py
+++ b/app/tests/core/controllers/images/viewer/grid/test_grid_review_controller.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from PySide6.QtCore import Qt, QRectF
+from PySide6.QtWidgets import QMessageBox
 
 
 def _key_event(key, modifiers=Qt.NoModifier):
@@ -167,6 +168,64 @@ def test_escape_deactivates_and_restores_view(controller):
     # Pending marks are flushed on exit.
     controller.parent.xml_service.save_xml_file.assert_called_once()
     assert controller.parent.messages['Grid Review'] is None
+
+
+def test_apply_grid_to_all_applies_to_every_image(controller):
+    """Bulk apply stamps the chosen grid onto every image and saves once."""
+    controller.parent.images = [
+        _image(),
+        _image(grid_review={'rows': 4, 'cols': 4, 'reviewed': set()}),
+    ]
+    controller._apply_grid_to_all(3, 3)
+
+    for img in controller.parent.images:
+        assert (img['grid_review']['rows'], img['grid_review']['cols']) == (3, 3)
+    assert controller.parent.xml_service.set_image_grid_review.call_count == 2
+    controller.parent.xml_service.save_xml_file.assert_called_once()
+
+
+def test_apply_grid_to_all_keeps_same_size_progress(controller):
+    """An image already at the target size keeps its reviewed cells."""
+    controller.parent.images = [_image(grid_review={'rows': 3, 'cols': 3, 'reviewed': {0, 4}})]
+    controller._apply_grid_to_all(3, 3)
+    assert controller.parent.images[0]['grid_review']['reviewed'] == {0, 4}
+
+
+def test_apply_grid_to_all_resets_conflicting_on_yes(controller):
+    """Confirming Yes resets progress recorded at a different size."""
+    controller.parent.images = [_image(grid_review={'rows': 4, 'cols': 4, 'reviewed': {0, 5}})]
+    with patch.object(QMessageBox, 'question', return_value=QMessageBox.Yes):
+        controller._apply_grid_to_all(3, 3)
+    grid = controller.parent.images[0]['grid_review']
+    assert (grid['rows'], grid['cols']) == (3, 3)
+    assert grid['reviewed'] == set()
+
+
+def test_apply_grid_to_all_keeps_conflicting_on_no(controller):
+    """Answering No leaves started images at their own size and progress."""
+    controller.parent.images = [
+        _image(grid_review={'rows': 4, 'cols': 4, 'reviewed': {0, 5}}),
+        _image(),
+    ]
+    with patch.object(QMessageBox, 'question', return_value=QMessageBox.No):
+        controller._apply_grid_to_all(3, 3)
+    started = controller.parent.images[0]['grid_review']
+    assert (started['rows'], started['cols']) == (4, 4)
+    assert started['reviewed'] == {0, 5}
+    # The unstarted image still takes the new size.
+    assert (controller.parent.images[1]['grid_review']['rows'],
+            controller.parent.images[1]['grid_review']['cols']) == (3, 3)
+
+
+def test_apply_grid_to_all_cancel_aborts(controller):
+    """Cancel makes no changes and writes nothing."""
+    controller.parent.images = [_image(grid_review={'rows': 4, 'cols': 4, 'reviewed': {0, 5}})]
+    with patch.object(QMessageBox, 'question', return_value=QMessageBox.Cancel):
+        controller._apply_grid_to_all(3, 3)
+    grid = controller.parent.images[0]['grid_review']
+    assert (grid['rows'], grid['cols']) == (4, 4)
+    assert grid['reviewed'] == {0, 5}
+    controller.parent.xml_service.save_xml_file.assert_not_called()
 
 
 def test_sub_guide_setting_controls_subdivisions(controller):

--- a/app/tests/core/controllers/images/viewer/grid/test_grid_review_controller.py
+++ b/app/tests/core/controllers/images/viewer/grid/test_grid_review_controller.py
@@ -1,0 +1,215 @@
+"""Unit tests for GridReviewController — grid review sweep lifecycle."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from PySide6.QtCore import Qt, QRectF
+
+
+def _key_event(key, modifiers=Qt.NoModifier):
+    event = MagicMock()
+    event.key.return_value = key
+    event.modifiers.return_value = modifiers
+    return event
+
+
+def _image(grid_review=None, hidden=False):
+    return {
+        'xml': MagicMock(),
+        'path': 'img.jpg',
+        'hidden': hidden,
+        'grid_review': grid_review,
+        'areas_of_interest': [],
+    }
+
+
+@pytest.fixture
+def controller(app):
+    """A GridReviewController with the overlay item patched to a mock."""
+    with patch(
+        "core.controllers.images.viewer.grid.GridReviewController.GridOverlayItem"
+    ):
+        from core.controllers.images.viewer.grid.GridReviewController import GridReviewController
+        parent = MagicMock()
+        parent.images = [_image(), _image()]
+        parent.current_image = 0
+        parent.gallery_mode = False
+        parent.messages = {}
+        parent.main_image._is_destroyed = False
+        parent.main_image.sceneRect.return_value = QRectF(0, 0, 800, 600)
+        parent._get_current_image_gsd.return_value = None
+        # Settings mocks fall through to controller defaults (4x4, auto-mark).
+        parent.settings_service.get_setting.return_value = None
+        parent.settings_service.get_bool_setting.return_value = True
+
+        controller = GridReviewController(parent)
+        yield controller
+        # Break the QObject<->MagicMock reference cycle on teardown so the
+        # controller is freed while QApplication is still alive.
+        parent.reset_mock()
+        controller.parent = None
+
+
+def test_handle_key_inactive_passes_keys_through(controller):
+    assert controller.handle_key(_key_event(Qt.Key_Space)) is False
+    assert controller.handle_key(_key_event(Qt.Key_Right)) is False
+    assert controller.handle_key(_key_event(Qt.Key_X)) is False
+    assert controller.active is False
+
+
+def test_s_key_activates_and_zooms_to_first_cell(controller):
+    assert controller.handle_key(_key_event(Qt.Key_S)) is True
+    assert controller.active is True
+    assert controller.current_cell == 0
+    # 800x600 at the 4x4 default -> cell 0 is (0, 0, 200, 150); the zoom
+    # rect is expanded by 8% per side so neighboring slivers are visible.
+    zoom_rect = controller.parent.main_image.zoomToRect.call_args.args[0]
+    assert zoom_rect == QRectF(-16.0, -12.0, 232.0, 174.0)
+
+
+def test_activation_refused_in_gallery_mode(controller):
+    controller.parent.gallery_mode = True
+    controller.handle_key(_key_event(Qt.Key_S))
+    assert controller.active is False
+    controller.parent.status_controller.show_toast.assert_called_once()
+
+
+def test_activation_resumes_at_first_unreviewed_cell(controller):
+    controller.parent.images[0]['grid_review'] = {'rows': 2, 'cols': 2, 'reviewed': {0}}
+    controller.activate()
+    # Stored grid dims win over defaults; serpentine order on 2x2 is
+    # [0, 1, 3, 2] and cell 0 is already reviewed.
+    assert (controller._rows, controller._cols) == (2, 2)
+    assert controller.current_cell == 1
+
+
+def test_space_marks_current_cell_and_advances(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Space))
+
+    image = controller.parent.images[0]
+    assert image['grid_review']['reviewed'] == {0}
+    assert controller.current_cell == 1
+    controller.parent.xml_service.set_image_grid_review.assert_called_with(
+        image['xml'], 4, 4, {0}
+    )
+    # The save is debounced, not written synchronously on every mark.
+    controller.parent.xml_service.save_xml_file.assert_not_called()
+    assert controller._save_pending is True
+
+
+def test_space_follows_serpentine_into_second_row(controller):
+    controller.parent.images[0]['grid_review'] = {'rows': 2, 'cols': 2, 'reviewed': set()}
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Space))  # 0 -> 1
+    controller.handle_key(_key_event(Qt.Key_Space))  # 1 -> 3 (row 1 runs right-to-left)
+    assert controller.current_cell == 3
+    assert controller.parent.images[0]['grid_review']['reviewed'] == {0, 1}
+
+
+def test_space_on_last_cell_flushes_and_advances_image(controller):
+    controller.parent.images[0]['grid_review'] = {'rows': 2, 'cols': 2, 'reviewed': {0, 1, 3}}
+    controller.activate()
+    assert controller.current_cell == 2  # last cell in serpentine order
+
+    controller.handle_key(_key_event(Qt.Key_Space))
+
+    assert controller.parent.images[0]['grid_review']['reviewed'] == {0, 1, 2, 3}
+    controller.parent.xml_service.save_xml_file.assert_called_once()
+    controller.parent._nextImageButton_clicked.assert_called_once()
+
+
+def test_arrows_move_without_marking(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Right))
+    assert controller.current_cell == 1
+    controller.handle_key(_key_event(Qt.Key_Down))
+    assert controller.current_cell == 5
+    controller.handle_key(_key_event(Qt.Key_Left))
+    assert controller.current_cell == 4
+    controller.handle_key(_key_event(Qt.Key_Up))
+    assert controller.current_cell == 0
+    assert controller.parent.images[0]['grid_review'] is None
+
+
+def test_arrows_clamp_at_grid_edges(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Left))
+    controller.handle_key(_key_event(Qt.Key_Up))
+    assert controller.current_cell == 0
+
+
+def test_backspace_steps_back_without_unmarking(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Space))
+    assert controller.current_cell == 1
+    controller.handle_key(_key_event(Qt.Key_Backspace))
+    assert controller.current_cell == 0
+    assert controller.parent.images[0]['grid_review']['reviewed'] == {0}
+
+
+def test_x_toggles_reviewed_state(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_X))
+    assert controller.parent.images[0]['grid_review']['reviewed'] == {0}
+    controller.handle_key(_key_event(Qt.Key_X))
+    assert controller.parent.images[0]['grid_review']['reviewed'] == set()
+
+
+def test_escape_deactivates_and_restores_view(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Space))
+    controller.handle_key(_key_event(Qt.Key_Escape))
+
+    assert controller.active is False
+    assert controller.current_cell is None
+    controller.parent.main_image.resetZoom.assert_called()
+    # Pending marks are flushed on exit.
+    controller.parent.xml_service.save_xml_file.assert_called_once()
+    assert controller.parent.messages['Grid Review'] is None
+
+
+def test_status_message_reports_progress(controller):
+    controller.activate()
+    message = controller.parent.messages['Grid Review']
+    assert "1/16" in message
+    assert "1/2" in message
+
+
+def test_on_image_loaded_inactive_hides_overlay(controller):
+    controller.activate()
+    overlay = controller._overlay_item
+    controller.deactivate()
+    overlay.hide.reset_mock()
+
+    controller.on_image_loaded()
+    overlay.hide.assert_called()
+    controller.parent.main_image.zoomToRect.reset_mock()
+    assert controller.active is False
+
+
+def test_on_image_loaded_active_resumes_sweep_on_new_image(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Space))
+
+    controller.parent.current_image = 1
+    controller.parent.images[1]['grid_review'] = {'rows': 2, 'cols': 2, 'reviewed': {0, 1}}
+    controller.on_image_loaded()
+
+    # The image change flushed the pending save and resumed at the new
+    # image's first unreviewed cell (serpentine [0, 1, 3, 2] -> 3).
+    controller.parent.xml_service.save_xml_file.assert_called_once()
+    assert controller.current_cell == 3
+    assert (controller._rows, controller._cols) == (2, 2)
+
+
+def test_cleanup_flushes_pending_save(controller):
+    controller.activate()
+    controller.handle_key(_key_event(Qt.Key_Space))
+    controller.parent.xml_service.save_xml_file.assert_not_called()
+
+    controller.cleanup()
+    controller.parent.xml_service.save_xml_file.assert_called_once()
+    # A second cleanup with nothing pending does not save again.
+    controller.cleanup()
+    controller.parent.xml_service.save_xml_file.assert_called_once()

--- a/app/tests/core/services/test_grid_review_service.py
+++ b/app/tests/core/services/test_grid_review_service.py
@@ -1,0 +1,190 @@
+import pytest
+from core.services.GridReviewService import GridReviewService
+
+
+# ---------------------------------------------------------------------------
+# cell_rects
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("width,height,rows,cols", [
+    (8000, 6000, 4, 4),
+    (8000, 6000, 1, 1),
+    (1001, 757, 3, 5),     # non-divisible dimensions
+    (640, 480, 12, 12),
+    (7, 5, 2, 3),          # tiny image
+])
+def test_cell_rects_tile_image_exactly(width, height, rows, cols):
+    """Cells cover every pixel exactly once: no gaps, no overlaps."""
+    rects = GridReviewService.cell_rects(width, height, rows, cols)
+    assert len(rects) == rows * cols
+
+    covered = sum(w * h for _, _, w, h in rects)
+    assert covered == width * height
+
+    # No rect extends outside the image.
+    for x, y, w, h in rects:
+        assert x >= 0 and y >= 0
+        assert x + w <= width
+        assert y + h <= height
+
+    # Cells in the same row don't overlap horizontally.
+    for i in range(rows):
+        row = rects[i * cols:(i + 1) * cols]
+        for left, right in zip(row, row[1:]):
+            assert left[0] + left[2] == right[0]
+
+
+def test_cell_rects_row_major_order():
+    rects = GridReviewService.cell_rects(100, 100, 2, 2)
+    assert rects[0] == (0, 0, 50, 50)
+    assert rects[1] == (50, 0, 50, 50)
+    assert rects[2] == (0, 50, 50, 50)
+    assert rects[3] == (50, 50, 50, 50)
+
+
+def test_cell_rects_clamps_degenerate_grid():
+    """Zero/negative rows or cols fall back to a single cell."""
+    assert GridReviewService.cell_rects(100, 100, 0, -3) == [(0, 0, 100, 100)]
+
+
+# ---------------------------------------------------------------------------
+# serpentine_order
+# ---------------------------------------------------------------------------
+
+def test_serpentine_order_single_cell():
+    assert GridReviewService.serpentine_order(1, 1) == [0]
+
+
+def test_serpentine_order_4x4():
+    assert GridReviewService.serpentine_order(4, 4) == [
+        0, 1, 2, 3,
+        7, 6, 5, 4,
+        8, 9, 10, 11,
+        15, 14, 13, 12,
+    ]
+
+
+def test_serpentine_order_3x5_visits_every_cell_once():
+    order = GridReviewService.serpentine_order(3, 5)
+    assert sorted(order) == list(range(15))
+    # Odd rows run right-to-left.
+    assert order[5:10] == [9, 8, 7, 6, 5]
+
+
+def test_serpentine_order_consecutive_cells_are_adjacent():
+    """Each step moves exactly one cell horizontally or vertically."""
+    rows, cols = 4, 6
+    order = GridReviewService.serpentine_order(rows, cols)
+    for a, b in zip(order, order[1:]):
+        ra, ca = divmod(a, cols)
+        rb, cb = divmod(b, cols)
+        assert abs(ra - rb) + abs(ca - cb) == 1
+
+
+# ---------------------------------------------------------------------------
+# suggest_grid
+# ---------------------------------------------------------------------------
+
+def test_suggest_grid_returns_none_without_gsd():
+    assert GridReviewService.suggest_grid(8000, 6000, None, 1920, 1080) is None
+    assert GridReviewService.suggest_grid(8000, 6000, 0, 1920, 1080) is None
+    assert GridReviewService.suggest_grid(8000, 6000, -1.5, 1920, 1080) is None
+
+
+def test_suggest_grid_returns_none_with_bad_dimensions():
+    assert GridReviewService.suggest_grid(0, 6000, 2.0, 1920, 1080) is None
+    assert GridReviewService.suggest_grid(8000, None, 2.0, 1920, 1080) is None
+    assert GridReviewService.suggest_grid(8000, 6000, 2.0, 0, 1080) is None
+
+
+def test_suggest_grid_coarser_gsd_means_more_cells():
+    """Coarser GSD = fewer pixels on the person = smaller cells needed."""
+    fine = GridReviewService.suggest_grid(8000, 6000, 0.5, 1920, 1080)
+    coarse = GridReviewService.suggest_grid(8000, 6000, 5.0, 1920, 1080)
+    assert fine is not None and coarse is not None
+    assert coarse[0] >= fine[0]
+    assert coarse[1] >= fine[1]
+
+
+def test_suggest_grid_clamps_to_bounds():
+    # Extremely fine GSD: person is huge, still at least min_n.
+    rows, cols = GridReviewService.suggest_grid(8000, 6000, 0.01, 1920, 1080)
+    assert (rows, cols) == (2, 2)
+    # Extremely coarse GSD: clamped at max_n.
+    rows, cols = GridReviewService.suggest_grid(8000, 6000, 100.0, 1920, 1080)
+    assert (rows, cols) == (12, 12)
+
+
+def test_suggest_grid_satisfies_min_person_px_when_unclamped():
+    """For an unclamped suggestion, a person spans >= min_person_px on screen."""
+    image_w, image_h, gsd, vp_w, vp_h = 8000, 6000, 2.5, 1920, 1080
+    rows, cols = GridReviewService.suggest_grid(image_w, image_h, gsd, vp_w, vp_h)
+    assert 2 < cols < 12  # meaningful (unclamped) suggestion for these inputs
+    cell_w = image_w / cols
+    person_px = GridReviewService.person_screen_px(gsd, cell_w, vp_w)
+    assert person_px >= 60
+
+
+def test_person_screen_px_unusable_inputs():
+    assert GridReviewService.person_screen_px(None, 2000, 1920) is None
+    assert GridReviewService.person_screen_px(2.0, 0, 1920) is None
+    assert GridReviewService.person_screen_px(2.0, 2000, None) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_reviewed / serialize_reviewed
+# ---------------------------------------------------------------------------
+
+def test_parse_serialize_round_trip():
+    cells = {0, 1, 5, 14}
+    serialized = GridReviewService.serialize_reviewed(cells)
+    assert serialized == "0,1,5,14"
+    assert GridReviewService.parse_reviewed(serialized) == cells
+
+
+def test_parse_reviewed_tolerates_junk():
+    assert GridReviewService.parse_reviewed("a,,5") == {5}
+    assert GridReviewService.parse_reviewed(" 3 , 7 ") == {3, 7}
+    assert GridReviewService.parse_reviewed("-1,2") == {2}
+    assert GridReviewService.parse_reviewed("") == set()
+    assert GridReviewService.parse_reviewed(None) == set()
+
+
+def test_serialize_reviewed_deduplicates_and_sorts():
+    assert GridReviewService.serialize_reviewed([5, 1, 5, 0]) == "0,1,5"
+    assert GridReviewService.serialize_reviewed([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# image_progress / run_progress
+# ---------------------------------------------------------------------------
+
+def test_image_progress_with_stored_grid():
+    image = {'grid_review': {'rows': 4, 'cols': 4, 'reviewed': {0, 1, 5}}}
+    assert GridReviewService.image_progress(image, 3, 3) == (3, 16)
+
+
+def test_image_progress_without_grid_uses_defaults():
+    assert GridReviewService.image_progress({'grid_review': None}, 4, 4) == (0, 16)
+    assert GridReviewService.image_progress({}, 3, 3) == (0, 9)
+
+
+def test_image_progress_ignores_out_of_range_indices():
+    """Stale indices from a previously larger grid don't inflate progress."""
+    image = {'grid_review': {'rows': 2, 'cols': 2, 'reviewed': {0, 3, 15, 99}}}
+    assert GridReviewService.image_progress(image, 4, 4) == (2, 4)
+
+
+def test_run_progress_excludes_hidden_images():
+    images = [
+        {'hidden': False, 'grid_review': {'rows': 2, 'cols': 2, 'reviewed': {0, 1, 2, 3}}},
+        {'hidden': True, 'grid_review': {'rows': 2, 'cols': 2, 'reviewed': set()}},
+        {'hidden': False, 'grid_review': None},
+    ]
+    # Visible: 4/4 from the first image + 0/16 default from the third.
+    assert GridReviewService.run_progress(images, 4, 4) == (4, 20)
+
+
+def test_run_progress_empty_inputs():
+    assert GridReviewService.run_progress([], 4, 4) == (0, 0)
+    assert GridReviewService.run_progress(None, 4, 4) == (0, 0)

--- a/app/tests/core/services/test_xml_service.py
+++ b/app/tests/core/services/test_xml_service.py
@@ -257,6 +257,74 @@ def test_ensure_aoi_numbers_persists_to_xml(tmp_path, sample_xml):
     assert reloaded[1]["areas_of_interest"][0]["number"] == 2
 
 
+# ---------------------------------------------------------------------------
+# Grid review state
+# ---------------------------------------------------------------------------
+
+def test_grid_review_round_trips_through_save_reload(tmp_path, sample_xml):
+    """Grid attributes survive save -> reload, and AOI parsing is unaffected."""
+    service = XmlService(sample_xml)
+    image = service.get_images()[0]
+    assert service.set_image_grid_review(image['xml'], 4, 4, {0, 1, 5}) is True
+
+    out_path = tmp_path / "grid.xml"
+    service.save_xml_file(out_path)
+
+    reloaded = XmlService(out_path).get_images()
+    grid = reloaded[0]['grid_review']
+    assert grid == {'rows': 4, 'cols': 4, 'reviewed': {0, 1, 5}}
+    # Regression for the <image> child-iteration hazard: the new attributes
+    # must not introduce elements that get mis-parsed as AOIs.
+    assert len(reloaded[0]['areas_of_interest']) == 1
+    assert reloaded[0]['areas_of_interest'][0]['center'] == (50, 50)
+    # The untouched image stays unreviewed.
+    assert reloaded[1]['grid_review'] is None
+
+
+def test_legacy_xml_loads_without_grid_review(sample_xml):
+    """Files written before grid review load with grid_review None."""
+    for image in XmlService(sample_xml).get_images():
+        assert image['grid_review'] is None
+
+
+def test_malformed_grid_attributes_treated_as_unreviewed(tmp_path):
+    xml_content = """
+    <data>
+        <images>
+            <image path="a.jpg" grid_rows="x" grid_cols="4" grid_reviewed="0,1">
+                <areas_of_interest center="(10,10)" radius="5" area="20"/>
+            </image>
+            <image path="b.jpg" grid_rows="0" grid_cols="4"/>
+            <image path="c.jpg" grid_rows="2" grid_cols="2" grid_reviewed="junk,3"/>
+        </images>
+    </data>
+    """.strip()
+    xml_path = tmp_path / "bad_grid.xml"
+    with open(xml_path, "w") as f:
+        f.write(xml_content)
+
+    images = XmlService(xml_path).get_images()
+    # Non-integer rows -> unreviewed; AOIs untouched.
+    assert images[0]['grid_review'] is None
+    assert len(images[0]['areas_of_interest']) == 1
+    # Zero rows -> unreviewed.
+    assert images[1]['grid_review'] is None
+    # Junk tokens in reviewed list are dropped, valid ones kept.
+    assert images[2]['grid_review'] == {'rows': 2, 'cols': 2, 'reviewed': {3}}
+
+
+def test_clear_image_grid_review(sample_xml):
+    service = XmlService(sample_xml)
+    image = service.get_images()[0]
+    service.set_image_grid_review(image['xml'], 2, 2, {0})
+    assert service.get_images()[0]['grid_review'] is not None
+
+    assert service.clear_image_grid_review(image['xml']) is True
+    assert service.get_images()[0]['grid_review'] is None
+    # Clearing an element with no grid attributes is harmless.
+    assert service.clear_image_grid_review(image['xml']) is True
+
+
 def test_ensure_aoi_numbers_fills_gaps_above_existing_max(tmp_path):
     """Partially numbered files keep existing numbers; gaps get max+1 upward."""
     xml_content = """

--- a/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
@@ -399,6 +399,26 @@ def test_grid_review_dialog_focus_guide_defaults_on(app):
     assert dialog.sub_guide_enabled()
 
 
+def test_grid_review_dialog_apply_to_all_defaults_off(app):
+    """Apply-to-all is a one-shot action and starts unchecked."""
+    dialog = GridReviewDialog(None)
+    assert dialog.applyAllCheckBox.isChecked() is False
+    assert dialog.apply_to_all() is False
+    dialog.applyAllCheckBox.setChecked(True)
+    assert dialog.apply_to_all() is True
+
+
+def test_grid_review_dialog_apply_to_all_not_persisted(app):
+    """Apply-to-all is never written to settings (it is not a preference)."""
+    settings = MagicMock()
+    dialog = GridReviewDialog(None, settings_service=settings)
+    dialog.applyAllCheckBox.setChecked(True)
+    dialog.accept()
+    persisted_keys = [call.args[0] for call in settings.set_setting.call_args_list]
+    assert "GridReviewApplyAll" not in persisted_keys
+    assert "applyAll" not in persisted_keys
+
+
 def test_grid_review_dialog_suggestion(app):
     """The GSD suggestion populates the label and the Use Suggestion button."""
     dialog = GridReviewDialog(None, suggestion=(6, 6), person_px=72.4)

--- a/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
@@ -18,6 +18,7 @@ from core.views.images.viewer.dialogs.CalTopoAuthDialog import CalTopoAuthDialog
 from core.views.images.viewer.dialogs.ColorHistogramDialog import ColorHistogramDialog
 from core.views.images.viewer.dialogs.ExportProgressDialog import ExportProgressDialog
 from core.views.images.viewer.dialogs.GPSMapDialog import GPSMapDialog
+from core.views.images.viewer.dialogs.GridReviewDialog import GridReviewDialog
 from core.views.images.viewer.dialogs.HelpDialog import HelpDialog
 from core.views.images.viewer.dialogs.ImageAdjustmentDialog import ImageAdjustmentDialog
 from core.views.images.viewer.dialogs.LoadingDialog import LoadingDialog
@@ -374,3 +375,39 @@ def test_zip_export_dialog_initialization(app):
     """Test ZipExportDialog initialization."""
     dialog = ZipExportDialog(None)
     assert dialog is not None
+
+
+def test_grid_review_dialog_initialization(app):
+    """Test GridReviewDialog initialization with current values."""
+    dialog = GridReviewDialog(None, current_rows=6, current_cols=8, auto_mark=False)
+    assert dialog.rowsSpinBox.value() == 6
+    assert dialog.colsSpinBox.value() == 8
+    assert not dialog.autoMarkCheckBox.isChecked()
+    # Spinboxes are bounded to a sane grid range.
+    assert dialog.rowsSpinBox.minimum() == 1
+    assert dialog.rowsSpinBox.maximum() == 12
+    # No suggestion provided -> the button stays disabled.
+    assert not dialog.useSuggestionButton.isEnabled()
+
+
+def test_grid_review_dialog_suggestion(app):
+    """The GSD suggestion populates the label and the Use Suggestion button."""
+    dialog = GridReviewDialog(None, suggestion=(6, 6), person_px=72.4)
+    assert dialog.useSuggestionButton.isEnabled()
+    assert "6" in dialog.suggestionLabel.text()
+    assert "72" in dialog.suggestionLabel.text()
+
+    dialog.useSuggestionButton.click()
+    assert dialog.values()[:2] == (6, 6)
+
+
+def test_grid_review_dialog_accept_persists_settings(app):
+    """Accepting the dialog writes the chosen values to settings."""
+    settings = MagicMock()
+    dialog = GridReviewDialog(None, settings_service=settings,
+                              current_rows=5, current_cols=7, auto_mark=True)
+    dialog.accept()
+
+    settings.set_setting.assert_any_call("GridReviewRows", 5)
+    settings.set_setting.assert_any_call("GridReviewCols", 7)
+    settings.set_setting.assert_any_call("GridReviewAutoMark", True)

--- a/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_dialogs.py
@@ -379,15 +379,24 @@ def test_zip_export_dialog_initialization(app):
 
 def test_grid_review_dialog_initialization(app):
     """Test GridReviewDialog initialization with current values."""
-    dialog = GridReviewDialog(None, current_rows=6, current_cols=8, auto_mark=False)
+    dialog = GridReviewDialog(None, current_rows=6, current_cols=8,
+                              auto_mark=False, sub_guide=False)
     assert dialog.rowsSpinBox.value() == 6
     assert dialog.colsSpinBox.value() == 8
     assert not dialog.autoMarkCheckBox.isChecked()
+    assert not dialog.subGuideCheckBox.isChecked()
     # Spinboxes are bounded to a sane grid range.
     assert dialog.rowsSpinBox.minimum() == 1
     assert dialog.rowsSpinBox.maximum() == 12
     # No suggestion provided -> the button stays disabled.
     assert not dialog.useSuggestionButton.isEnabled()
+
+
+def test_grid_review_dialog_focus_guide_defaults_on(app):
+    """The focus-guide toggle defaults on."""
+    dialog = GridReviewDialog(None)
+    assert dialog.subGuideCheckBox.isChecked()
+    assert dialog.sub_guide_enabled()
 
 
 def test_grid_review_dialog_suggestion(app):
@@ -411,3 +420,4 @@ def test_grid_review_dialog_accept_persists_settings(app):
     settings.set_setting.assert_any_call("GridReviewRows", 5)
     settings.set_setting.assert_any_call("GridReviewCols", 7)
     settings.set_setting.assert_any_call("GridReviewAutoMark", True)
+    settings.set_setting.assert_any_call("GridReviewSubGuide", True)

--- a/app/tests/core/views/images/viewer/widgets/test_grid_overlay_item.py
+++ b/app/tests/core/views/images/viewer/widgets/test_grid_overlay_item.py
@@ -1,0 +1,129 @@
+"""Tests for the grid review on-image overlay and cell zoom."""
+
+from unittest.mock import MagicMock
+
+from PySide6.QtCore import QRectF
+from PySide6.QtGui import QPixmap, QPainter
+from PySide6.QtWidgets import QGraphicsScene, QStyleOptionGraphicsItem
+
+from core.views.images.viewer.widgets.GridOverlayItem import GridOverlayItem
+from core.views.images.viewer.widgets.QtImageViewer import QtImageViewer
+
+
+# ---------------------------------------------------------------------------
+# GridOverlayItem
+# ---------------------------------------------------------------------------
+
+def test_grid_overlay_hidden_until_configured(app):
+    item = GridOverlayItem()
+    assert not item.isVisible()
+    assert item.boundingRect().isEmpty()
+
+
+def test_grid_overlay_bounding_rect_matches_image(app):
+    item = GridOverlayItem()
+    item.configure(8000, 6000, 4, 4, set(), None)
+    assert item.boundingRect() == QRectF(0, 0, 8000, 6000)
+
+
+def test_grid_overlay_cell_rect_lookup(app):
+    item = GridOverlayItem()
+    item.configure(100, 100, 2, 2, set(), None)
+    assert item.cell_rect(0) == (0, 0, 50, 50)
+    assert item.cell_rect(3) == (50, 50, 50, 50)
+    assert item.cell_rect(4) is None
+    assert item.cell_rect(None) is None
+    assert item.cell_rect(-1) is None
+
+
+def test_grid_overlay_lives_in_a_scene(app):
+    scene = QGraphicsScene()
+    item = GridOverlayItem()
+    scene.addItem(item)
+    item.configure(640, 480, 3, 3, {0, 4}, 5)
+    assert item.scene() is scene
+
+
+def test_grid_overlay_paint_smoke(app):
+    """Configured overlay paints reviewed + current cells without error."""
+    item = GridOverlayItem()
+    item.configure(400, 300, 4, 4, {0, 1, 5}, 6)
+
+    pixmap = QPixmap(400, 300)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
+def test_grid_overlay_paint_unconfigured_is_noop(app):
+    item = GridOverlayItem()
+    pixmap = QPixmap(50, 50)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
+def test_grid_overlay_partial_updates(app):
+    item = GridOverlayItem()
+    item.configure(100, 100, 2, 2, set(), 0)
+    item.set_reviewed({0, 1})
+    item.set_current_index(2)
+    assert item._reviewed == {0, 1}
+    assert item._current_index == 2
+
+
+def test_grid_overlay_reconfigure_for_new_image(app):
+    """Reconfiguring for a different image replaces geometry and state."""
+    item = GridOverlayItem()
+    item.configure(100, 100, 2, 2, {0}, 1)
+    item.configure(200, 100, 1, 2, {1}, 0)
+    assert item.boundingRect() == QRectF(0, 0, 200, 100)
+    assert item.cell_rect(0) == (0, 0, 100, 100)
+    assert item.cell_rect(2) is None
+
+
+# ---------------------------------------------------------------------------
+# QtImageViewer.zoomToRect
+# ---------------------------------------------------------------------------
+
+def _viewer_with_image(width=800, height=600):
+    viewer = QtImageViewer(MagicMock())
+    viewer.resize(400, 300)
+    viewer.setImage(QPixmap(width, height))
+    return viewer
+
+
+def test_zoom_to_rect_replaces_zoom_stack(app):
+    viewer = _viewer_with_image()
+    viewer.zoomStack = [QRectF(0, 0, 800, 600), QRectF(10, 10, 100, 100)]
+
+    viewer.zoomToRect(QRectF(200, 150, 400, 300))
+
+    assert len(viewer.zoomStack) == 1
+    assert viewer.zoomStack[0] == QRectF(200, 150, 400, 300)
+
+
+def test_zoom_to_rect_clips_to_scene(app):
+    viewer = _viewer_with_image()
+    viewer.zoomToRect(QRectF(600, 400, 400, 400))
+
+    assert len(viewer.zoomStack) == 1
+    assert viewer.zoomStack[0] == QRectF(600, 400, 200, 200)
+
+
+def test_zoom_to_rect_rejects_degenerate_rect(app):
+    viewer = _viewer_with_image()
+    viewer.zoomToRect(QRectF(0, 0, 2, 2))
+    assert viewer.zoomStack == []
+    viewer.zoomToRect(QRectF())
+    assert viewer.zoomStack == []
+
+
+def test_zoom_to_rect_without_image_is_noop(app):
+    viewer = QtImageViewer(MagicMock())
+    viewer.zoomToRect(QRectF(0, 0, 100, 100))
+    assert viewer.zoomStack == []

--- a/app/tests/core/views/images/viewer/widgets/test_grid_overlay_item.py
+++ b/app/tests/core/views/images/viewer/widgets/test_grid_overlay_item.py
@@ -57,6 +57,39 @@ def test_grid_overlay_paint_smoke(app):
         painter.end()
 
 
+def test_grid_overlay_focus_guide_defaults_and_paints(app):
+    """The 3x3 focus guide defaults on and paints inside the active cell."""
+    item = GridOverlayItem()
+    item.configure(400, 300, 4, 4, set(), 5)
+    assert item._subdivisions == 3
+
+    pixmap = QPixmap(400, 300)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
+def test_grid_overlay_focus_guide_can_be_disabled(app):
+    """subdivisions=1 disables the guide; painting still succeeds."""
+    item = GridOverlayItem()
+    item.configure(400, 300, 4, 4, set(), 5, subdivisions=1)
+    assert item._subdivisions == 1
+    item.set_subdivisions(3)
+    assert item._subdivisions == 3
+    # Clamps degenerate values up to 1.
+    item.set_subdivisions(0)
+    assert item._subdivisions == 1
+
+    pixmap = QPixmap(400, 300)
+    painter = QPainter(pixmap)
+    try:
+        item.paint(painter, QStyleOptionGraphicsItem(), None)
+    finally:
+        painter.end()
+
+
 def test_grid_overlay_paint_unconfigured_is_noop(app):
     item = GridOverlayItem()
     pixmap = QPixmap(50, 50)

--- a/resources/views/images/viewer/GridReviewDialog.ui
+++ b/resources/views/images/viewer/GridReviewDialog.ui
@@ -92,6 +92,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="applyAllCheckBox">
+     <property name="toolTip">
+      <string>Apply the chosen rows and columns to every image in this dataset, not just the current one. Images you have already started reviewing keep their progress unless you confirm a reset.</string>
+     </property>
+     <property name="text">
+      <string>Apply this grid size to all images</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="suggestionLayout">
      <item>
       <widget class="QLabel" name="suggestionLabel">

--- a/resources/views/images/viewer/GridReviewDialog.ui
+++ b/resources/views/images/viewer/GridReviewDialog.ui
@@ -79,6 +79,19 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="subGuideCheckBox">
+     <property name="toolTip">
+      <string>Draw a 3×3 guide inside the active cell to focus your scan. Visual only — it does not change what gets reviewed.</string>
+     </property>
+     <property name="text">
+      <string>Show 3×3 focus guide inside each cell</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="suggestionLayout">
      <item>
       <widget class="QLabel" name="suggestionLabel">

--- a/resources/views/images/viewer/GridReviewDialog.ui
+++ b/resources/views/images/viewer/GridReviewDialog.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GridReviewDialog</class>
+ <widget class="QDialog" name="GridReviewDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>260</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Grid Review Settings</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="descriptionLabel">
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Choose how many cells the review grid divides each image into. Smaller cells mean a higher zoom per cell.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="rowsLabel">
+       <property name="text">
+        <string>Rows</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QSpinBox" name="rowsSpinBox">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>12</number>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="colsLabel">
+       <property name="text">
+        <string>Columns</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="colsSpinBox">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>12</number>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="autoMarkCheckBox">
+     <property name="text">
+      <string>Mark cells reviewed when advancing (Space)</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="suggestionLayout">
+     <item>
+      <widget class="QLabel" name="suggestionLabel">
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>No grid suggestion available (image GSD unknown).</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="useSuggestionButton">
+       <property name="text">
+        <string>Use Suggestion</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>GridReviewDialog</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>GridReviewDialog</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/resources/views/images/viewer/Viewer.ui
+++ b/resources/views/images/viewer/Viewer.ui
@@ -419,6 +419,28 @@ Shows all AOIs from all images in a grid view</string>
                </widget>
               </item>
               <item>
+               <widget class="QToolButton" name="gridReviewButton">
+                <property name="toolTip">
+                 <string>Toggle Grid Review Mode (S) — sweep the image cell by cell; Shift+S for grid settings</string>
+                </property>
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>25</width>
+                  <height>25</height>
+                 </size>
+                </property>
+                <property name="checkable">
+                 <bool>true</bool>
+                </property>
+                <property name="iconName" stdset="0">
+                 <string>grid.png</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QToolButton" name="magnifyButton">
                 <property name="toolTip">
                  <string>Toggle Magnifying Glass (Middle Mouse)</string>


### PR DESCRIPTION
## Grid Review Mode

Adds a systematic, keyboard-driven **grid review mode** to the results viewer for the case where the detection algorithms can't help — most importantly a missing person in natural-tone clothing, where colour/anomaly/thermal all lose signal and a human must reliably check every part of every image.

### What it does
Press **`S`** in the results viewer to overlay an N×N grid and sweep it cell by cell at a constant zoom:

| Key | Action |
|-----|--------|
| `S` | Toggle grid review mode |
| `Shift+S` | Open grid settings |
| `Space` | Mark current cell reviewed and advance (serpentine order; rolls into the next image after the last cell) |
| `Backspace` / `Shift+Space` | Step back one cell (no unmarking) |
| Arrow keys | Move one cell without marking |
| `X` | Toggle the current cell's reviewed state |
| `Esc` | Exit and restore the full-image view |

- **Progress is persisted** per image to `ADIAT_Data.xml` and resumes across sessions; the status bar shows `cell c/n — image i/t — run p% reviewed`.
- **GSD-aware grid suggestion** sizes cells so a person stays comfortably visible at cell zoom.
- **3×3 focus guide** (toggleable) drawn inside the active cell to structure the eye's scan — purely visual, no extra state.
- **Apply to all images** option stamps a chosen grid size across the whole dataset, protecting any in-progress review (confirms before resetting cells recorded at a different size).

### Design / layering
- Qt-free math & persistence format in `core/services/GridReviewService.py`; orchestration in `core/controllers/images/viewer/grid/GridReviewController.py`; painting in a mouse-transparent `GridOverlayItem` `QGraphicsItem`; settings in `.ui`-backed `GridReviewDialog`.
- **XML compatibility:** grid state is stored as `grid_rows`/`grid_cols`/`grid_reviewed` **attributes on `<image>`** (never child elements — `XmlService.get_images()` parses every `<image>` child as an AOI). Old files load with no grid state; malformed attributes are tolerated.
- Viewer wiring is minimal and localized (key delegation ahead of existing bindings, status key, gallery-mode mutual exclusion, end-of-load hook).

### Tests
117 tests pass (service math, XML round-trip + legacy/backward-compat, controller behaviour incl. apply-to-all, overlay painting, dialog). `flake8 app/` clean on changed files.

### Notes
- **Translations:** the grid strings are translation-ready (`self.tr(...)` and `.ui` text). I deliberately did **not** regenerate the `.ts` catalogs here — regenerating against this branch dropped unrelated existing translations (a tooling/source-state difference in the committed catalogs), so I left locale extraction to the normal release workflow.
- Built on `dev`; no dependency on any in-flight feature branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
