### PR TITLE
feat: Find Similar AOIs with bulk flag/unflag/comment actions

### DIFF
--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -21,6 +21,7 @@ from core.controllers.images.viewer.thumbnails.ThumbnailController import Thumbn
 from core.controllers.images.viewer.gallery.GalleryController import GalleryController
 from core.controllers.images.viewer.aoi.AOIController import AOIController
 from core.controllers.images.viewer.neighbor.AOINeighborTrackingController import AOINeighborTrackingController
+from core.controllers.images.viewer.similarity.AOISimilarityController import AOISimilarityController
 from core.controllers.images.viewer.exports.UnifiedMapExportController import UnifiedMapExportController
 from core.controllers.images.viewer.exports.CoverageExtentExportController import CoverageExtentExportController
 from core.controllers.images.viewer.exports.CalTopoExportController import CalTopoExportController
@@ -224,6 +225,7 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self.gps_map_controller = GPSMapController(self)
         self.team_planning_controller = TeamPlanningController(self)
         self.neighbor_tracking_controller = AOINeighborTrackingController(self)
+        self.similarity_controller = AOISimilarityController(self)
 
         self.ui_style_controller = UIStyleController(self, theme)
         self.thermal_controller = ThermalDataController(self)
@@ -413,6 +415,10 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         # Clean up neighbor tracking controller
         if hasattr(self, 'neighbor_tracking_controller'):
             self.neighbor_tracking_controller.cleanup()
+
+        # Clean up similarity search controller
+        if hasattr(self, 'similarity_controller'):
+            self.similarity_controller.cleanup()
 
         event.accept()
 
@@ -932,24 +938,55 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             if hasattr(self, 'neighbor_tracking_controller'):
                 if (hasattr(self, 'gallery_mode') and self.gallery_mode and
                         hasattr(self, 'gallery_controller') and self.gallery_controller):
-                    ui_component = self.gallery_controller.ui_component
-                    if ui_component and ui_component.gallery_view:
-                        current_index = ui_component.gallery_view.currentIndex()
-                        if current_index.isValid():
-                            aoi_info = self.gallery_controller.model.get_aoi_info(current_index)
-                            if aoi_info:
-                                image_idx, aoi_idx, _ = aoi_info
-                                self.neighbor_tracking_controller.track_selected_aoi(
-                                    image_idx=image_idx, aoi_idx=aoi_idx
-                                )
+                    gallery_selection = self._resolve_gallery_selected_aoi()
+                    if gallery_selection:
+                        image_idx, aoi_idx = gallery_selection
+                        self.neighbor_tracking_controller.track_selected_aoi(
+                            image_idx=image_idx, aoi_idx=aoi_idx
+                        )
                 else:
                     self.neighbor_tracking_controller.track_selected_aoi()
+        if e.key() == Qt.Key_Z and e.modifiers() == Qt.ShiftModifier:
+            # Find visually similar AOIs with 'Shift+Z'
+            if hasattr(self, 'similarity_controller'):
+                if (hasattr(self, 'gallery_mode') and self.gallery_mode and
+                        hasattr(self, 'gallery_controller') and self.gallery_controller):
+                    gallery_selection = self._resolve_gallery_selected_aoi()
+                    if gallery_selection:
+                        image_idx, aoi_idx = gallery_selection
+                        self.similarity_controller.find_similar_for_selected(
+                            image_idx=image_idx, aoi_idx=aoi_idx
+                        )
+                else:
+                    self.similarity_controller.find_similar_for_selected()
         if e.key() == Qt.Key_W and e.modifiers() == Qt.ShiftModifier:
             # Load Wingtra CSV flight log with 'Shift+W' key
             self.wingtra_controller.prompt_and_load_csv()
         if e.key() == Qt.Key_A and e.modifiers() == Qt.NoModifier:
             # Open the Align Image dialog with 'A' key
             self.align_image_controller.open_dialog()
+
+    def _resolve_gallery_selected_aoi(self):
+        """Resolve the AOI selected in the gallery model.
+
+        In gallery mode the selection may belong to an image other than the
+        one displayed in the main viewer, so it must be read from the gallery
+        model rather than the single-image AOIController.
+
+        Returns:
+            tuple: (image_idx, aoi_idx) of the selected AOI, or None.
+        """
+        ui_component = self.gallery_controller.ui_component
+        if not ui_component or not ui_component.gallery_view:
+            return None
+        current_index = ui_component.gallery_view.currentIndex()
+        if not current_index.isValid():
+            return None
+        aoi_info = self.gallery_controller.model.get_aoi_info(current_index)
+        if not aoi_info:
+            return None
+        image_idx, aoi_idx, _ = aoi_info
+        return (image_idx, aoi_idx)
 
     def _build_source_images(self):
         """Enumerate every capture from the original flight folder.

--- a/app/core/controllers/images/viewer/aoi/AOIController.py
+++ b/app/core/controllers/images/viewer/aoi/AOIController.py
@@ -519,6 +519,99 @@ class AOIController(TranslationMixin):
                         except Exception:
                             pass
 
+    def set_aoi_flags_bulk(self, items, flagged):
+        """Set the flag state on multiple AOIs with a single XML save.
+
+        Args:
+            items: Iterable of (image_index, aoi_index) pairs.
+            flagged (bool): Desired flag state for every item.
+
+        Returns:
+            int: Number of AOIs actually updated.
+        """
+        touched_images = set()
+        applied = 0
+        for image_index, aoi_index in items:
+            aoi = self._get_aoi_safe(image_index, aoi_index)
+            if aoi is None:
+                continue
+            aoi['flagged'] = flagged
+            if aoi.get('xml') is not None:
+                aoi['xml'].set('flagged', str(flagged))
+
+            flagged_set = self.flagged_aois.setdefault(image_index, set())
+            if flagged:
+                flagged_set.add(aoi_index)
+            else:
+                flagged_set.discard(aoi_index)
+            touched_images.add(image_index)
+            applied += 1
+
+        if touched_images:
+            self._save_xml_and_refresh_bulk(touched_images)
+        return applied
+
+    def set_aoi_comments_bulk(self, items, comment):
+        """Set the same comment on multiple AOIs with a single XML save.
+
+        An empty comment clears the comment (mirrors save_aoi_comment_to_xml).
+
+        Args:
+            items: Iterable of (image_index, aoi_index) pairs.
+            comment (str): Comment text to apply to every item.
+
+        Returns:
+            int: Number of AOIs actually updated.
+        """
+        touched_images = set()
+        applied = 0
+        for image_index, aoi_index in items:
+            aoi = self._get_aoi_safe(image_index, aoi_index)
+            if aoi is None:
+                continue
+            aoi['user_comment'] = comment
+            if aoi.get('xml') is not None:
+                if comment:
+                    aoi['xml'].set('user_comment', str(comment))
+                elif 'user_comment' in aoi['xml'].attrib:
+                    del aoi['xml'].attrib['user_comment']
+            touched_images.add(image_index)
+            applied += 1
+
+        if touched_images:
+            self._save_xml_and_refresh_bulk(touched_images)
+        return applied
+
+    def _get_aoi_safe(self, image_index, aoi_index):
+        """Return the AOI dict at (image_index, aoi_index), or None if invalid."""
+        if image_index is None or aoi_index is None:
+            return None
+        if not hasattr(self.parent, 'images'):
+            return None
+        if not (0 <= image_index < len(self.parent.images)):
+            return None
+        aois = self.parent.images[image_index].get('areas_of_interest', [])
+        if not (0 <= aoi_index < len(aois)):
+            return None
+        return aois[aoi_index]
+
+    def _save_xml_and_refresh_bulk(self, touched_images):
+        """Persist bulk AOI edits with one XML save and refresh affected displays."""
+        if hasattr(self.parent, 'xml_service') and self.parent.xml_service:
+            try:
+                self.parent.xml_service.save_xml_file(self.parent.xml_path)
+            except Exception:
+                pass
+
+        if getattr(self.parent, 'current_image', None) in touched_images and self.ui_component:
+            self.ui_component.refresh_aoi_display()
+
+        if hasattr(self.parent, 'gallery_controller') and self.parent.gallery_controller:
+            try:
+                self.parent.gallery_controller.refresh_gallery()
+            except Exception:
+                pass
+
     def edit_aoi_comment(self, aoi_index, image_idx=None):
         """Open dialog to edit the comment for an AOI.
 
@@ -663,6 +756,14 @@ class AOIController(TranslationMixin):
         copy_action = menu.addAction(self.tr("Copy Data"))
         copy_action.triggered.connect(
             lambda: self.copy_aoi_data(center, pixel_area, avg_info, aoi_index, image_idx=image_idx)
+        )
+
+        # Add find-similar action
+        similar_action = menu.addAction(self.tr("Find Similar AOIs"))
+        similar_action.setEnabled(aoi_index is not None and hasattr(self.parent, 'similarity_controller'))
+        similar_action.triggered.connect(
+            lambda: self.parent.similarity_controller.find_similar_for_selected(
+                image_idx=image_idx, aoi_idx=aoi_index)
         )
 
         # Get the current cursor position (global coordinates)

--- a/app/core/controllers/images/viewer/similarity/AOISimilarityController.py
+++ b/app/core/controllers/images/viewer/similarity/AOISimilarityController.py
@@ -1,0 +1,416 @@
+"""
+AOISimilarityController - Controller for finding visually similar AOIs.
+
+Runs the AOISimilarityService on a worker thread to rank every other AOI in the
+dataset against the selected one, then displays the top matches in a gallery
+dialog. Mirrors the AOINeighborTrackingController threading pattern.
+"""
+
+from pathlib import Path
+
+from PySide6.QtCore import QObject, Signal, QThread, Qt
+from PySide6.QtWidgets import QMessageBox, QProgressDialog
+
+from core.services.image.AOISimilarityService import AOISimilarityService
+from core.services.LoggerService import LoggerService
+from helpers.TranslationMixin import TranslationMixin
+
+
+class SimilaritySearchWorker(QObject):
+    """Worker that runs the similarity search off the GUI thread."""
+
+    progress = Signal(int, int)  # done, total
+    finished = Signal(list)      # Ranked result dicts
+    error = Signal(str)          # Error message
+
+    def __init__(self, similarity_service, images, ref_image_idx, ref_aoi_idx):
+        super().__init__()
+        self.similarity_service = similarity_service
+        self.images = images
+        self.ref_image_idx = ref_image_idx
+        self.ref_aoi_idx = ref_aoi_idx
+        self._cancelled = False
+
+    def cancel(self):
+        """Cancel the search operation."""
+        self._cancelled = True
+
+    def run(self):
+        """Execute the similarity search."""
+        try:
+            if self._cancelled:
+                self.finished.emit([])
+                return
+
+            results = self.similarity_service.find_similar(
+                images=self.images,
+                ref_image_idx=self.ref_image_idx,
+                ref_aoi_idx=self.ref_aoi_idx,
+                progress_callback=self._emit_progress,
+                cancel_check=lambda: self._cancelled,
+            )
+
+            self.finished.emit([] if self._cancelled else results)
+
+        except Exception as e:
+            self.error.emit(str(e))
+
+    def _emit_progress(self, done, total):
+        if not self._cancelled:
+            self.progress.emit(done, total)
+
+
+class AOISimilarityController(TranslationMixin, QObject):
+    """Controller for ranking all AOIs by visual similarity to a selected AOI."""
+
+    search_started = Signal()
+    search_completed = Signal(list)  # Ranked result dicts (reference excluded)
+    search_error = Signal(str)
+
+    def __init__(self, parent):
+        """
+        Initialize the AOISimilarityController.
+
+        Args:
+            parent: The parent viewer window
+        """
+        super().__init__(parent)
+        self.parent = parent
+        self.logger = LoggerService()
+
+        # Built lazily so the dataset .thumbnails dir can be resolved from xml_path
+        self._similarity_service = None
+
+        # Thread management
+        self._worker = None
+        self._thread = None
+        self._cancelled = False
+        self.progress_dialog = None
+
+        # Results dialog and the entries backing it (row 0 = reference)
+        self._results_dialog = None
+        self._current_results = []
+        self._ref_indices = None
+        self._total_candidates = 0
+
+    def _get_service(self):
+        """Lazily build the similarity service with the dataset thumbnail cache dir."""
+        if self._similarity_service is None:
+            dataset_dir = None
+            xml_path = getattr(self.parent, 'xml_path', None)
+            if xml_path:
+                thumbnail_dir = Path(xml_path).parent / '.thumbnails'
+                if thumbnail_dir.exists():
+                    dataset_dir = str(thumbnail_dir)
+            self._similarity_service = AOISimilarityService(dataset_thumbnail_dir=dataset_dir)
+        return self._similarity_service
+
+    def find_similar_for_selected(self, image_idx=None, aoi_idx=None):
+        """
+        Rank all other AOIs by similarity to the selected AOI.
+
+        Triggered by the context menu ("Find Similar AOIs") or Shift+Z. When called
+        with explicit indices those are used directly (context menu and gallery mode);
+        with no arguments the AOI is read from the single-image AOIController.
+        """
+        try:
+            # One search at a time
+            if self._thread is not None:
+                return
+
+            if aoi_idx is not None:
+                ref_image_idx = image_idx if image_idx is not None else self.parent.current_image
+                if ref_image_idx < 0 or ref_image_idx >= len(self.parent.images):
+                    return
+                aois = self.parent.images[ref_image_idx].get('areas_of_interest', [])
+                if aoi_idx < 0 or aoi_idx >= len(aois):
+                    return
+                ref_aoi_idx = aoi_idx
+            else:
+                selected_aoi = self.parent.aoi_controller.get_selected_aoi()
+                if not selected_aoi:
+                    QMessageBox.information(
+                        self.parent,
+                        self.tr("No AOI Selected"),
+                        self.tr("Please select an AOI first by clicking on it in the thumbnail panel.")
+                    )
+                    return
+                _, ref_aoi_idx = selected_aoi
+                ref_image_idx = self.parent.current_image
+
+            self._ref_indices = (ref_image_idx, ref_aoi_idx)
+            self._total_candidates = max(
+                0,
+                sum(len(image.get('areas_of_interest') or []) for image in self.parent.images) - 1
+            )
+            self._start_search(ref_image_idx=ref_image_idx, ref_aoi_idx=ref_aoi_idx)
+
+        except Exception as e:
+            self.logger.error(f"Error starting AOI similarity search: {e}")
+            QMessageBox.critical(
+                self.parent,
+                self.tr("Similarity Search Error"),
+                self.tr("An error occurred while starting the similarity search:\n{error}").format(
+                    error=str(e)
+                )
+            )
+
+    def _start_search(self, **worker_kwargs):
+        """Show the progress dialog and start the worker thread."""
+        self._cancelled = False
+
+        # Show progress dialog (indeterminate until the first progress signal)
+        self.progress_dialog = QProgressDialog(
+            self.tr("Analyzing AOIs for visual similarity..."),
+            self.tr("Cancel"),
+            0, 0,
+            self.parent
+        )
+        self.progress_dialog.setWindowTitle(self.tr("Find Similar AOIs"))
+        self.progress_dialog.setWindowModality(Qt.WindowModal)
+        self.progress_dialog.setMinimumDuration(0)
+        self.progress_dialog.setValue(0)
+
+        # Create worker and thread
+        self._thread = QThread()
+        self._worker = SimilaritySearchWorker(
+            similarity_service=self._get_service(),
+            images=self.parent.images,
+            **worker_kwargs
+        )
+        self._worker.moveToThread(self._thread)
+
+        # Connect signals
+        self._thread.started.connect(self._worker.run)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished.connect(self._on_search_complete)
+        self._worker.error.connect(self._on_search_error)
+        self.progress_dialog.canceled.connect(self._on_cancelled)
+
+        self.search_started.emit()
+        self._thread.start()
+
+    def _on_progress(self, done, total):
+        """Handle progress updates from the worker."""
+        if self.progress_dialog and total > 0:
+            if self.progress_dialog.maximum() != total:
+                self.progress_dialog.setRange(0, total)
+            self.progress_dialog.setValue(done)
+            self.progress_dialog.setLabelText(
+                self.tr("Analyzing AOI {done} of {total}...").format(done=done, total=total)
+            )
+
+    def _on_search_complete(self, results):
+        """Handle search completion."""
+        try:
+            self._cleanup_thread()
+            self._close_progress_dialog()
+
+            if self._cancelled:
+                return
+
+            if not results:
+                QMessageBox.information(
+                    self.parent,
+                    self.tr("No Similar AOIs"),
+                    self.tr("No other AOIs could be analyzed for similarity.")
+                )
+                return
+
+            # Prepend the reference AOI so it is always visible as row 0
+            display_results = results
+            try:
+                reference_entry = self._get_service().build_reference_entry(
+                    self.parent.images, *self._ref_indices)
+                display_results = [reference_entry] + results
+            except Exception as e:
+                self.logger.error(f"Error building similarity reference entry: {e}")
+
+            self._show_results_dialog(display_results)
+            self.search_completed.emit(results)
+
+        except Exception as e:
+            self.logger.error(f"Error handling similarity search completion: {e}")
+
+    def _on_search_error(self, error_msg):
+        """Handle search error."""
+        try:
+            self._cleanup_thread()
+            self._close_progress_dialog()
+
+            if self._cancelled:
+                return
+
+            QMessageBox.warning(
+                self.parent,
+                self.tr("Similarity Search Error"),
+                self.tr("The similarity search could not be completed:\n{error}").format(
+                    error=error_msg
+                )
+            )
+
+            self.search_error.emit(error_msg)
+
+        except Exception as e:
+            self.logger.error(f"Error handling similarity search error: {e}")
+
+    def _on_cancelled(self):
+        """Handle cancellation from the progress dialog."""
+        self._cancelled = True
+        if self._worker:
+            self._worker.cancel()
+        self._cleanup_thread()
+
+    def _close_progress_dialog(self):
+        """Close the progress dialog without triggering a spurious cancellation.
+
+        QProgressDialog emits canceled() from its closeEvent, so the canceled
+        handler must be disconnected before closing or a completed search would
+        be treated as user-cancelled and its results silently dropped.
+        """
+        if self.progress_dialog:
+            try:
+                self.progress_dialog.canceled.disconnect(self._on_cancelled)
+            except (RuntimeError, TypeError):
+                pass
+            self.progress_dialog.close()
+            self.progress_dialog = None
+
+    def _cleanup_thread(self):
+        """Clean up the worker thread."""
+        if self._thread:
+            self._thread.quit()
+            self._thread.wait()
+            self._thread = None
+        self._worker = None
+
+    def _show_results_dialog(self, display_results):
+        """
+        Show the results dialog with the ranked thumbnails.
+
+        Args:
+            display_results (list): Result dicts; row 0 is the reference entry.
+        """
+        try:
+            # Import here to avoid circular imports
+            from core.views.images.viewer.dialogs.AOISimilarityResultsDialog import AOISimilarityResultsDialog
+
+            self._current_results = display_results
+
+            if self._results_dialog:
+                self._results_dialog.close()
+
+            self._results_dialog = AOISimilarityResultsDialog(
+                self.parent, display_results, total_candidates=self._total_candidates)
+            self._results_dialog.result_clicked.connect(self._on_result_clicked)
+            self._results_dialog.bulk_flag_requested.connect(self._on_bulk_flag)
+            self._results_dialog.bulk_comment_requested.connect(self._on_bulk_comment)
+            self._results_dialog.show()
+
+        except Exception as e:
+            self.logger.error(f"Error showing similarity results dialog: {e}")
+            QMessageBox.critical(
+                self.parent,
+                self.tr("Display Error"),
+                self.tr("An error occurred while displaying results:\n{error}").format(
+                    error=str(e)
+                )
+            )
+
+    def _on_result_clicked(self, row):
+        """
+        Navigate the viewer to the clicked result's AOI.
+
+        Args:
+            row (int): Row of the clicked result in the dialog.
+        """
+        try:
+            if row < 0 or row >= len(self._current_results):
+                return
+            result = self._current_results[row]
+            image_idx = result['image_idx']
+            aoi_idx = result['aoi_idx']
+            aoi_data = result.get('aoi_data')
+
+            gallery_controller = self.parent.gallery_controller
+            if getattr(self.parent, 'gallery_mode', False):
+                # go_to_aoi also syncs the gallery selection; it returns False when
+                # the AOI is filtered out of the gallery, so fall through to a
+                # direct load+zoom in that case.
+                if gallery_controller.go_to_aoi(image_idx, aoi_idx):
+                    return
+            gallery_controller.on_aoi_clicked(image_idx, aoi_idx, aoi_data)
+
+        except Exception as e:
+            self.logger.error(f"Error navigating to similar AOI: {e}")
+
+    def _entries_for_rows(self, rows):
+        """Map dialog rows to their result entries, dropping out-of-range rows."""
+        return [self._current_results[row] for row in rows
+                if 0 <= row < len(self._current_results)]
+
+    def _on_bulk_flag(self, rows, flagged):
+        """Flag or unflag all checked result AOIs."""
+        try:
+            entries = self._entries_for_rows(rows)
+            if not entries:
+                return
+
+            items = [(entry['image_idx'], entry['aoi_idx']) for entry in entries]
+            applied = self.parent.aoi_controller.set_aoi_flags_bulk(items, flagged)
+
+            if self._results_dialog:
+                self._results_dialog.refresh_status_badges()
+
+            if applied and hasattr(self.parent, 'status_controller'):
+                if flagged:
+                    message = self.tr("Flagged {count} AOI(s)").format(count=applied)
+                    self.parent.status_controller.show_toast(message, 2000, color="#00C853")
+                else:
+                    message = self.tr("Removed flag from {count} AOI(s)").format(count=applied)
+                    self.parent.status_controller.show_toast(message, 2000, color="#808080")
+
+        except Exception as e:
+            self.logger.error(f"Error applying bulk flag to similar AOIs: {e}")
+
+    def _on_bulk_comment(self, rows):
+        """Add or edit the comment on all checked result AOIs."""
+        try:
+            entries = self._entries_for_rows(rows)
+            if not entries:
+                return
+
+            # Pre-fill with the common comment when every checked AOI agrees
+            comments = {(entry.get('aoi_data') or {}).get('user_comment', '') for entry in entries}
+            current_comment = comments.pop() if len(comments) == 1 else ''
+
+            # Import here to avoid circular imports
+            from core.views.images.viewer.dialogs.AOICommentDialog import AOICommentDialog
+            dialog = AOICommentDialog(self.parent, current_comment)
+            if not dialog.exec():
+                return
+            comment = dialog.get_comment()
+
+            items = [(entry['image_idx'], entry['aoi_idx']) for entry in entries]
+            applied = self.parent.aoi_controller.set_aoi_comments_bulk(items, comment)
+
+            if self._results_dialog:
+                self._results_dialog.refresh_status_badges()
+
+            if applied and hasattr(self.parent, 'status_controller'):
+                if comment:
+                    message = self.tr("Comment saved on {count} AOI(s)").format(count=applied)
+                    self.parent.status_controller.show_toast(message, 2000, color="#00C853")
+                else:
+                    message = self.tr("Comment cleared on {count} AOI(s)").format(count=applied)
+                    self.parent.status_controller.show_toast(message, 2000, color="#808080")
+
+        except Exception as e:
+            self.logger.error(f"Error applying bulk comment to similar AOIs: {e}")
+
+    def cleanup(self):
+        """Clean up resources."""
+        self._cleanup_thread()
+        if self._results_dialog:
+            self._results_dialog.close()
+            self._results_dialog = None

--- a/app/core/controllers/images/viewer/similarity/__init__.py
+++ b/app/core/controllers/images/viewer/similarity/__init__.py
@@ -1,0 +1,9 @@
+"""
+AOI Similarity Search module.
+
+Provides functionality for ranking AOIs across the dataset by visual similarity.
+"""
+
+from .AOISimilarityController import AOISimilarityController
+
+__all__ = ['AOISimilarityController']

--- a/app/core/services/image/AOISimilarityService.py
+++ b/app/core/services/image/AOISimilarityService.py
@@ -1,0 +1,328 @@
+"""
+AOISimilarityService - Ranks AOIs across a dataset by visual similarity to a reference AOI.
+
+Similarity is color-first: an HSV hue/saturation histogram computed over a circular
+mask of the cached 180x180 AOI thumbnail is the dominant signal, blended with a
+brightness (V) histogram, a pixel-area log-ratio, and mean saturation/value stats.
+Descriptors are cached in memory for the lifetime of the service (one Viewer session).
+
+Thread-safety: descriptors are computed and cached only from a single worker thread,
+and the owning controller enforces one search at a time, so no locking is used here.
+Only ndarray/PIL/cv2 code paths of ThumbnailCacheService are used (never QPixmap/QIcon),
+which keeps this service safe to run off the GUI thread.
+"""
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import cv2
+import numpy as np
+
+from core.services.LoggerService import LoggerService
+from core.services.cache.ThumbnailCacheService import ThumbnailCacheService
+
+THUMB_SIZE = 180
+CROP_PADDING = 10
+HS_BINS = (16, 8)
+V_BINS = 16
+CHROMA_S_MIN = 40
+CHROMA_V_MIN = 40
+CHROMA_MIN_PIXELS = 25
+CHROMA_MIN_FRACTION = 0.10
+MAX_RESULTS_DEFAULT = 40
+AREA_RATIO_SATURATION = 16.0
+PROGRESS_EVERY = 100
+
+# Fixed blend weights per regime. The mixed regime carries a flat penalty because a
+# chromatic AOI is categorically unlike an achromatic one, but candidates can still
+# rank among themselves via brightness/area.
+WEIGHT_CHROMATIC_HS = 0.55
+WEIGHT_CHROMATIC_V = 0.20
+WEIGHT_CHROMATIC_AREA = 0.15
+WEIGHT_CHROMATIC_STATS = 0.10
+WEIGHT_ACHROMATIC_V = 0.55
+WEIGHT_ACHROMATIC_AREA = 0.25
+WEIGHT_ACHROMATIC_STATS = 0.20
+MIXED_PENALTY = 0.30
+WEIGHT_MIXED_V = 0.35
+WEIGHT_MIXED_AREA = 0.20
+WEIGHT_MIXED_STATS = 0.15
+
+
+@dataclass
+class AOIDescriptor:
+    """Compact per-AOI appearance descriptor (~600 bytes)."""
+    hs_hist: Optional[np.ndarray]  # L1-normalized 16x8 hue/sat histogram; None when achromatic
+    v_hist: np.ndarray             # L1-normalized 16-bin brightness histogram
+    chromatic_fraction: float      # Fraction of masked pixels passing the chroma gate
+    mean_s: float                  # Mean saturation over the circular mask (0-255)
+    mean_v: float                  # Mean value over the circular mask (0-255)
+    area: float                    # Detected pixel count (fallback: circle area)
+
+    @property
+    def is_chromatic(self) -> bool:
+        return self.hs_hist is not None
+
+
+class AOISimilarityService:
+    """Computes appearance descriptors for AOIs and ranks candidates by similarity."""
+
+    def __init__(self, dataset_thumbnail_dir: Optional[str] = None):
+        """
+        Args:
+            dataset_thumbnail_dir: The dataset's .thumbnails directory, when it exists.
+                Cached 180x180 crops are read from (and self-healed back to) this dir.
+        """
+        self.logger = LoggerService()
+        self.thumbnail_cache = ThumbnailCacheService(dataset_cache_dir=dataset_thumbnail_dir)
+        # Keyed by the thumbnail cache key (content-derived from filename:center:radius),
+        # so entries survive AOI index shifts and auto-invalidate on center/radius edits.
+        # Failed computations are cached as None to avoid re-decoding broken images.
+        self._descriptor_cache: Dict[str, Optional[AOIDescriptor]] = {}
+
+    def clear_cache(self):
+        """Drop all cached descriptors."""
+        self._descriptor_cache.clear()
+
+    def get_crop(self, image_path: str, aoi_data: Dict[str, Any]) -> Optional[np.ndarray]:
+        """
+        Get the 180x180 RGB crop for an AOI without loading the full source image.
+
+        Checks the disk thumbnail cache (portable then legacy key), then falls back to a
+        lazy PIL region extract; a successful fallback is written back to the cache so
+        legacy datasets self-heal.
+        """
+        cache = self.thumbnail_cache
+        cache_key = cache.get_cache_key(image_path, aoi_data)
+        crop = cache.load_thumbnail_from_disk(cache_key)
+
+        if crop is None:
+            legacy_key = cache.get_legacy_cache_key(image_path, aoi_data, aoi_data.get('_xml_path'))
+            if legacy_key != cache_key:
+                crop = cache.load_thumbnail_from_disk(legacy_key)
+
+        if crop is None:
+            crop = cache.extract_aoi_region_fast(image_path, aoi_data, (THUMB_SIZE, THUMB_SIZE))
+            if crop is not None and cache.dataset_cache_dir:
+                try:
+                    cache.save_thumbnail_to_disk(cache_key, crop, cache.dataset_cache_dir)
+                except Exception:
+                    pass  # Best-effort self-heal; read-only datasets must not fail the search
+
+        return crop
+
+    def build_circle_mask(self, radius: float) -> np.ndarray:
+        """
+        Build the circular mask isolating the AOI within its 180x180 thumbnail.
+
+        The thumbnail is a (radius + padding) square crop resized to 180px, so the AOI
+        circle maps to 90 * radius / (radius + padding) pixels, clamped to keep at least
+        a few samples and to stay inside the tile.
+        """
+        radius = max(1.0, float(radius))
+        mask_radius = int(round((THUMB_SIZE / 2) * radius / (radius + CROP_PADDING)))
+        mask_radius = max(4, min(88, mask_radius))
+        mask = np.zeros((THUMB_SIZE, THUMB_SIZE), dtype=np.uint8)
+        cv2.circle(mask, (THUMB_SIZE // 2, THUMB_SIZE // 2), mask_radius, 255, -1)
+        return mask
+
+    def compute_descriptor(self, crop_rgb: Optional[np.ndarray], aoi_data: Dict[str, Any]) -> Optional[AOIDescriptor]:
+        """
+        Compute the appearance descriptor for one AOI crop. Deterministic.
+
+        Gray/near-gray pixels are excluded from the hue/sat histogram (chroma gate); when
+        too few chromatic pixels remain the crop is flagged achromatic (hs_hist=None) and
+        similarity falls back to brightness/area/stats.
+        """
+        if crop_rgb is None:
+            return None
+        try:
+            crop = self._normalize_crop(crop_rgb)
+            radius = aoi_data.get('radius', 50)
+            mask = self.build_circle_mask(radius)
+            mask_bool = mask > 0
+            mask_count = int(np.count_nonzero(mask_bool))
+            if mask_count == 0:
+                return None
+
+            hsv = cv2.cvtColor(crop, cv2.COLOR_RGB2HSV)
+            saturation = hsv[:, :, 1]
+            value = hsv[:, :, 2]
+
+            chroma_bool = mask_bool & (saturation >= CHROMA_S_MIN) & (value >= CHROMA_V_MIN)
+            chroma_count = int(np.count_nonzero(chroma_bool))
+            chromatic_fraction = chroma_count / mask_count
+
+            hs_hist = None
+            if chroma_count >= CHROMA_MIN_PIXELS and chromatic_fraction >= CHROMA_MIN_FRACTION:
+                chroma_mask = chroma_bool.astype(np.uint8) * 255
+                hs_hist = cv2.calcHist([hsv], [0, 1], chroma_mask, list(HS_BINS), [0, 180, 0, 256])
+                total = float(hs_hist.sum())
+                hs_hist = (hs_hist / total).astype(np.float32) if total > 0 else None
+
+            v_hist = cv2.calcHist([hsv], [2], mask, [V_BINS], [0, 256])
+            v_total = float(v_hist.sum())
+            if v_total > 0:
+                v_hist = (v_hist / v_total).astype(np.float32)
+            else:
+                v_hist = v_hist.astype(np.float32)
+
+            area = aoi_data.get('area') or round(math.pi * max(1.0, float(radius)) ** 2)
+            return AOIDescriptor(
+                hs_hist=hs_hist,
+                v_hist=v_hist,
+                chromatic_fraction=chromatic_fraction,
+                mean_s=float(saturation[mask_bool].mean()),
+                mean_v=float(value[mask_bool].mean()),
+                area=float(area),
+            )
+        except Exception as e:
+            self.logger.error(f"Error computing AOI similarity descriptor: {e}")
+            return None
+
+    def get_descriptor(self, image_path: str, aoi_data: Dict[str, Any]) -> Optional[AOIDescriptor]:
+        """Cached wrapper around get_crop + compute_descriptor."""
+        cache_key = self.thumbnail_cache.get_cache_key(image_path, aoi_data)
+        if cache_key in self._descriptor_cache:
+            return self._descriptor_cache[cache_key]
+        descriptor = self.compute_descriptor(self.get_crop(image_path, aoi_data), aoi_data)
+        self._descriptor_cache[cache_key] = descriptor
+        return descriptor
+
+    def compare(self, desc_a: AOIDescriptor, desc_b: AOIDescriptor) -> float:
+        """
+        Blended distance between two descriptors, in [0, 1] (0 = identical).
+
+        Histogram distances use Bhattacharyya: symmetric, bounded, and more tolerant of
+        bin-edge/JPEG jitter on single-dominant-bin (solid color) crops than intersection.
+        """
+        d_v = self._bhattacharyya(desc_a.v_hist, desc_b.v_hist)
+        d_area = min(1.0, abs(math.log((desc_a.area + 1.0) / (desc_b.area + 1.0))) / math.log(AREA_RATIO_SATURATION))
+        d_stats = (abs(desc_a.mean_s - desc_b.mean_s) + abs(desc_a.mean_v - desc_b.mean_v)) / (2.0 * 255.0)
+
+        if desc_a.is_chromatic and desc_b.is_chromatic:
+            d_hs = self._bhattacharyya(desc_a.hs_hist, desc_b.hs_hist)
+            distance = (WEIGHT_CHROMATIC_HS * d_hs + WEIGHT_CHROMATIC_V * d_v +
+                        WEIGHT_CHROMATIC_AREA * d_area + WEIGHT_CHROMATIC_STATS * d_stats)
+        elif not desc_a.is_chromatic and not desc_b.is_chromatic:
+            distance = (WEIGHT_ACHROMATIC_V * d_v + WEIGHT_ACHROMATIC_AREA * d_area +
+                        WEIGHT_ACHROMATIC_STATS * d_stats)
+        else:
+            distance = min(1.0, MIXED_PENALTY + WEIGHT_MIXED_V * d_v +
+                           WEIGHT_MIXED_AREA * d_area + WEIGHT_MIXED_STATS * d_stats)
+
+        return min(max(distance, 0.0), 1.0)
+
+    def find_similar(self, images: List[Dict[str, Any]], ref_image_idx: int, ref_aoi_idx: int,
+                     progress_callback: Optional[Callable[[int, int], None]] = None,
+                     cancel_check: Optional[Callable[[], bool]] = None,
+                     max_results: int = MAX_RESULTS_DEFAULT) -> List[Dict[str, Any]]:
+        """
+        Rank every other AOI in the dataset by similarity to the reference AOI.
+
+        Args:
+            images: Viewer image dicts (each with 'path' and 'areas_of_interest').
+            ref_image_idx / ref_aoi_idx: Location of the reference AOI.
+            progress_callback: Optional callable(done, total), invoked every 100 AOIs.
+            cancel_check: Optional callable returning True to abort; returns [] on cancel.
+            max_results: Cap on returned matches.
+
+        Returns:
+            Top-N result dicts sorted by similarity desc (ties: image/AOI index asc).
+
+        Raises:
+            ValueError: If the reference AOI is missing or cannot be analyzed.
+        """
+        try:
+            ref_image = images[ref_image_idx]
+            ref_aoi = ref_image['areas_of_interest'][ref_aoi_idx]
+        except (IndexError, KeyError, TypeError):
+            raise ValueError(f"Reference AOI not found (image {ref_image_idx}, AOI {ref_aoi_idx})")
+
+        ref_descriptor = self.get_descriptor(ref_image.get('path'), ref_aoi)
+        if ref_descriptor is None:
+            raise ValueError(
+                f"Could not analyze the selected AOI (image '{ref_image.get('path')}', AOI {ref_aoi_idx})"
+            )
+
+        candidates = []
+        for image_idx, image in enumerate(images):
+            for aoi_idx, aoi in enumerate(image.get('areas_of_interest') or []):
+                if image_idx == ref_image_idx and aoi_idx == ref_aoi_idx:
+                    continue
+                candidates.append((image_idx, aoi_idx, aoi, image))
+
+        total = len(candidates)
+        scored = []
+        skipped = 0
+        for done, (image_idx, aoi_idx, aoi, image) in enumerate(candidates, start=1):
+            if cancel_check and cancel_check():
+                return []
+            try:
+                descriptor = self.get_descriptor(image.get('path'), aoi)
+            except Exception as e:
+                self.logger.error(
+                    f"Similarity search: descriptor failed for image '{image.get('path')}' AOI {aoi_idx}: {e}"
+                )
+                descriptor = None
+            if descriptor is None:
+                skipped += 1
+            else:
+                distance = self.compare(ref_descriptor, descriptor)
+                similarity = int(max(0, min(100, round(100.0 * (1.0 - distance)))))
+                scored.append((similarity, image_idx, aoi_idx, aoi, image))
+            if progress_callback and (done % PROGRESS_EVERY == 0 or done == total):
+                progress_callback(done, total)
+
+        if skipped:
+            self.logger.warning(f"Similarity search skipped {skipped} AOI(s) with no readable thumbnail")
+
+        scored.sort(key=lambda entry: (-entry[0], entry[1], entry[2]))
+        return [self._build_result(image, image_idx, aoi_idx, aoi, similarity)
+                for similarity, image_idx, aoi_idx, aoi, image in scored[:max_results]]
+
+    def build_reference_entry(self, images: List[Dict[str, Any]], ref_image_idx: int,
+                              ref_aoi_idx: int) -> Dict[str, Any]:
+        """Build the display entry for the reference AOI itself (similarity 100)."""
+        image = images[ref_image_idx]
+        aoi = image['areas_of_interest'][ref_aoi_idx]
+        entry = self._build_result(image, ref_image_idx, ref_aoi_idx, aoi, 100)
+        entry['is_reference'] = True
+        return entry
+
+    def _build_result(self, image: Dict[str, Any], image_idx: int, aoi_idx: int,
+                      aoi: Dict[str, Any], similarity: int) -> Dict[str, Any]:
+        image_path = image.get('path')
+        return {
+            'image_idx': image_idx,
+            'aoi_idx': aoi_idx,
+            'image_name': Path(image_path).name if image_path else '',
+            'image_path': image_path,
+            'aoi_number': aoi.get('number'),
+            'center': aoi.get('center'),
+            'area': aoi.get('area'),
+            'similarity': similarity,
+            'thumbnail': self.get_crop(image_path, aoi),
+            'aoi_data': aoi,
+            'is_reference': False,
+        }
+
+    @staticmethod
+    def _bhattacharyya(hist_a: np.ndarray, hist_b: np.ndarray) -> float:
+        distance = float(cv2.compareHist(hist_a, hist_b, cv2.HISTCMP_BHATTACHARYYA))
+        return min(max(distance, 0.0), 1.0)
+
+    @staticmethod
+    def _normalize_crop(crop: np.ndarray) -> np.ndarray:
+        """Coerce a cached/loaded crop to 180x180 RGB uint8."""
+        if crop.ndim == 2:
+            crop = np.stack([crop] * 3, axis=-1)
+        elif crop.shape[2] == 4:
+            crop = crop[:, :, :3]
+        if crop.dtype != np.uint8:
+            crop = np.clip(crop, 0, 255).astype(np.uint8)
+        if crop.shape[0] != THUMB_SIZE or crop.shape[1] != THUMB_SIZE:
+            crop = cv2.resize(crop, (THUMB_SIZE, THUMB_SIZE), interpolation=cv2.INTER_AREA)
+        return np.ascontiguousarray(crop)

--- a/app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py
+++ b/app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py
@@ -1,0 +1,593 @@
+"""
+AOISimilarityResultsDialog - Dialog for displaying AOIs ranked by visual similarity.
+
+Displays a horizontal gallery of AOI thumbnails ranked by similarity to a reference
+AOI. Row 0 is the reference itself; every other tile shows its similarity score.
+Adapted from AOINeighborGalleryDialog, but keyed by result row rather than image
+index because multiple AOIs from the same image can appear in the results.
+"""
+
+import numpy as np
+import cv2
+from PySide6.QtCore import Qt, Signal, QRectF, QPointF, QTimer
+from PySide6.QtGui import (
+    QImage, QPixmap, QPainter, QColor, QPen, QFont, QBrush,
+    QWheelEvent, QMouseEvent
+)
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QSizePolicy,
+    QGraphicsView, QGraphicsScene, QGraphicsPixmapItem, QGraphicsTextItem,
+    QGraphicsRectItem
+)
+
+from core.services.LoggerService import LoggerService
+from helpers.TranslationMixin import TranslationMixin
+
+
+class SimilarityGalleryView(TranslationMixin, QGraphicsView):
+    """
+    Graphics view for displaying similarity-ranked AOI thumbnails.
+
+    Supports zoom with mouse wheel and pan with right-click drag.
+    """
+
+    thumbnail_clicked = Signal(int)  # Emits the result row when a thumbnail is clicked
+    selection_changed = Signal(int)  # Emits the number of checked rows
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.logger = LoggerService()
+
+        # Create scene
+        self.scene = QGraphicsScene(self)
+        self.setScene(self.scene)
+
+        # Enable antialiasing
+        self.setRenderHint(QPainter.Antialiasing)
+        self.setRenderHint(QPainter.SmoothPixmapTransform)
+
+        # Configure view
+        self.setDragMode(QGraphicsView.NoDrag)
+        self.setTransformationAnchor(QGraphicsView.AnchorUnderMouse)
+        self.setResizeAnchor(QGraphicsView.AnchorUnderMouse)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.setBackgroundBrush(QBrush(QColor(30, 30, 30)))
+
+        # Zoom state
+        self._zoom = 1.0
+        self._min_zoom = 0.1
+
+        # Pan state
+        self._panning = False
+        self._pan_start = QPointF()
+
+        # Thumbnail items (for click detection)
+        self._thumbnail_rects = []  # List of (QRectF, row)
+
+        # Selection tracking
+        self._selected_row = -1
+        self._border_items = []  # List of (row, border_rect, is_reference)
+        self._results = []
+
+        # Checkbox state (bulk actions)
+        self._checked_rows = set()
+        self._checkbox_rects = []  # List of (QRectF, row) for hit-testing
+        self._checkbox_items = {}  # row -> (box_item, tick_item)
+
+        # Status badges (flag / comment), refreshed after bulk actions
+        self._badge_items = {}  # row -> (flag_item, comment_item)
+
+        # Style settings
+        self.thumbnail_spacing = 20
+        self.thumbnail_size = 200
+        self.label_height = 60  # Three caption lines per tile
+        self.reference_highlight_width = 4
+        self.checkbox_size = 22
+
+    def load_thumbnails(self, results):
+        """
+        Load thumbnails from similarity search results.
+
+        Args:
+            results (list): Result dicts; row 0 is expected to be the reference entry.
+        """
+        self.scene.clear()
+        self._thumbnail_rects = []
+        self._border_items = []
+        self._results = results or []
+        self._selected_row = -1
+        self._checked_rows = set()
+        self._checkbox_rects = []
+        self._checkbox_items = {}
+        self._badge_items = {}
+        self.selection_changed.emit(0)
+
+        if not results:
+            return
+
+        x = self.thumbnail_spacing
+        y = self.thumbnail_spacing
+
+        for row, result in enumerate(results):
+            try:
+                thumbnail = result.get('thumbnail')
+                if thumbnail is None:
+                    continue
+
+                # Resize to consistent size
+                height, width = thumbnail.shape[:2]
+                scale = self.thumbnail_size / max(width, height)
+                new_width = int(width * scale)
+                new_height = int(height * scale)
+                thumbnail_resized = cv2.resize(thumbnail, (new_width, new_height),
+                                               interpolation=cv2.INTER_LANCZOS4)
+
+                # Convert to QImage and QPixmap (copy so the buffer stays valid)
+                if len(thumbnail_resized.shape) == 2:
+                    thumbnail_contiguous = np.ascontiguousarray(thumbnail_resized, dtype=np.uint8)
+                    qimage = QImage(thumbnail_contiguous.tobytes(), new_width, new_height,
+                                    new_width, QImage.Format_Grayscale8).copy()
+                else:
+                    thumbnail_contiguous = np.ascontiguousarray(thumbnail_resized, dtype=np.uint8)
+                    qimage = QImage(thumbnail_contiguous.tobytes(), new_width, new_height,
+                                    3 * new_width, QImage.Format_RGB888).copy()
+
+                pixmap = QPixmap.fromImage(qimage)
+                if pixmap.isNull():
+                    self.logger.warning("Failed to create pixmap for similarity thumbnail")
+                    continue
+
+                pixmap_item = QGraphicsPixmapItem(pixmap)
+                pixmap_item.setPos(x + (self.thumbnail_size - new_width) / 2,
+                                   y + (self.thumbnail_size - new_height) / 2)
+                self.scene.addItem(pixmap_item)
+
+                # Border: reference tile is highlighted green
+                is_reference = result.get('is_reference', False)
+                border_color = QColor(0, 200, 0) if is_reference else QColor(100, 100, 100)
+                border_width = self.reference_highlight_width if is_reference else 2
+
+                border_rect = QGraphicsRectItem(x - border_width / 2, y - border_width / 2,
+                                                self.thumbnail_size + border_width,
+                                                self.thumbnail_size + border_width)
+                border_rect.setPen(QPen(border_color, border_width))
+                border_rect.setBrush(QBrush(Qt.NoBrush))
+                self.scene.addItem(border_rect)
+                self._border_items.append((row, border_rect, is_reference))
+
+                # Store rect for click detection
+                click_rect = QRectF(x, y, self.thumbnail_size, self.thumbnail_size)
+                self._thumbnail_rects.append((click_rect, row))
+
+                # Checkbox (top-left) for bulk actions — only rows backed by a real AOI
+                if result.get('aoi_idx') is not None:
+                    self._add_checkbox(row, x, y)
+
+                # Status badges (top-right): flag and comment indicators
+                self._add_status_badges(row, result, x, y)
+
+                # Caption line 1: similarity badge (or "Reference")
+                if is_reference:
+                    badge_text = self.tr("Reference")
+                    badge_color = QColor(0, 200, 0)
+                else:
+                    similarity = result.get('similarity', 0)
+                    badge_text = f"{similarity}%"
+                    badge_color = self._similarity_color(similarity)
+                self._add_caption(badge_text, badge_color, x, y + self.thumbnail_size + 5, bold=True)
+
+                # Caption line 2: image name
+                image_name = result.get('image_name') or self.tr("Unknown")
+                self._add_caption(image_name, QColor(255, 255, 255),
+                                  x, y + self.thumbnail_size + 22)
+
+                # Caption line 3: AOI number (fallback to 1-based index within its image;
+                # external query images have no AOI, so their line is left blank)
+                aoi_number = result.get('aoi_number')
+                aoi_idx = result.get('aoi_idx')
+                if aoi_number is not None:
+                    aoi_text = self.tr("AOI #{number}").format(number=aoi_number)
+                elif aoi_idx is not None:
+                    aoi_text = self.tr("AOI {index}").format(index=aoi_idx + 1)
+                else:
+                    aoi_text = ""
+                if aoi_text:
+                    self._add_caption(aoi_text, QColor(170, 170, 170),
+                                      x, y + self.thumbnail_size + 39)
+
+                x += self.thumbnail_size + self.thumbnail_spacing
+
+            except Exception as e:
+                self.logger.error(f"Error loading similarity thumbnail (row {row}): {e}")
+                continue
+
+        # Set scene rect
+        total_width = x + self.thumbnail_spacing
+        total_height = self.thumbnail_size + self.label_height + 2 * self.thumbnail_spacing
+        self.scene.setSceneRect(0, 0, total_width, total_height)
+
+        # Reset transform; show from the start if content is wider than the view
+        self.resetTransform()
+        self._zoom = 1.0
+        view_width = self.viewport().width()
+        if total_width <= view_width:
+            self.fitInView(self.scene.sceneRect(), Qt.KeepAspectRatio)
+        else:
+            self.centerOn(self.thumbnail_spacing + self.thumbnail_size / 2,
+                          self.thumbnail_spacing + self.thumbnail_size / 2)
+
+    def _add_caption(self, text, color, tile_x, text_y, bold=False):
+        """Add a centered caption line under a tile."""
+        text_item = QGraphicsTextItem(text)
+        text_item.setDefaultTextColor(color)
+        font = QFont("Arial", 9)
+        font.setBold(bold)
+        text_item.setFont(font)
+        text_width = text_item.boundingRect().width()
+        text_item.setPos(tile_x + (self.thumbnail_size - text_width) / 2, text_y)
+        self.scene.addItem(text_item)
+
+    def _add_checkbox(self, row, tile_x, tile_y):
+        """Add a selection checkbox at the tile's top-left corner."""
+        size = self.checkbox_size
+        box_rect = QRectF(tile_x + 6, tile_y + 6, size, size)
+
+        box_item = QGraphicsRectItem(box_rect)
+        box_item.setPen(QPen(QColor(255, 255, 255), 2))
+        box_item.setBrush(QBrush(QColor(0, 0, 0, 140)))
+        self.scene.addItem(box_item)
+
+        tick_item = QGraphicsTextItem("✓")
+        tick_item.setDefaultTextColor(QColor(0, 230, 0))
+        tick_font = QFont("Arial", 12)
+        tick_font.setBold(True)
+        tick_item.setFont(tick_font)
+        tick_bounds = tick_item.boundingRect()
+        tick_item.setPos(box_rect.x() + (size - tick_bounds.width()) / 2,
+                         box_rect.y() + (size - tick_bounds.height()) / 2)
+        tick_item.setVisible(False)
+        self.scene.addItem(tick_item)
+
+        self._checkbox_rects.append((box_rect, row))
+        self._checkbox_items[row] = (box_item, tick_item)
+
+    def _add_status_badges(self, row, result, tile_x, tile_y):
+        """Add flag/comment indicator badges at the tile's top-right corner."""
+        aoi_data = result.get('aoi_data') or {}
+
+        flag_item = QGraphicsTextItem("⚑")
+        flag_item.setDefaultTextColor(QColor(255, 82, 82))
+        flag_font = QFont("Arial", 13)
+        flag_font.setBold(True)
+        flag_item.setFont(flag_font)
+        flag_item.setPos(tile_x + self.thumbnail_size - 28, tile_y + 2)
+        flag_item.setVisible(bool(aoi_data.get('flagged')))
+        self.scene.addItem(flag_item)
+
+        comment_item = QGraphicsTextItem("\U0001F5E8")
+        comment_item.setDefaultTextColor(QColor(255, 214, 0))
+        comment_item.setFont(QFont("Arial", 11))
+        comment_item.setPos(tile_x + self.thumbnail_size - 28, tile_y + 24)
+        comment_item.setVisible(bool(aoi_data.get('user_comment')))
+        self.scene.addItem(comment_item)
+
+        self._badge_items[row] = (flag_item, comment_item)
+
+    def refresh_status_badges(self, results=None):
+        """Update flag/comment badges from the (live) result AOI dicts."""
+        results = results if results is not None else self._results
+        for row, (flag_item, comment_item) in self._badge_items.items():
+            if row < len(results):
+                aoi_data = results[row].get('aoi_data') or {}
+                flag_item.setVisible(bool(aoi_data.get('flagged')))
+                comment_item.setVisible(bool(aoi_data.get('user_comment')))
+
+    def toggle_row_checked(self, row):
+        """Toggle the checkbox state of a row."""
+        self.set_row_checked(row, row not in self._checked_rows)
+
+    def set_row_checked(self, row, checked):
+        """Set the checkbox state of a row (no-op for rows without a checkbox)."""
+        if row not in self._checkbox_items:
+            return
+        if checked:
+            self._checked_rows.add(row)
+        else:
+            self._checked_rows.discard(row)
+
+        box_item, tick_item = self._checkbox_items[row]
+        tick_item.setVisible(checked)
+        box_item.setPen(QPen(QColor(0, 230, 0) if checked else QColor(255, 255, 255), 2))
+        self.selection_changed.emit(len(self._checked_rows))
+
+    def set_all_checked(self, checked):
+        """Check or uncheck every checkable row."""
+        for row in self._checkbox_items:
+            if checked:
+                self._checked_rows.add(row)
+            else:
+                self._checked_rows.discard(row)
+            box_item, tick_item = self._checkbox_items[row]
+            tick_item.setVisible(checked)
+            box_item.setPen(QPen(QColor(0, 230, 0) if checked else QColor(255, 255, 255), 2))
+        self.selection_changed.emit(len(self._checked_rows))
+
+    def get_checked_rows(self):
+        """Return the checked rows in ascending order."""
+        return sorted(self._checked_rows)
+
+    @staticmethod
+    def _similarity_color(similarity):
+        """Color-code a similarity score (matches AOI confidence color conventions)."""
+        if similarity >= 75:
+            return QColor(76, 175, 80)    # Green (#4CAF50)
+        if similarity >= 50:
+            return QColor(255, 215, 0)    # Gold (#FFD700)
+        return QColor(170, 170, 170)      # Gray
+
+    def wheelEvent(self, event: QWheelEvent):
+        """Handle mouse wheel for zooming."""
+        zoom_factor = 1.15
+        if event.angleDelta().y() > 0:
+            self._zoom *= zoom_factor
+            self.scale(zoom_factor, zoom_factor)
+        else:
+            if self._zoom > self._min_zoom:
+                self._zoom /= zoom_factor
+                self.scale(1 / zoom_factor, 1 / zoom_factor)
+        event.accept()
+
+    def mousePressEvent(self, event: QMouseEvent):
+        """Handle mouse press for panning and clicking."""
+        if event.button() == Qt.RightButton:
+            self._panning = True
+            self._pan_start = event.position()
+            self.setCursor(Qt.ClosedHandCursor)
+            event.accept()
+        elif event.button() == Qt.LeftButton:
+            scene_pos = self.mapToScene(event.pos())
+            # Checkboxes take priority over tile navigation
+            for rect, row in self._checkbox_rects:
+                if rect.contains(scene_pos):
+                    self.toggle_row_checked(row)
+                    event.accept()
+                    return
+            for rect, row in self._thumbnail_rects:
+                if rect.contains(scene_pos):
+                    self.select_thumbnail(row)
+                    self.thumbnail_clicked.emit(row)
+                    event.accept()
+                    return
+            super().mousePressEvent(event)
+        else:
+            super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event: QMouseEvent):
+        """Handle mouse release."""
+        if event.button() == Qt.RightButton:
+            self._panning = False
+            self.setCursor(Qt.ArrowCursor)
+            event.accept()
+        else:
+            super().mouseReleaseEvent(event)
+
+    def mouseMoveEvent(self, event: QMouseEvent):
+        """Handle mouse move for panning."""
+        if self._panning:
+            delta = event.position() - self._pan_start
+            self._pan_start = event.position()
+            self.horizontalScrollBar().setValue(
+                self.horizontalScrollBar().value() - int(delta.x())
+            )
+            self.verticalScrollBar().setValue(
+                self.verticalScrollBar().value() - int(delta.y())
+            )
+            event.accept()
+        else:
+            super().mouseMoveEvent(event)
+
+    def reset_view(self):
+        """Reset zoom and fit all thumbnails in view."""
+        self._zoom = 1.0
+        self.resetTransform()
+        if self.scene.sceneRect().width() > 0:
+            self.fitInView(self.scene.sceneRect(), Qt.KeepAspectRatio)
+
+    def select_thumbnail(self, row):
+        """
+        Update selection highlighting to the specified result row.
+
+        Args:
+            row (int): Result row to select.
+        """
+        self._selected_row = row
+
+        for item_row, border_rect, is_reference in self._border_items:
+            if item_row == row:
+                border_rect.setPen(QPen(QColor(0, 200, 0), self.reference_highlight_width))
+            elif is_reference:
+                border_rect.setPen(QPen(QColor(0, 150, 0), 3))
+            else:
+                border_rect.setPen(QPen(QColor(100, 100, 100), 2))
+
+
+class AOISimilarityResultsDialog(TranslationMixin, QDialog):
+    """
+    Dialog for displaying AOIs ranked by visual similarity to a reference AOI.
+
+    Shows the reference AOI followed by the top matches; clicking a thumbnail
+    emits result_clicked with its row so the controller can navigate to it.
+    """
+
+    result_clicked = Signal(int)          # Emits the result row when the user clicks a thumbnail
+    bulk_flag_requested = Signal(list, bool)  # (checked rows, desired flag state)
+    bulk_comment_requested = Signal(list)     # (checked rows)
+
+    def __init__(self, parent=None, results=None, total_candidates=0):
+        """
+        Initialize the similarity results dialog.
+
+        Args:
+            parent: Parent widget (usually the Viewer)
+            results (list): Result dicts; row 0 is the reference entry.
+            total_candidates (int): Total number of AOIs that were ranked.
+        """
+        super().__init__(parent)
+        self.logger = LoggerService()
+        self.results = results or []
+        self.total_candidates = total_candidates
+        self._thumbnails_loaded = False
+
+        self.setWindowTitle(self.tr("Similar AOIs"))
+        self.setModal(False)  # Non-modal so user can interact with main window
+        self.setWindowFlags(self.windowFlags() | Qt.WindowStaysOnTopHint)
+
+        self._setup_ui()
+        self._apply_translations()
+
+        # Set initial size (thumbnails loaded in showEvent when viewport is ready)
+        self.resize(900, 430)
+
+    def showEvent(self, event):
+        """Load thumbnails when dialog is shown (viewport is ready)."""
+        super().showEvent(event)
+        if not self._thumbnails_loaded and self.results:
+            self._thumbnails_loaded = True
+            # Small delay to ensure the viewport is fully initialized
+            QTimer.singleShot(10, lambda: self.gallery_view.load_thumbnails(self.results))
+
+    def _setup_ui(self):
+        """Create the dialog UI components."""
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(10, 10, 10, 10)
+        main_layout.setSpacing(10)
+
+        # Info label
+        shown = max(0, len(self.results) - 1)  # Exclude the reference tile
+        reference_label = self._reference_label()
+        info_text = self.tr(
+            "Top {shown} of {total} AOIs ranked by similarity to {reference}. "
+            "Use mouse wheel to zoom, right-click drag to pan. "
+            "Click a thumbnail to jump to that AOI."
+        ).format(shown=shown, total=self.total_candidates, reference=reference_label)
+        self.info_label = QLabel(info_text)
+        self.info_label.setWordWrap(True)
+        self.info_label.setStyleSheet("QLabel { color: #aaa; padding: 5px; }")
+        main_layout.addWidget(self.info_label)
+
+        # Gallery view
+        self.gallery_view = SimilarityGalleryView(self)
+        self.gallery_view.setMinimumHeight(280)
+        self.gallery_view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.gallery_view.thumbnail_clicked.connect(self._on_thumbnail_clicked)
+        self.gallery_view.selection_changed.connect(self._on_selection_changed)
+        main_layout.addWidget(self.gallery_view)
+
+        # Selection / bulk-action bar
+        selection_layout = QHBoxLayout()
+        selection_layout.setSpacing(10)
+
+        self.select_all_button = QPushButton(self.tr("Select All"))
+        self.select_all_button.clicked.connect(lambda: self.gallery_view.set_all_checked(True))
+        selection_layout.addWidget(self.select_all_button)
+
+        self.select_none_button = QPushButton(self.tr("Clear Selection"))
+        self.select_none_button.clicked.connect(lambda: self.gallery_view.set_all_checked(False))
+        selection_layout.addWidget(self.select_none_button)
+
+        self.selection_label = QLabel(self.tr("{count} selected").format(count=0))
+        self.selection_label.setStyleSheet("QLabel { color: #aaa; padding: 0 8px; }")
+        selection_layout.addWidget(self.selection_label)
+
+        selection_layout.addStretch()
+
+        self.flag_button = QPushButton(self.tr("Flag"))
+        self.flag_button.setToolTip(self.tr("Flag all checked AOIs"))
+        self.flag_button.setEnabled(False)
+        self.flag_button.clicked.connect(lambda: self._emit_bulk_flag(True))
+        selection_layout.addWidget(self.flag_button)
+
+        self.unflag_button = QPushButton(self.tr("Unflag"))
+        self.unflag_button.setToolTip(self.tr("Remove the flag from all checked AOIs"))
+        self.unflag_button.setEnabled(False)
+        self.unflag_button.clicked.connect(lambda: self._emit_bulk_flag(False))
+        selection_layout.addWidget(self.unflag_button)
+
+        self.comment_button = QPushButton(self.tr("Comment..."))
+        self.comment_button.setToolTip(self.tr("Add or edit the comment on all checked AOIs"))
+        self.comment_button.setEnabled(False)
+        self.comment_button.clicked.connect(self._emit_bulk_comment)
+        selection_layout.addWidget(self.comment_button)
+
+        main_layout.addLayout(selection_layout)
+
+        # Button layout
+        button_layout = QHBoxLayout()
+        button_layout.setSpacing(10)
+
+        reset_button = QPushButton(self.tr("Reset View"))
+        reset_button.setMinimumHeight(35)
+        reset_button.clicked.connect(self.gallery_view.reset_view)
+        reset_button.setToolTip(self.tr("Reset zoom and fit all thumbnails in view"))
+        button_layout.addWidget(reset_button)
+
+        button_layout.addStretch()
+
+        close_button = QPushButton(self.tr("Close"))
+        close_button.setMinimumHeight(35)
+        close_button.clicked.connect(self.close)
+        button_layout.addWidget(close_button)
+
+        main_layout.addLayout(button_layout)
+        self.setLayout(main_layout)
+
+    def _on_selection_changed(self, count):
+        """Update the selection label and bulk-action button states."""
+        self.selection_label.setText(self.tr("{count} selected").format(count=count))
+        has_selection = count > 0
+        self.flag_button.setEnabled(has_selection)
+        self.unflag_button.setEnabled(has_selection)
+        self.comment_button.setEnabled(has_selection)
+
+    def _emit_bulk_flag(self, flagged):
+        rows = self.gallery_view.get_checked_rows()
+        if rows:
+            self.bulk_flag_requested.emit(rows, flagged)
+
+    def _emit_bulk_comment(self):
+        rows = self.gallery_view.get_checked_rows()
+        if rows:
+            self.bulk_comment_requested.emit(rows)
+
+    def refresh_status_badges(self):
+        """Refresh flag/comment badges from the live result AOI dicts."""
+        self.gallery_view.refresh_status_badges(self.results)
+
+    def _reference_label(self):
+        """Human-readable label for the reference AOI (row 0 of results)."""
+        if self.results:
+            number = self.results[0].get('aoi_number')
+            if number is not None:
+                return self.tr("AOI #{number}").format(number=number)
+        return self.tr("the selected AOI")
+
+    def _on_thumbnail_clicked(self, row):
+        """
+        Handle thumbnail click.
+
+        Args:
+            row (int): Result row of the clicked thumbnail.
+        """
+        self.result_clicked.emit(row)
+
+    def keyPressEvent(self, event):
+        """Handle keyboard shortcuts."""
+        if event.key() == Qt.Key_Escape:
+            self.close()
+            event.accept()
+        elif event.key() == Qt.Key_R:
+            self.gallery_view.reset_view()
+            event.accept()
+        else:
+            super().keyPressEvent(event)

--- a/app/core/views/images/viewer/dialogs/HelpDialog.py
+++ b/app/core/views/images/viewer/dialogs/HelpDialog.py
@@ -242,6 +242,10 @@ class HelpDialog(TranslationMixin, QDialog):
                         <td>Track selected AOI across neighboring images (shows where AOI appears in flight path)</td>
                     </tr>
                     <tr>
+                        <td>Shift + Z</td>
+                        <td>Find visually similar AOIs (ranks all other AOIs by color/size similarity to the selected AOI)</td>
+                    </tr>
+                    <tr>
                         <td>Shift + O</td>
                         <td>Override altitude for all images (manually set custom
                             AGL altitude for GSD calculations)</td>
@@ -482,6 +486,12 @@ class HelpDialog(TranslationMixin, QDialog):
                     <li>Press <b>R</b> to view images oriented to true north based on drone heading</li>
                     <li>Press <b>Z</b> to track a selected AOI across neighboring images
                         - useful for verifying if a detection appears in multiple overlapping shots</li>
+                    <li>Press <b>Shift+Z</b> (or right-click an AOI thumbnail and choose
+                        <b>Find Similar AOIs</b>) to rank all other AOIs by visual similarity
+                        - useful for finding other detections of the same object or material</li>
+                    <li>In the similar-AOI results, <b>check thumbnails</b> to select them, then
+                        use <b>Flag</b>, <b>Unflag</b>, or <b>Comment</b> to update all checked
+                        AOIs at once</li>
                 </ul>
             </div>
 

--- a/app/tests/core/controllers/images/viewer/aoi/test_aoi_controller.py
+++ b/app/tests/core/controllers/images/viewer/aoi/test_aoi_controller.py
@@ -482,3 +482,140 @@ def test_go_to_aoi_number_single_image_rebuilds_stale_map(controller):
     assert controller.go_to_aoi_number(1) is True
     controller.ui_component.refresh_aoi_display.assert_called_once()
     controller.select_aoi.assert_called_once_with(0, 0)
+
+
+# ---------------------------------------------------------------------------
+# show_aoi_context_menu — Find Similar AOIs action
+# ---------------------------------------------------------------------------
+
+def _open_context_menu(controller, aoi_index, image_idx):
+    """Open the AOI context menu with QMenu mocked; returns the added action mocks.
+
+    Shiboken methods cannot be monkeypatched on the class, so the whole QMenu
+    class is replaced in the controller module and the action mocks inspected.
+    """
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtCore import QPoint
+    QApplication.instance() or QApplication([])
+
+    actions = {}
+
+    def make_action(text):
+        action = MagicMock()
+        actions[text] = action
+        return action
+
+    with patch("core.controllers.images.viewer.aoi.AOIController.QMenu") as menu_cls:
+        menu_cls.return_value.addAction.side_effect = make_action
+        controller.show_aoi_context_menu(
+            QPoint(0, 0), MagicMock(), (10, 10), 100, None,
+            aoi_index=aoi_index, image_idx=image_idx,
+        )
+    menu_cls.return_value.exec.assert_called_once()
+    return actions
+
+
+def test_context_menu_find_similar_triggers_controller(controller):
+    actions = _open_context_menu(controller, aoi_index=0, image_idx=1)
+
+    assert "Find Similar AOIs" in actions
+    action = actions["Find Similar AOIs"]
+    action.setEnabled.assert_called_once_with(True)
+
+    triggered_handler = action.triggered.connect.call_args[0][0]
+    triggered_handler()
+    controller.parent.similarity_controller.find_similar_for_selected.assert_called_once_with(
+        image_idx=1, aoi_idx=0)
+
+
+def test_context_menu_find_similar_disabled_without_index(controller):
+    actions = _open_context_menu(controller, aoi_index=None, image_idx=None)
+
+    actions["Find Similar AOIs"].setEnabled.assert_called_once_with(False)
+
+
+# ---------------------------------------------------------------------------
+# Bulk flag / comment setters
+# ---------------------------------------------------------------------------
+
+def _bulk_parent():
+    """Parent mock with two images, real AOI dicts, and XML elements attached."""
+    import xml.etree.ElementTree as ET
+    parent = _mock_parent(images=[
+        {"areas_of_interest": [
+            _aoi(center=(10, 10), xml=ET.Element("area_of_interest")),
+            _aoi(center=(20, 20), xml=ET.Element("area_of_interest")),
+        ]},
+        {"areas_of_interest": [
+            _aoi(center=(30, 30), xml=ET.Element("area_of_interest")),
+        ]},
+    ])
+    parent.xml_path = "results.xml"
+    parent.xml_service = MagicMock()
+    parent.gallery_controller = MagicMock()
+    return parent
+
+
+@pytest.fixture
+def bulk_controller():
+    with patch("core.controllers.images.viewer.aoi.AOIController.AOIUIComponent"):
+        from core.controllers.images.viewer.aoi.AOIController import AOIController
+        return AOIController(_bulk_parent())
+
+
+def test_set_aoi_flags_bulk_flags_and_saves_once(bulk_controller):
+    applied = bulk_controller.set_aoi_flags_bulk([(0, 0), (0, 1), (1, 0), (9, 9)], True)
+
+    assert applied == 3
+    images = bulk_controller.parent.images
+    assert images[0]["areas_of_interest"][0]["flagged"] is True
+    assert images[0]["areas_of_interest"][1]["flagged"] is True
+    assert images[1]["areas_of_interest"][0]["flagged"] is True
+    assert images[0]["areas_of_interest"][0]["xml"].get("flagged") == "True"
+    assert bulk_controller.flagged_aois == {0: {0, 1}, 1: {0}}
+    bulk_controller.parent.xml_service.save_xml_file.assert_called_once_with("results.xml")
+    bulk_controller.parent.gallery_controller.refresh_gallery.assert_called_once()
+    # Current image (0) was touched -> single-image display refreshed
+    bulk_controller.ui_component.refresh_aoi_display.assert_called_once()
+
+
+def test_set_aoi_flags_bulk_unflag(bulk_controller):
+    bulk_controller.set_aoi_flags_bulk([(0, 0), (1, 0)], True)
+    bulk_controller.parent.xml_service.reset_mock()
+
+    applied = bulk_controller.set_aoi_flags_bulk([(0, 0), (1, 0)], False)
+
+    assert applied == 2
+    images = bulk_controller.parent.images
+    assert images[0]["areas_of_interest"][0]["flagged"] is False
+    assert images[0]["areas_of_interest"][0]["xml"].get("flagged") == "False"
+    assert bulk_controller.flagged_aois == {0: set(), 1: set()}
+    bulk_controller.parent.xml_service.save_xml_file.assert_called_once()
+
+
+def test_set_aoi_flags_bulk_empty_and_invalid(bulk_controller):
+    assert bulk_controller.set_aoi_flags_bulk([], True) == 0
+    assert bulk_controller.set_aoi_flags_bulk([(9, 9), (None, 0)], True) == 0
+    bulk_controller.parent.xml_service.save_xml_file.assert_not_called()
+
+
+def test_set_aoi_comments_bulk_sets_text(bulk_controller):
+    applied = bulk_controller.set_aoi_comments_bulk([(0, 0), (1, 0)], "orange tarp")
+
+    assert applied == 2
+    images = bulk_controller.parent.images
+    assert images[0]["areas_of_interest"][0]["user_comment"] == "orange tarp"
+    assert images[1]["areas_of_interest"][0]["user_comment"] == "orange tarp"
+    assert images[0]["areas_of_interest"][0]["xml"].get("user_comment") == "orange tarp"
+    bulk_controller.parent.xml_service.save_xml_file.assert_called_once_with("results.xml")
+
+
+def test_set_aoi_comments_bulk_empty_clears_attribute(bulk_controller):
+    bulk_controller.set_aoi_comments_bulk([(0, 0)], "note")
+    assert bulk_controller.parent.images[0]["areas_of_interest"][0]["xml"].get("user_comment") == "note"
+
+    bulk_controller.set_aoi_comments_bulk([(0, 0)], "")
+
+    aoi = bulk_controller.parent.images[0]["areas_of_interest"][0]
+    assert aoi["user_comment"] == ""
+    assert "user_comment" not in aoi["xml"].attrib

--- a/app/tests/core/controllers/images/viewer/similarity/test_aoi_similarity_controller.py
+++ b/app/tests/core/controllers/images/viewer/similarity/test_aoi_similarity_controller.py
@@ -1,0 +1,392 @@
+"""
+Tests for AOISimilarityController and SimilaritySearchWorker.
+
+Covers worker signal flow (progress/finished/error/cancel), controller AOI
+resolution and guards, result-click navigation routing, and the end-to-end
+QThread plumbing with both a mocked service and a real (failing) one.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from PySide6.QtWidgets import QApplication, QMessageBox, QWidget
+
+from core.controllers.images.viewer.similarity.AOISimilarityController import (
+    AOISimilarityController,
+    SimilaritySearchWorker,
+)
+
+
+@pytest.fixture(scope='session')
+def app():
+    """Create QApplication for widget tests."""
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def viewer(app, tmp_path, qtbot):
+    """Minimal viewer stand-in: a real QWidget carrying the attributes the controller reads."""
+    widget = QWidget()
+    qtbot.addWidget(widget)
+    widget.images = [
+        {'path': str(tmp_path / 'DJI_0001.JPG'),
+         'areas_of_interest': [{'center': (100, 100), 'radius': 20, 'area': 400, 'number': 1}]},
+        {'path': str(tmp_path / 'DJI_0002.JPG'),
+         'areas_of_interest': [{'center': (200, 200), 'radius': 30, 'area': 600, 'number': 2}]},
+    ]
+    widget.current_image = 0
+    widget.xml_path = str(tmp_path / 'ADIAT_Data.xml')
+    widget.aoi_controller = MagicMock()
+    widget.gallery_controller = MagicMock()
+    widget.gallery_mode = False
+    return widget
+
+
+@pytest.fixture
+def controller(viewer):
+    return AOISimilarityController(viewer)
+
+
+# ---------------------------------------------------------------------------
+# SimilaritySearchWorker
+# ---------------------------------------------------------------------------
+
+class TestSimilaritySearchWorker:
+
+    def test_run_emits_progress_then_finished(self, app):
+        service = MagicMock()
+
+        def fake_find_similar(**kwargs):
+            kwargs['progress_callback'](100, 200)
+            return [{'image_idx': 1, 'aoi_idx': 0, 'similarity': 90}]
+
+        service.find_similar.side_effect = fake_find_similar
+        worker = SimilaritySearchWorker(service, images=[], ref_image_idx=0, ref_aoi_idx=0)
+
+        progress, finished = [], []
+        worker.progress.connect(lambda done, total: progress.append((done, total)))
+        worker.finished.connect(finished.append)
+        worker.run()
+
+        assert progress == [(100, 200)]
+        assert finished == [[{'image_idx': 1, 'aoi_idx': 0, 'similarity': 90}]]
+
+    def test_cancel_before_run_skips_service(self, app):
+        service = MagicMock()
+        worker = SimilaritySearchWorker(service, images=[], ref_image_idx=0, ref_aoi_idx=0)
+        finished = []
+        worker.finished.connect(finished.append)
+
+        worker.cancel()
+        worker.run()
+
+        assert finished == [[]]
+        service.find_similar.assert_not_called()
+
+    def test_cancel_check_reflects_cancellation(self, app):
+        service = MagicMock()
+        worker = SimilaritySearchWorker(service, images=[], ref_image_idx=0, ref_aoi_idx=0)
+
+        def fake_find_similar(**kwargs):
+            assert kwargs['cancel_check']() is False
+            worker.cancel()
+            assert kwargs['cancel_check']() is True
+            return []
+
+        service.find_similar.side_effect = fake_find_similar
+        finished = []
+        worker.finished.connect(finished.append)
+        worker.run()
+        assert finished == [[]]
+
+    def test_service_exception_emits_error(self, app):
+        service = MagicMock()
+        service.find_similar.side_effect = ValueError("no thumbnail")
+        worker = SimilaritySearchWorker(service, images=[], ref_image_idx=0, ref_aoi_idx=0)
+
+        errors = []
+        worker.error.connect(errors.append)
+        worker.run()
+
+        assert errors == ["no thumbnail"]
+
+
+# ---------------------------------------------------------------------------
+# Controller: guards and AOI resolution
+# ---------------------------------------------------------------------------
+
+class TestControllerGuards:
+
+    def test_initialization(self, controller, viewer):
+        assert controller.parent is viewer
+        assert controller._similarity_service is None
+        assert controller._thread is None
+
+    def test_service_without_thumbnail_dir(self, controller):
+        service = controller._get_service()
+        assert service.thumbnail_cache.dataset_cache_dir is None
+
+    def test_service_with_thumbnail_dir(self, viewer, tmp_path):
+        (tmp_path / '.thumbnails').mkdir()
+        controller = AOISimilarityController(viewer)
+        service = controller._get_service()
+        assert str(service.thumbnail_cache.dataset_cache_dir) == str(tmp_path / '.thumbnails')
+
+    def test_no_selection_shows_message(self, controller, viewer, monkeypatch):
+        info = MagicMock()
+        monkeypatch.setattr(QMessageBox, 'information', info)
+        viewer.aoi_controller.get_selected_aoi.return_value = None
+
+        controller.find_similar_for_selected()
+
+        info.assert_called_once()
+        assert controller._thread is None
+
+    def test_reentrancy_guard(self, controller):
+        controller._thread = object()  # Simulate a running search
+        controller.find_similar_for_selected(image_idx=0, aoi_idx=0)
+        assert controller.progress_dialog is None
+        controller._thread = None
+
+    def test_invalid_image_index_ignored(self, controller):
+        controller.find_similar_for_selected(image_idx=99, aoi_idx=0)
+        assert controller._thread is None
+
+    def test_invalid_aoi_index_ignored(self, controller):
+        controller.find_similar_for_selected(image_idx=0, aoi_idx=99)
+        assert controller._thread is None
+
+
+# ---------------------------------------------------------------------------
+# Controller: completion handling
+# ---------------------------------------------------------------------------
+
+class TestControllerCompletion:
+
+    def test_empty_results_shows_info(self, controller, monkeypatch):
+        info = MagicMock()
+        monkeypatch.setattr(QMessageBox, 'information', info)
+        controller._cancelled = False
+        controller._on_search_complete([])
+        info.assert_called_once()
+
+    def test_cancelled_completion_is_silent(self, controller, monkeypatch):
+        info = MagicMock()
+        monkeypatch.setattr(QMessageBox, 'information', info)
+        controller._cancelled = True
+        controller._on_search_complete([])
+        info.assert_not_called()
+
+    def test_reference_entry_prepended(self, controller, viewer, monkeypatch):
+        fake_service = MagicMock()
+        reference_entry = {'image_idx': 0, 'aoi_idx': 0, 'is_reference': True, 'similarity': 100}
+        fake_service.build_reference_entry.return_value = reference_entry
+        controller._similarity_service = fake_service
+        controller._ref_indices = (0, 0)
+        controller._cancelled = False
+
+        shown = MagicMock()
+        monkeypatch.setattr(controller, '_show_results_dialog', shown)
+
+        results = [{'image_idx': 1, 'aoi_idx': 0, 'similarity': 88, 'is_reference': False}]
+        emitted = []
+        controller.search_completed.connect(emitted.append)
+        controller._on_search_complete(results)
+
+        shown.assert_called_once()
+        display = shown.call_args[0][0]
+        assert display[0] is reference_entry
+        assert display[1:] == results
+        assert emitted == [results]
+
+    def test_cancel_stops_worker_and_thread(self, controller):
+        worker = MagicMock()
+        thread = MagicMock()
+        controller._worker = worker
+        controller._thread = thread
+
+        controller._on_cancelled()
+
+        worker.cancel.assert_called_once()
+        thread.quit.assert_called_once()
+        thread.wait.assert_called_once()
+        assert controller._thread is None
+        assert controller._worker is None
+        assert controller._cancelled is True
+
+    def test_show_results_dialog_and_cleanup(self, controller):
+        results = [
+            {'image_idx': 0, 'aoi_idx': 0, 'image_name': 'a.jpg', 'aoi_number': 1,
+             'similarity': 100, 'thumbnail': None, 'is_reference': True},
+            {'image_idx': 1, 'aoi_idx': 0, 'image_name': 'b.jpg', 'aoi_number': 2,
+             'similarity': 70, 'thumbnail': None, 'is_reference': False},
+        ]
+        controller._total_candidates = 1
+        controller._show_results_dialog(results)
+        assert controller._results_dialog is not None
+        assert controller._current_results == results
+
+        controller.cleanup()
+        assert controller._results_dialog is None
+
+
+# ---------------------------------------------------------------------------
+# Controller: result-click navigation
+# ---------------------------------------------------------------------------
+
+class TestResultNavigation:
+
+    @pytest.fixture
+    def controller_with_results(self, controller, viewer):
+        aoi_data = viewer.images[1]['areas_of_interest'][0]
+        controller._current_results = [
+            {'image_idx': 0, 'aoi_idx': 0, 'aoi_data': viewer.images[0]['areas_of_interest'][0],
+             'is_reference': True},
+            {'image_idx': 1, 'aoi_idx': 0, 'aoi_data': aoi_data, 'is_reference': False},
+        ]
+        return controller
+
+    def test_gallery_mode_uses_go_to_aoi(self, controller_with_results, viewer):
+        viewer.gallery_mode = True
+        viewer.gallery_controller.go_to_aoi.return_value = True
+
+        controller_with_results._on_result_clicked(1)
+
+        viewer.gallery_controller.go_to_aoi.assert_called_once_with(1, 0)
+        viewer.gallery_controller.on_aoi_clicked.assert_not_called()
+
+    def test_gallery_mode_falls_back_when_filtered_out(self, controller_with_results, viewer):
+        viewer.gallery_mode = True
+        viewer.gallery_controller.go_to_aoi.return_value = False
+
+        controller_with_results._on_result_clicked(1)
+
+        viewer.gallery_controller.on_aoi_clicked.assert_called_once_with(
+            1, 0, viewer.images[1]['areas_of_interest'][0])
+
+    def test_single_image_mode_uses_on_aoi_clicked(self, controller_with_results, viewer):
+        viewer.gallery_mode = False
+
+        controller_with_results._on_result_clicked(1)
+
+        viewer.gallery_controller.go_to_aoi.assert_not_called()
+        viewer.gallery_controller.on_aoi_clicked.assert_called_once()
+
+    def test_out_of_range_row_ignored(self, controller_with_results, viewer):
+        controller_with_results._on_result_clicked(99)
+        viewer.gallery_controller.go_to_aoi.assert_not_called()
+        viewer.gallery_controller.on_aoi_clicked.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end thread plumbing
+# ---------------------------------------------------------------------------
+
+class TestThreadedFlows:
+
+    def test_success_flow_with_mocked_service(self, controller, viewer, qtbot, monkeypatch):
+        fake_service = MagicMock()
+        results = [{'image_idx': 1, 'aoi_idx': 0, 'similarity': 88, 'is_reference': False,
+                    'aoi_data': viewer.images[1]['areas_of_interest'][0]}]
+        fake_service.find_similar.return_value = results
+        reference_entry = {'image_idx': 0, 'aoi_idx': 0, 'similarity': 100, 'is_reference': True}
+        fake_service.build_reference_entry.return_value = reference_entry
+        controller._similarity_service = fake_service
+
+        shown = MagicMock()
+        monkeypatch.setattr(controller, '_show_results_dialog', shown)
+
+        with qtbot.waitSignal(controller.search_completed, timeout=5000):
+            controller.find_similar_for_selected(image_idx=0, aoi_idx=0)
+
+        shown.assert_called_once()
+        assert shown.call_args[0][0] == [reference_entry] + results
+        assert controller._thread is None
+        assert controller.progress_dialog is None
+
+    def test_error_flow_with_real_service(self, controller, qtbot, monkeypatch):
+        """Nonexistent images and no thumbnail cache -> the reference AOI cannot be
+        analyzed -> worker error -> warning dialog and search_error signal."""
+        warning = MagicMock()
+        monkeypatch.setattr(QMessageBox, 'warning', warning)
+
+        with qtbot.waitSignal(controller.search_error, timeout=5000):
+            controller.find_similar_for_selected(image_idx=0, aoi_idx=0)
+
+        warning.assert_called_once()
+        assert controller._thread is None
+        assert controller.progress_dialog is None
+
+
+# ---------------------------------------------------------------------------
+# Bulk actions
+# ---------------------------------------------------------------------------
+
+class TestBulkActions:
+
+    @pytest.fixture
+    def controller_with_results(self, controller, viewer):
+        controller._current_results = [
+            {'image_idx': 0, 'aoi_idx': 0, 'is_reference': True,
+             'aoi_data': viewer.images[0]['areas_of_interest'][0]},
+            {'image_idx': 1, 'aoi_idx': 0, 'is_reference': False,
+             'aoi_data': viewer.images[1]['areas_of_interest'][0]},
+        ]
+        controller._results_dialog = MagicMock()
+        return controller
+
+    def test_entries_for_rows_drops_out_of_range(self, controller_with_results):
+        entries = controller_with_results._entries_for_rows([0, 1, 99, -1])
+        assert len(entries) == 2
+        assert [entry['image_idx'] for entry in entries] == [0, 1]
+
+    def test_bulk_flag_applies_and_refreshes(self, controller_with_results, viewer):
+        viewer.status_controller = MagicMock()
+        viewer.aoi_controller.set_aoi_flags_bulk.return_value = 2
+
+        controller_with_results._on_bulk_flag([0, 1], True)
+
+        viewer.aoi_controller.set_aoi_flags_bulk.assert_called_once_with(
+            [(0, 0), (1, 0)], True)
+        controller_with_results._results_dialog.refresh_status_badges.assert_called_once()
+        viewer.status_controller.show_toast.assert_called_once()
+
+    def test_bulk_unflag(self, controller_with_results, viewer):
+        viewer.aoi_controller.set_aoi_flags_bulk.return_value = 2
+
+        controller_with_results._on_bulk_flag([0, 1], False)
+
+        viewer.aoi_controller.set_aoi_flags_bulk.assert_called_once_with(
+            [(0, 0), (1, 0)], False)
+
+    def test_bulk_flag_no_valid_rows_is_noop(self, controller_with_results, viewer):
+        controller_with_results._on_bulk_flag([99], True)
+        viewer.aoi_controller.set_aoi_flags_bulk.assert_not_called()
+
+    def test_bulk_comment_applies_text(self, controller_with_results, viewer):
+        viewer.aoi_controller.set_aoi_comments_bulk.return_value = 2
+
+        with patch('core.views.images.viewer.dialogs.AOICommentDialog.AOICommentDialog') as dialog_cls:
+            dialog_cls.return_value.exec.return_value = True
+            dialog_cls.return_value.get_comment.return_value = 'orange tarp'
+            controller_with_results._on_bulk_comment([0, 1])
+
+        viewer.aoi_controller.set_aoi_comments_bulk.assert_called_once_with(
+            [(0, 0), (1, 0)], 'orange tarp')
+        controller_with_results._results_dialog.refresh_status_badges.assert_called_once()
+
+    def test_bulk_comment_prefills_common_comment(self, controller_with_results, viewer):
+        for result in controller_with_results._current_results:
+            result['aoi_data']['user_comment'] = 'same note'
+
+        with patch('core.views.images.viewer.dialogs.AOICommentDialog.AOICommentDialog') as dialog_cls:
+            dialog_cls.return_value.exec.return_value = False
+            controller_with_results._on_bulk_comment([0, 1])
+
+        assert dialog_cls.call_args[0][1] == 'same note'
+
+    def test_bulk_comment_cancel_applies_nothing(self, controller_with_results, viewer):
+        with patch('core.views.images.viewer.dialogs.AOICommentDialog.AOICommentDialog') as dialog_cls:
+            dialog_cls.return_value.exec.return_value = False
+            controller_with_results._on_bulk_comment([0, 1])
+
+        viewer.aoi_controller.set_aoi_comments_bulk.assert_not_called()

--- a/app/tests/core/services/image/test_aoi_similarity_service.py
+++ b/app/tests/core/services/image/test_aoi_similarity_service.py
@@ -1,0 +1,379 @@
+"""
+Tests for AOISimilarityService.
+
+Covers the circular mask geometry, descriptor determinism, chromatic gating,
+the blended distance regimes, and the find_similar ranking pipeline against
+real cached thumbnail JPEGs in a temporary .thumbnails directory.
+"""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from core.services.image.AOISimilarityService import (
+    AOISimilarityService,
+    MIXED_PENALTY,
+    THUMB_SIZE,
+)
+
+RED = (255, 0, 0)
+ORANGE = (255, 165, 0)
+BLUE = (0, 0, 255)
+GRAY = (128, 128, 128)
+
+
+def solid_crop(rgb):
+    """Create a solid-color 180x180 RGB crop."""
+    return np.full((THUMB_SIZE, THUMB_SIZE, 3), rgb, dtype=np.uint8)
+
+
+def split_crop(rgb_left, rgb_right, right_fraction):
+    """Create a crop with a vertical split: right_fraction of columns get rgb_right."""
+    crop = np.full((THUMB_SIZE, THUMB_SIZE, 3), rgb_left, dtype=np.uint8)
+    split_col = int(THUMB_SIZE * (1.0 - right_fraction))
+    crop[:, split_col:] = rgb_right
+    return crop
+
+
+def make_aoi(center=(200, 200), radius=50, area=1000, number=None):
+    aoi = {'center': center, 'radius': radius, 'area': area}
+    if number is not None:
+        aoi['number'] = number
+    return aoi
+
+
+@pytest.fixture
+def service(tmp_path):
+    """Service backed by a temporary per-dataset thumbnail cache directory."""
+    cache_dir = tmp_path / '.thumbnails'
+    return AOISimilarityService(dataset_thumbnail_dir=str(cache_dir))
+
+
+def seed_thumbnail(service, image_path, aoi, crop):
+    """Write a crop into the service's thumbnail disk cache under the portable key."""
+    key = service.thumbnail_cache.get_cache_key(image_path, aoi)
+    assert service.thumbnail_cache.save_thumbnail_to_disk(
+        key, crop, service.thumbnail_cache.dataset_cache_dir)
+
+
+def build_dataset(service, tmp_path, crops_by_name):
+    """Build viewer-style image dicts with one AOI each and seeded cached thumbnails."""
+    images = []
+    for i, (name, crop) in enumerate(crops_by_name):
+        path = str(tmp_path / name)
+        aoi = make_aoi(number=i + 1)
+        if crop is not None:
+            seed_thumbnail(service, path, aoi, crop)
+        images.append({'path': path, 'areas_of_interest': [aoi]})
+    return images
+
+
+# ---------------------------------------------------------------------------
+# Circular mask
+# ---------------------------------------------------------------------------
+
+class TestCircleMask:
+
+    def test_mask_radius_formula(self, service):
+        # radius=50 -> 90 * 50/60 = 75 px in thumbnail coordinates
+        mask = service.build_circle_mask(50)
+        assert mask[90, 90 + 74] == 255
+        assert mask[90, 90 + 76] == 0
+
+    def test_mask_radius_small_aoi(self, service):
+        # radius=3 -> round(90 * 3/13) = 21
+        mask = service.build_circle_mask(3)
+        assert mask[90, 90 + 20] == 255
+        assert mask[90, 90 + 22] == 0
+
+    def test_mask_radius_clamped_to_tile(self, service):
+        # Huge radius asymptotically approaches 90; clamped to 88
+        mask = service.build_circle_mask(100000)
+        assert mask[90, 90 + 87] == 255
+        assert mask[90, 90 + 89] == 0
+
+    def test_mask_excludes_corners(self, service):
+        mask = service.build_circle_mask(100000)
+        assert mask[0, 0] == 0
+        assert mask[0, THUMB_SIZE - 1] == 0
+        assert mask[THUMB_SIZE - 1, 0] == 0
+        assert mask[THUMB_SIZE - 1, THUMB_SIZE - 1] == 0
+
+
+# ---------------------------------------------------------------------------
+# Descriptor computation
+# ---------------------------------------------------------------------------
+
+class TestComputeDescriptor:
+
+    def test_deterministic(self, service):
+        crop = split_crop(RED, ORANGE, 0.3)
+        aoi = make_aoi()
+        d1 = service.compute_descriptor(crop, aoi)
+        d2 = service.compute_descriptor(crop, aoi)
+        assert np.array_equal(d1.hs_hist, d2.hs_hist)
+        assert np.array_equal(d1.v_hist, d2.v_hist)
+        assert d1.mean_s == d2.mean_s
+        assert d1.mean_v == d2.mean_v
+        assert d1.area == d2.area
+
+    def test_gray_crop_is_achromatic(self, service):
+        descriptor = service.compute_descriptor(solid_crop(GRAY), make_aoi())
+        assert descriptor is not None
+        assert descriptor.hs_hist is None
+        assert not descriptor.is_chromatic
+
+    def test_red_crop_is_chromatic(self, service):
+        descriptor = service.compute_descriptor(solid_crop(RED), make_aoi())
+        assert descriptor.is_chromatic
+        assert descriptor.hs_hist is not None
+        assert descriptor.chromatic_fraction > 0.99
+        # L1-normalized
+        assert descriptor.hs_hist.sum() == pytest.approx(1.0, abs=1e-5)
+        assert descriptor.v_hist.sum() == pytest.approx(1.0, abs=1e-5)
+
+    def test_mask_excludes_background_corners(self, service):
+        """A red disc on green background scores the same as pure red."""
+        import cv2
+        green_corners = solid_crop((0, 255, 0))
+        # Paint the AOI circle red exactly where the mask samples (radius 50 -> 75px)
+        cv2.circle(green_corners, (90, 90), 75, RED, -1)
+        aoi = make_aoi(radius=50)
+        d_disc = service.compute_descriptor(green_corners, aoi)
+        d_red = service.compute_descriptor(solid_crop(RED), aoi)
+        assert service.compare(d_disc, d_red) == pytest.approx(0.0, abs=0.01)
+
+    def test_none_crop_returns_none(self, service):
+        assert service.compute_descriptor(None, make_aoi()) is None
+
+    def test_grayscale_2d_crop_handled(self, service):
+        crop = np.full((THUMB_SIZE, THUMB_SIZE), 128, dtype=np.uint8)
+        descriptor = service.compute_descriptor(crop, make_aoi())
+        assert descriptor is not None
+        assert not descriptor.is_chromatic
+
+    def test_area_fallback_when_missing(self, service):
+        aoi = {'center': (200, 200), 'radius': 50}
+        descriptor = service.compute_descriptor(solid_crop(RED), aoi)
+        assert descriptor.area == pytest.approx(np.pi * 50 ** 2, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Distance / compare
+# ---------------------------------------------------------------------------
+
+class TestCompare:
+
+    def test_identical_chromatic_is_zero(self, service):
+        d = service.compute_descriptor(solid_crop(RED), make_aoi())
+        assert service.compare(d, d) == pytest.approx(0.0, abs=1e-4)
+
+    def test_red_vs_blue_is_high(self, service):
+        aoi = make_aoi()
+        d_red = service.compute_descriptor(solid_crop(RED), aoi)
+        d_blue = service.compute_descriptor(solid_crop(BLUE), aoi)
+        assert service.compare(d_red, d_blue) > 0.5
+
+    def test_partial_hue_overlap_ranks_between(self, service):
+        aoi = make_aoi()
+        d_red = service.compute_descriptor(solid_crop(RED), aoi)
+        d_mostly_red = service.compute_descriptor(split_crop(RED, ORANGE, 0.3), aoi)
+        d_blue = service.compute_descriptor(solid_crop(BLUE), aoi)
+        assert (service.compare(d_red, d_mostly_red)
+                < service.compare(d_red, d_blue))
+
+    def test_achromatic_brightness_ordering(self, service):
+        aoi = make_aoi()
+        d_gray = service.compute_descriptor(solid_crop(GRAY), aoi)
+        d_gray_close = service.compute_descriptor(solid_crop((140, 140, 140)), aoi)
+        d_white = service.compute_descriptor(solid_crop((250, 250, 250)), aoi)
+        assert (service.compare(d_gray, d_gray_close)
+                < service.compare(d_gray, d_white))
+
+    def test_mixed_regime_has_floor(self, service):
+        aoi = make_aoi()
+        d_red = service.compute_descriptor(solid_crop(RED), aoi)
+        d_gray = service.compute_descriptor(solid_crop(GRAY), aoi)
+        assert service.compare(d_red, d_gray) >= MIXED_PENALTY
+
+    def test_area_log_ratio_monotonic(self, service):
+        crop = solid_crop(RED)
+        d_100 = service.compute_descriptor(crop, make_aoi(area=100))
+        d_200 = service.compute_descriptor(crop, make_aoi(area=200))
+        d_400 = service.compute_descriptor(crop, make_aoi(area=400))
+        assert service.compare(d_100, d_200) < service.compare(d_100, d_400)
+
+    def test_area_ratio_saturates(self, service):
+        crop = solid_crop(RED)
+        d_small = service.compute_descriptor(crop, make_aoi(area=100))
+        d_big = service.compute_descriptor(crop, make_aoi(area=100 * 20))
+        d_bigger = service.compute_descriptor(crop, make_aoi(area=100 * 200))
+        assert service.compare(d_small, d_big) == pytest.approx(
+            service.compare(d_small, d_bigger), abs=1e-6)
+
+    def test_symmetry(self, service):
+        aoi = make_aoi()
+        d_a = service.compute_descriptor(split_crop(RED, ORANGE, 0.3), aoi)
+        d_b = service.compute_descriptor(solid_crop(BLUE), make_aoi(area=5000))
+        assert service.compare(d_a, d_b) == pytest.approx(service.compare(d_b, d_a), abs=1e-6)
+
+    def test_bounds(self, service):
+        descriptors = [
+            service.compute_descriptor(solid_crop(c), make_aoi(area=a))
+            for c, a in [(RED, 1), (BLUE, 10 ** 6), (GRAY, 500), ((250, 250, 250), 3)]
+        ]
+        for d_a in descriptors:
+            for d_b in descriptors:
+                assert 0.0 <= service.compare(d_a, d_b) <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# find_similar pipeline
+# ---------------------------------------------------------------------------
+
+class TestFindSimilar:
+
+    def test_ranking_order(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            ('DJI_0001.JPG', solid_crop(RED)),            # reference
+            ('DJI_0002.JPG', solid_crop(GRAY)),
+            ('DJI_0003.JPG', solid_crop(RED)),            # clone -> best match
+            ('DJI_0004.JPG', solid_crop(BLUE)),
+            ('DJI_0005.JPG', split_crop(RED, ORANGE, 0.3)),  # mostly red -> second
+        ])
+        results = service.find_similar(images, 0, 0)
+
+        names = [r['image_name'] for r in results]
+        assert names[0] == 'DJI_0003.JPG'
+        assert names[1] == 'DJI_0005.JPG'
+        similarities = [r['similarity'] for r in results]
+        assert similarities == sorted(similarities, reverse=True)
+        assert all(isinstance(s, int) and 0 <= s <= 100 for s in similarities)
+        # Blue (chromatic) outranks gray (mixed-regime penalty)
+        assert names.index('DJI_0004.JPG') < names.index('DJI_0002.JPG')
+
+    def test_reference_excluded_and_fields_present(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            ('DJI_0001.JPG', solid_crop(RED)),
+            ('DJI_0002.JPG', solid_crop(RED)),
+        ])
+        results = service.find_similar(images, 0, 0)
+        assert len(results) == 1
+        result = results[0]
+        assert (result['image_idx'], result['aoi_idx']) == (1, 0)
+        for key in ('image_name', 'image_path', 'aoi_number', 'center', 'area',
+                    'similarity', 'thumbnail', 'aoi_data', 'is_reference'):
+            assert key in result
+        assert result['is_reference'] is False
+        assert result['thumbnail'].shape == (THUMB_SIZE, THUMB_SIZE, 3)
+
+    def test_max_results_honored(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            (f'DJI_{i:04d}.JPG', solid_crop(RED)) for i in range(6)
+        ])
+        results = service.find_similar(images, 0, 0, max_results=2)
+        assert len(results) == 2
+
+    def test_deterministic_tie_order(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            ('DJI_0001.JPG', solid_crop(RED)),
+            ('DJI_0002.JPG', solid_crop(RED)),
+            ('DJI_0003.JPG', solid_crop(RED)),
+            ('DJI_0004.JPG', solid_crop(RED)),
+        ])
+        results = service.find_similar(images, 0, 0)
+        assert [r['image_idx'] for r in results] == [1, 2, 3]
+
+    def test_unreadable_image_skipped(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            ('DJI_0001.JPG', solid_crop(RED)),
+            ('DJI_0002.JPG', solid_crop(RED)),
+            ('missing.JPG', None),  # no cached thumbnail, no source file
+        ])
+        results = service.find_similar(images, 0, 0)
+        assert len(results) == 1
+        assert results[0]['image_name'] == 'DJI_0002.JPG'
+
+    def test_unanalyzable_reference_raises(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            ('missing.JPG', None),
+            ('DJI_0002.JPG', solid_crop(RED)),
+        ])
+        with pytest.raises(ValueError):
+            service.find_similar(images, 0, 0)
+
+    def test_invalid_reference_index_raises(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [('DJI_0001.JPG', solid_crop(RED))])
+        with pytest.raises(ValueError):
+            service.find_similar(images, 5, 0)
+
+    def test_cancel_returns_empty(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            ('DJI_0001.JPG', solid_crop(RED)),
+            ('DJI_0002.JPG', solid_crop(RED)),
+        ])
+        assert service.find_similar(images, 0, 0, cancel_check=lambda: True) == []
+
+    def test_progress_callback_reports_total(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [
+            (f'DJI_{i:04d}.JPG', solid_crop(RED)) for i in range(4)
+        ])
+        calls = []
+        service.find_similar(images, 0, 0, progress_callback=lambda d, t: calls.append((d, t)))
+        assert calls[-1] == (3, 3)
+
+    def test_descriptor_cache_prevents_recompute(self, service, tmp_path, monkeypatch):
+        images = build_dataset(service, tmp_path, [
+            ('DJI_0001.JPG', solid_crop(RED)),
+            ('DJI_0002.JPG', solid_crop(BLUE)),
+        ])
+        calls = {'n': 0}
+        original = service.compute_descriptor
+
+        def counting(crop, aoi_data):
+            calls['n'] += 1
+            return original(crop, aoi_data)
+
+        monkeypatch.setattr(service, 'compute_descriptor', counting)
+        service.find_similar(images, 0, 0)
+        first_pass = calls['n']
+        assert first_pass == 2
+        service.find_similar(images, 0, 0)
+        assert calls['n'] == first_pass
+
+    def test_build_reference_entry(self, service, tmp_path):
+        images = build_dataset(service, tmp_path, [('DJI_0001.JPG', solid_crop(RED))])
+        entry = service.build_reference_entry(images, 0, 0)
+        assert entry['is_reference'] is True
+        assert entry['similarity'] == 100
+        assert entry['image_idx'] == 0
+        assert entry['thumbnail'] is not None
+
+
+# ---------------------------------------------------------------------------
+# Crop acquisition fallback
+# ---------------------------------------------------------------------------
+
+class TestCropFallback:
+
+    def test_fallback_extracts_and_self_heals_cache(self, service, tmp_path):
+        """With no cached thumbnail, the crop comes from the source image and is
+        written back to the dataset cache."""
+        source_path = tmp_path / 'DJI_0100.JPG'
+        Image.fromarray(np.full((400, 400, 3), RED, dtype=np.uint8)).save(source_path, 'JPEG')
+        aoi = make_aoi(center=(200, 200), radius=50)
+
+        crop = service.get_crop(str(source_path), aoi)
+        assert crop is not None
+        assert crop.shape == (THUMB_SIZE, THUMB_SIZE, 3)
+
+        key = service.thumbnail_cache.get_cache_key(str(source_path), aoi)
+        cached = service.thumbnail_cache.dataset_cache_dir / f'{key}.jpg'
+        assert cached.exists()
+
+        descriptor = service.compute_descriptor(crop, aoi)
+        assert descriptor.is_chromatic
+
+    def test_get_crop_missing_everything_returns_none(self, service, tmp_path):
+        crop = service.get_crop(str(tmp_path / 'nope.JPG'), make_aoi())
+        assert crop is None

--- a/app/tests/core/views/images/viewer/dialogs/test_aoi_similarity_results_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_aoi_similarity_results_dialog.py
@@ -1,0 +1,372 @@
+"""
+Tests for AOISimilarityResultsDialog.
+
+Covers dialog initialization, thumbnail loading (including reference styling and
+None-thumbnail tolerance), click-to-row signal propagation, and keyboard shortcuts.
+"""
+
+from core.views.images.viewer.dialogs.AOISimilarityResultsDialog import (
+    AOISimilarityResultsDialog,
+    SimilarityGalleryView,
+)
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import Qt, qInstallMessageHandler
+import os
+import pytest
+import numpy as np
+
+# Suppress Qt QPainter warnings in headless test environment
+os.environ.setdefault('QT_LOGGING_RULES', '*.debug=false;qt.qpa.*=false')
+
+
+def _qt_message_handler(mode, context, message):
+    """Filter out QPainter warnings that occur in headless test environments."""
+    if 'QPainter' in message:
+        return
+    print(message)
+
+
+qInstallMessageHandler(_qt_message_handler)
+
+
+@pytest.fixture(scope='session')
+def app():
+    """Create QApplication for widget tests."""
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def sample_thumbnail():
+    """Create a sample thumbnail image."""
+    return np.random.randint(0, 255, (180, 180, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def sample_results(sample_thumbnail):
+    """Create sample similarity results: reference first, then two matches."""
+    return [
+        {
+            'image_idx': 1,
+            'aoi_idx': 0,
+            'image_name': 'DJI_0002.JPG',
+            'image_path': '/path/to/DJI_0002.JPG',
+            'aoi_number': 12,
+            'similarity': 100,
+            'thumbnail': sample_thumbnail.copy(),
+            'aoi_data': {'center': (100, 100), 'radius': 40},
+            'is_reference': True,
+        },
+        {
+            'image_idx': 0,
+            'aoi_idx': 2,
+            'image_name': 'DJI_0001.JPG',
+            'image_path': '/path/to/DJI_0001.JPG',
+            'aoi_number': 3,
+            'similarity': 82,
+            'thumbnail': sample_thumbnail.copy(),
+            'aoi_data': {'center': (300, 200), 'radius': 30},
+            'is_reference': False,
+        },
+        {
+            'image_idx': 2,
+            'aoi_idx': 1,
+            'image_name': 'DJI_0003.JPG',
+            'image_path': '/path/to/DJI_0003.JPG',
+            'aoi_number': None,  # Exercises the index fallback caption
+            'similarity': 47,
+            'thumbnail': sample_thumbnail.copy(),
+            'aoi_data': {'center': (50, 60), 'radius': 25},
+            'is_reference': False,
+        },
+    ]
+
+
+class TestSimilarityGalleryView:
+
+    def test_initialization(self, app):
+        view = SimilarityGalleryView()
+        assert view.scene is not None
+        assert view._zoom == 1.0
+        assert view._thumbnail_rects == []
+        assert view._selected_row == -1
+
+    def test_load_thumbnails_empty_and_none(self, app):
+        view = SimilarityGalleryView()
+        view.load_thumbnails([])
+        assert view._thumbnail_rects == []
+        view.load_thumbnails(None)
+        assert view._thumbnail_rects == []
+
+    def test_load_thumbnails_success(self, app, sample_results):
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+        assert len(view._thumbnail_rects) == 3
+        assert len(view._border_items) == 3
+        # Rows map to the results-list indices
+        assert [row for _, row in view._thumbnail_rects] == [0, 1, 2]
+
+    def test_reference_row_styled(self, app, sample_results):
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+        reference_items = [item for item in view._border_items if item[2] is True]
+        assert len(reference_items) == 1
+        assert reference_items[0][0] == 0  # Row 0 is the reference
+
+    def test_none_thumbnail_skipped_but_rows_stay_aligned(self, app, sample_results):
+        sample_results[1]['thumbnail'] = None
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+        # Row 1 is skipped; remaining tiles keep their original row keys
+        assert [row for _, row in view._thumbnail_rects] == [0, 2]
+
+    def test_select_thumbnail(self, app, sample_results):
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+        view.select_thumbnail(2)
+        assert view._selected_row == 2
+
+    def test_similarity_color_thresholds(self, app):
+        green = SimilarityGalleryView._similarity_color(80)
+        gold = SimilarityGalleryView._similarity_color(60)
+        gray = SimilarityGalleryView._similarity_color(30)
+        assert green.name() == '#4caf50'
+        assert gold.name() == '#ffd700'
+        assert gray.name() == '#aaaaaa'
+
+    def test_grayscale_thumbnail_supported(self, app):
+        results = [{
+            'image_idx': 0, 'aoi_idx': 0, 'image_name': 'thermal.JPG',
+            'similarity': 90, 'is_reference': False,
+            'thumbnail': np.random.randint(0, 255, (180, 180), dtype=np.uint8),
+        }]
+        view = SimilarityGalleryView()
+        view.load_thumbnails(results)
+        assert len(view._thumbnail_rects) == 1
+
+
+class TestAOISimilarityResultsDialog:
+
+    def test_initialization(self, app, sample_results):
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=57)
+        assert dialog.results == sample_results
+        assert dialog.windowTitle() == "Similar AOIs"
+        assert not dialog.isModal()
+        assert dialog.windowFlags() & Qt.WindowStaysOnTopHint
+        assert dialog.width() == 900
+        assert dialog.height() == 430
+
+    def test_initialization_no_results(self, app):
+        dialog = AOISimilarityResultsDialog(None, None)
+        assert dialog.results == []
+
+    def test_info_label_counts(self, app, sample_results):
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=57)
+        text = dialog.info_label.text()
+        assert "Top 2 of 57" in text
+        assert "AOI #12" in text  # Reference AOI number
+
+    def test_result_clicked_signal(self, app, sample_results):
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=2)
+        clicked_rows = []
+        dialog.result_clicked.connect(clicked_rows.append)
+
+        dialog.gallery_view.thumbnail_clicked.emit(1)
+        assert clicked_rows == [1]
+
+    def test_click_inside_tile_rect_emits_row(self, app, sample_results):
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=2)
+        dialog.show()
+        app.processEvents()
+        import time
+        time.sleep(0.05)  # Wait for the deferred QTimer load (10ms)
+        app.processEvents()
+
+        view = dialog.gallery_view
+        assert len(view._thumbnail_rects) == 3
+
+        clicked_rows = []
+        dialog.result_clicked.connect(clicked_rows.append)
+
+        # Simulate a click on the second tile via its stored rect
+        rect, row = view._thumbnail_rects[1]
+        view.select_thumbnail(row)
+        view.thumbnail_clicked.emit(row)
+
+        assert clicked_rows == [1]
+        assert view._selected_row == 1
+        dialog.close()
+
+    def test_escape_key_closes(self, app, sample_results):
+        from PySide6.QtGui import QKeyEvent
+        from PySide6.QtCore import QEvent
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=2)
+        dialog.show()
+        event = QKeyEvent(QEvent.KeyPress, Qt.Key_Escape, Qt.NoModifier)
+        dialog.keyPressEvent(event)
+        assert event.isAccepted()
+
+    def test_r_key_resets_view(self, app, sample_results):
+        from PySide6.QtGui import QKeyEvent
+        from PySide6.QtCore import QEvent
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=2)
+        dialog.gallery_view._zoom = 3.0
+        event = QKeyEvent(QEvent.KeyPress, Qt.Key_R, Qt.NoModifier)
+        dialog.keyPressEvent(event)
+        assert dialog.gallery_view._zoom == 1.0
+
+    def test_tolerates_none_thumbnails(self, app, sample_results):
+        for result in sample_results:
+            result['thumbnail'] = None
+        dialog = AOISimilarityResultsDialog(None, sample_results, total_candidates=2)
+        dialog.show()
+        app.processEvents()
+        import time
+        time.sleep(0.05)
+        app.processEvents()
+        assert dialog.gallery_view._thumbnail_rects == []
+        dialog.close()
+
+
+# ============================================================================
+# Bulk selection and actions
+# ============================================================================
+
+def _loaded_dialog(app, results, total=2):
+    """Create a dialog and force-load its thumbnails synchronously."""
+    dialog = AOISimilarityResultsDialog(None, results, total_candidates=total)
+    dialog.gallery_view.load_thumbnails(results)
+    return dialog
+
+
+class TestBulkSelection:
+
+    def test_checkboxes_only_on_aoi_rows(self, app, sample_results):
+        # A malformed row without a backing AOI gets no checkbox but still renders
+        sample_results[0]['aoi_idx'] = None
+        sample_results[0]['image_idx'] = None
+        sample_results[0]['aoi_data'] = None
+        sample_results[0]['aoi_number'] = None
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+
+        assert set(view._checkbox_items.keys()) == {1, 2}
+        assert len(view._thumbnail_rects) == 3
+
+    def test_toggle_and_get_checked_rows(self, app, sample_results):
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+
+        counts = []
+        view.selection_changed.connect(counts.append)
+
+        view.toggle_row_checked(1)
+        view.toggle_row_checked(2)
+        assert view.get_checked_rows() == [1, 2]
+        view.toggle_row_checked(1)
+        assert view.get_checked_rows() == [2]
+        assert counts == [1, 2, 1]
+
+    def test_set_row_checked_ignores_uncheckable_rows(self, app, sample_results):
+        sample_results[0]['aoi_idx'] = None
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+
+        view.set_row_checked(0, True)  # No checkbox on row 0
+        assert view.get_checked_rows() == []
+
+    def test_select_all_and_clear(self, app, sample_results):
+        dialog = _loaded_dialog(app, sample_results)
+
+        dialog.gallery_view.set_all_checked(True)
+        assert dialog.gallery_view.get_checked_rows() == [0, 1, 2]
+        assert dialog.flag_button.isEnabled()
+        assert dialog.unflag_button.isEnabled()
+        assert dialog.comment_button.isEnabled()
+        assert "3" in dialog.selection_label.text()
+
+        dialog.gallery_view.set_all_checked(False)
+        assert dialog.gallery_view.get_checked_rows() == []
+        assert not dialog.flag_button.isEnabled()
+        assert not dialog.unflag_button.isEnabled()
+        assert not dialog.comment_button.isEnabled()
+
+    def test_reload_clears_selection(self, app, sample_results):
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+        view.set_all_checked(True)
+        view.load_thumbnails(sample_results)
+        assert view.get_checked_rows() == []
+
+    def test_bulk_flag_signal_carries_checked_rows(self, app, sample_results):
+        dialog = _loaded_dialog(app, sample_results)
+        dialog.gallery_view.set_row_checked(1, True)
+        dialog.gallery_view.set_row_checked(2, True)
+
+        received = []
+        dialog.bulk_flag_requested.connect(lambda rows, flagged: received.append((rows, flagged)))
+        dialog._emit_bulk_flag(True)
+        dialog._emit_bulk_flag(False)
+
+        assert received == [([1, 2], True), ([1, 2], False)]
+
+    def test_bulk_comment_signal_carries_checked_rows(self, app, sample_results):
+        dialog = _loaded_dialog(app, sample_results)
+        dialog.gallery_view.set_row_checked(2, True)
+
+        received = []
+        dialog.bulk_comment_requested.connect(received.append)
+        dialog._emit_bulk_comment()
+
+        assert received == [[2]]
+
+    def test_bulk_signals_not_emitted_without_selection(self, app, sample_results):
+        dialog = _loaded_dialog(app, sample_results)
+        received = []
+        dialog.bulk_flag_requested.connect(lambda rows, flagged: received.append(rows))
+        dialog.bulk_comment_requested.connect(received.append)
+        dialog._emit_bulk_flag(True)
+        dialog._emit_bulk_comment()
+        assert received == []
+
+
+class TestStatusBadges:
+
+    def test_badges_reflect_initial_state(self, app, sample_results):
+        sample_results[1]['aoi_data'] = {'flagged': True, 'user_comment': 'check this'}
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+
+        flag_item, comment_item = view._badge_items[1]
+        assert flag_item.isVisible()
+        assert comment_item.isVisible()
+
+        flag_item0, comment_item0 = view._badge_items[0]
+        assert not flag_item0.isVisible()
+        assert not comment_item0.isVisible()
+
+    def test_refresh_status_badges_after_change(self, app, sample_results):
+        dialog = _loaded_dialog(app, sample_results)
+        flag_item, comment_item = dialog.gallery_view._badge_items[1]
+        assert not flag_item.isVisible()
+
+        # Simulate a bulk action mutating the live AOI dict
+        dialog.results[1]['aoi_data']['flagged'] = True
+        dialog.results[1]['aoi_data']['user_comment'] = 'orange tarp'
+        dialog.refresh_status_badges()
+
+        assert flag_item.isVisible()
+        assert comment_item.isVisible()
+
+    def test_checkbox_hit_takes_priority_over_tile(self, app, sample_results):
+        view = SimilarityGalleryView()
+        view.load_thumbnails(sample_results)
+
+        # A point inside row 0's checkbox is also inside row 0's tile rect
+        box_rect, row = view._checkbox_rects[0]
+        assert any(tile.contains(box_rect.center()) for tile, _ in view._thumbnail_rects)
+
+        clicked = []
+        view.thumbnail_clicked.connect(clicked.append)
+        view.toggle_row_checked(row)
+        assert view.get_checked_rows() == [row]
+        assert clicked == []

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -230,67 +230,72 @@ Permissive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="572"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="665"/>
         <source>Comment saved</source>
         <translation>Comment saved</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="574"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="667"/>
         <source>Comment cleared</source>
         <translation>Comment cleared</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="756"/>
         <source>Copy Data</source>
         <translation>Copy Data</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="764"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="762"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="865"/>
         <source>AOI data copied</source>
         <translation>AOI data copied</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="851"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="952"/>
         <source>Invalid image index</source>
         <translation>Invalid image index</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="856"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="957"/>
         <source>Invalid AOI index</source>
         <translation>Invalid AOI index</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="919"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1020"/>
         <source>Could not calculate AOI location. Diagnostic info copied to clipboard!</source>
         <translation>Could not calculate AOI location. Diagnostic info copied to clipboard!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="925"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1026"/>
         <source>Could not calculate AOI location</source>
         <translation>Could not calculate AOI location</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1380"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1481"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Temperature sorting unavailable (no thermal data)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1732"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1833"/>
         <source>Cannot Delete AOI</source>
         <translation>Cannot Delete AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1734"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1835"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1743"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1844"/>
         <source>Delete AOI</source>
         <translation>Delete AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1745"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1846"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>Are you sure you want to delete this AOI? This action cannot be undone.</translation>
     </message>
@@ -713,6 +718,183 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
 {error}</source>
         <translation>An error occurred while displaying results:
 {error}</translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="134"/>
+        <source>No AOI Selected</source>
+        <translation type="unfinished">No AOI Selected</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="135"/>
+        <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
+        <translation type="unfinished">Please select an AOI first by clicking on it in the thumbnail panel.</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="164"/>
+        <source>Analyzing AOIs for visual similarity...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="165"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="169"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="152"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="246"/>
+        <source>Similarity Search Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="153"/>
+        <source>An error occurred while starting the similarity search:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="200"/>
+        <source>Analyzing AOI {done} of {total}...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="215"/>
+        <source>No Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="216"/>
+        <source>No other AOIs could be analyzed for similarity.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="247"/>
+        <source>The similarity search could not be completed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="314"/>
+        <source>Display Error</source>
+        <translation type="unfinished">Display Error</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="315"/>
+        <source>An error occurred while displaying results:
+{error}</source>
+        <translation type="unfinished">An error occurred while displaying results:
+{error}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="367"/>
+        <source>Flagged {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="370"/>
+        <source>Removed flag from {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="402"/>
+        <source>Comment saved on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="405"/>
+        <source>Comment cleared on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityResultsDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="442"/>
+        <source>Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="470"/>
+        <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="491"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="495"/>
+        <source>Clear Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="499"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="547"/>
+        <source>{count} selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="505"/>
+        <source>Flag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="506"/>
+        <source>Flag all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="511"/>
+        <source>Unflag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="512"/>
+        <source>Remove the flag from all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="517"/>
+        <source>Comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="518"/>
+        <source>Add or edit the comment on all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="529"/>
+        <source>Reset View</source>
+        <translation type="unfinished">Reset View</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="532"/>
+        <source>Reset zoom and fit all thumbnails in view</source>
+        <translation type="unfinished">Reset zoom and fit all thumbnails in view</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="537"/>
+        <source>Close</source>
+        <translation type="unfinished">Close</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="572"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="573"/>
+        <source>the selected AOI</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2142,39 +2324,6 @@ The items should now be visible on your map.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>Select CalTopo Map</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Select a CalTopo map to export flagged AOIs:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Search:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Filter maps by name...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Select Map</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Cancel</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3333,55 +3482,44 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Select Color from List</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Search:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filter by name or uses…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Uses</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Use Color</translation>
@@ -3390,13 +3528,11 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Select Color from Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Use Color</translation>
@@ -3405,29 +3541,22 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Load Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Color Selector</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Select Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3435,37 +3564,31 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>Could not load image: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Error loading image: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Error setting image: {error}</translation>
@@ -8970,89 +9093,6 @@ then click again to place the second point.</translation>
     </message>
 </context>
 <context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Detection Mode</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Mode:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Auto</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Static Camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Moving Camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algorithm</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algorithm:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Frame Difference</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>MOG2 Background</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>KNN Background</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Optical Flow</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Feature Matching</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Detection Parameters</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Sensitivity: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Min Area:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Max Area:</translation>
-    </message>
-</context>
-<context>
     <name>PDFExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="151"/>
@@ -10155,42 +10195,42 @@ Aggressive</source>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</translation>
     </message>
@@ -10198,22 +10238,22 @@ Aggressive</source>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Recent Colors</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Select a recently used color:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>No recent colors found</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -10645,6 +10685,29 @@ You can change it later in Preferences or by clicking the reviewer name in the v
         <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="51"/>
         <source>Scanning for Results</source>
         <translation>Scanning for Results</translation>
+    </message>
+</context>
+<context>
+    <name>SimilarityGalleryView</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
+        <source>Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="190"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="192"/>
+        <source>AOI {index}</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11280,14 +11343,6 @@ Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Select Recording Folder</translation>
     </message>
 </context>
 <context>
@@ -13699,29 +13754,6 @@ Shows total frames extracted when complete.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -13753,13 +13785,13 @@ When disabled, shows the original unprocessed image.
 Use to compare original image with detection results.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="437"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="443"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="205"/>
         <source>Show Overlay</source>
         <translation>Show Overlay</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1151"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1188"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -13777,7 +13809,7 @@ Shows all AOIs from all images in a grid view</translation>
         <translation>Show AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1171"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1208"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="299"/>
         <source>Open Histogram</source>
         <translation type="unfinished"></translation>
@@ -13824,7 +13856,7 @@ Shows all AOIs from all images in a grid view</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1900"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14011,32 +14043,32 @@ Sorting helps prioritize review of larger or closer objects.</translation>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="130"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="131"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="143"/>
         <source>Reading result file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="159"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="160"/>
         <source>Checking image dimensions ({n} images)...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="169"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="170"/>
         <source>Validating image paths...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="176"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="177"/>
         <source>Load Results Failed</source>
         <translation>Load Results Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="178"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="179"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -14045,60 +14077,60 @@ The viewer will now close.</source>
 The viewer will now close.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="185"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Scanning source folder for full flight...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="201"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="202"/>
         <source>Initialising controllers...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="213"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1390"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Skip Hidden ({count}) </translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="242"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="244"/>
         <source>Loading detection results from {n} images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="281"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="283"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="313"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="315"/>
         <source>Loading first image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="328"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="330"/>
         <source>Preparing thumbnails...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="602"/>
         <source>No Dataset</source>
         <translation>No Dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="597"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="603"/>
         <source>No dataset is currently loaded.</source>
         <translation>No dataset is currently loaded.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="604"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="610"/>
         <source>Generate Cache</source>
         <translation>Generate Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="606"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="612"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -14111,39 +14143,39 @@ This may take a few minutes depending on the dataset size.
 Continue?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="619"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
         <source>Initializing cache generation...</source>
         <translation>Initializing cache generation...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="620"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="626"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="631"/>
         <source>Generating Cache</source>
         <translation>Generating Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="662"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="668"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="669"/>
         <source>Failed to start cache generation:
 {error}</source>
         <translation>Failed to start cache generation:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="681"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="687"/>
         <source>Cache Generated</source>
         <translation>Cache Generated</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="689"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -14156,12 +14188,12 @@ Processed {images} images with {aois} AOIs.
 The viewer will now load thumbnails and colors much faster.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>Cache Generation Error</source>
         <translation>Cache Generation Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="716"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="722"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -14170,12 +14202,12 @@ The viewer will now load thumbnails and colors much faster.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="896"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="902"/>
         <source>AOI Not Visible</source>
         <translation>AOI Not Visible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="898"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="904"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -14184,68 +14216,68 @@ To select this AOI, please clear or adjust your filters.</source>
 To select this AOI, please clear or adjust your filters.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1069"/>
         <source>Update Image Dimensions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1034"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1071"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1073"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1110"/>
         <source>Reading image dimensions ({done}/{total})...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1199"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Show Pixels of Interest (H or Ctrl+I)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1177"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1214"/>
         <source>Toggle AOI Circles</source>
         <translation>Toggle AOI Circles</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1565"/>
         <source>Missing Dependency</source>
         <translation>Missing Dependency</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1567"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1576"/>
         <source>Upscale Error</source>
         <translation>Upscale Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1578"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>An error occurred while opening the upscale dialog:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1904"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2001"/>
         <source>Unknown Reviewer</source>
         <translation>Unknown Reviewer</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2064"/>
         <source>Loading gallery...</source>
         <translation>Loading gallery...</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -232,67 +232,72 @@ permisivo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="572"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="665"/>
         <source>Comment saved</source>
         <translation>Comentario guardado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="574"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="667"/>
         <source>Comment cleared</source>
         <translation>Comentario borrado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="756"/>
         <source>Copy Data</source>
         <translation>Copiar datos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="764"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="762"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="865"/>
         <source>AOI data copied</source>
         <translation>Datos del AOI copiados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="851"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="952"/>
         <source>Invalid image index</source>
         <translation>Índice de imagen no válido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="856"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="957"/>
         <source>Invalid AOI index</source>
         <translation>Índice de AOI no válido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="919"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1020"/>
         <source>Could not calculate AOI location. Diagnostic info copied to clipboard!</source>
         <translation>No se pudo calcular la ubicación del AOI. ¡Información de diagnóstico copiada al portapapeles!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="925"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1026"/>
         <source>Could not calculate AOI location</source>
         <translation>No se pudo calcular la ubicación del AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1380"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1481"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Ordenación por temperatura no disponible (sin datos térmicos)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1732"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1833"/>
         <source>Cannot Delete AOI</source>
         <translation>No se puede eliminar el AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1734"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1835"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Solo se pueden eliminar los AOI creados manualmente. Los AOI detectados por algoritmo no se pueden eliminar.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1743"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1844"/>
         <source>Delete AOI</source>
         <translation>Eliminar AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1745"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1846"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>¿Está seguro de que desea eliminar este AOI? Esta acción no se puede deshacer.</translation>
     </message>
@@ -715,6 +720,183 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
 {error}</source>
         <translation>Se produjo un error al mostrar los resultados:
 {error}</translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="134"/>
+        <source>No AOI Selected</source>
+        <translation type="unfinished">Ningún AOI seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="135"/>
+        <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
+        <translation type="unfinished">Primero seleccione un AOI haciendo clic sobre él en el panel de miniaturas.</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="164"/>
+        <source>Analyzing AOIs for visual similarity...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="165"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="169"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="152"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="246"/>
+        <source>Similarity Search Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="153"/>
+        <source>An error occurred while starting the similarity search:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="200"/>
+        <source>Analyzing AOI {done} of {total}...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="215"/>
+        <source>No Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="216"/>
+        <source>No other AOIs could be analyzed for similarity.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="247"/>
+        <source>The similarity search could not be completed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="314"/>
+        <source>Display Error</source>
+        <translation type="unfinished">Error de visualización</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="315"/>
+        <source>An error occurred while displaying results:
+{error}</source>
+        <translation type="unfinished">Se produjo un error al mostrar los resultados:
+{error}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="367"/>
+        <source>Flagged {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="370"/>
+        <source>Removed flag from {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="402"/>
+        <source>Comment saved on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="405"/>
+        <source>Comment cleared on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityResultsDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="442"/>
+        <source>Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="470"/>
+        <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="491"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="495"/>
+        <source>Clear Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="499"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="547"/>
+        <source>{count} selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="505"/>
+        <source>Flag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="506"/>
+        <source>Flag all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="511"/>
+        <source>Unflag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="512"/>
+        <source>Remove the flag from all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="517"/>
+        <source>Comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="518"/>
+        <source>Add or edit the comment on all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="529"/>
+        <source>Reset View</source>
+        <translation type="unfinished">Restablecer vista</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="532"/>
+        <source>Reset zoom and fit all thumbnails in view</source>
+        <translation type="unfinished">Restablecer el zoom y ajustar todas las miniaturas a la vista</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="537"/>
+        <source>Close</source>
+        <translation type="unfinished">Cerrar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="572"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="573"/>
+        <source>the selected AOI</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2144,39 +2326,6 @@ Los elementos deberían estar ahora visibles en su mapa.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>Seleccionar mapa de CalTopo</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Seleccione un mapa de CalTopo para exportar los AOI marcados:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Búsqueda:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Filtrar mapas por nombre...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Seleccionar mapa</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3337,55 +3486,44 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Seleccionar color desde lista</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Búsqueda:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filtrar por nombre o usos…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Usos</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Usar color</translation>
@@ -3394,13 +3532,11 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Seleccionar color desde imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Usar color</translation>
@@ -3409,29 +3545,22 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Cargar imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Selector de color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3439,37 +3568,31 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>No se pudo cargar la imagen: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Error al cargar la imagen: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (cursor)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Error al establecer la imagen: {error}</translation>
@@ -9025,89 +9148,6 @@ y luego vuelva a hacer clic para colocar el segundo punto.</translation>
     </message>
 </context>
 <context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Modo de detección</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Modo:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Automático</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Cámara estática</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Cámara en movimiento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algoritmo</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algoritmo:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Diferencia de fotograma</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>Fondo MOG2</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>Fondo KNN</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Flujo óptico</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Coincidencia de características</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Parámetros de detección</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Sensibilidad: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Área mín.:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Área máx.:</translation>
-    </message>
-</context>
-<context>
     <name>PDFExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="151"/>
@@ -10212,42 +10252,42 @@ agresivo</translation>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Umbral:&lt;/b&gt; {value}</translation>
     </message>
@@ -10255,22 +10295,22 @@ agresivo</translation>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Colores recientes</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Seleccione un color usado recientemente:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>No se encontraron colores recientes</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
@@ -10702,6 +10742,29 @@ Puede cambiarlo más tarde en Preferencias o haciendo clic en el nombre del revi
         <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="51"/>
         <source>Scanning for Results</source>
         <translation>Escaneando en busca de resultados</translation>
+    </message>
+</context>
+<context>
+    <name>SimilarityGalleryView</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
+        <source>Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="190"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="192"/>
+        <source>AOI {index}</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11338,14 +11401,6 @@ Formatos compatibles: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Archivos de vídeo (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Todos los archivos (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Seleccionar carpeta de grabación</translation>
     </message>
 </context>
 <context>
@@ -13787,29 +13842,6 @@ Muestra el total de fotogramas extraídos al completarse.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -13841,13 +13873,13 @@ Cuando está deshabilitada, muestra la imagen original sin procesar.
 Úselo para comparar la imagen original con los resultados de detección.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="437"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="443"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="205"/>
         <source>Show Overlay</source>
         <translation>Mostrar superposición</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1151"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1188"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -13865,7 +13897,7 @@ Muestra todos los AOI de todas las imágenes en una vista de cuadrícula</transl
         <translation>Mostrar AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1171"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1208"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="299"/>
         <source>Open Histogram</source>
         <translation>Abrir histograma</translation>
@@ -13912,7 +13944,7 @@ Muestra todos los AOI de todas las imágenes en una vista de cuadrícula</transl
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1900"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14099,32 +14131,32 @@ La ordenación ayuda a priorizar la revisión de objetos más grandes o más cer
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="130"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="131"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Herramienta automatizada de análisis de imágenes de dron v{version} - Patrocinado por TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="143"/>
         <source>Reading result file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="159"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="160"/>
         <source>Checking image dimensions ({n} images)...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="169"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="170"/>
         <source>Validating image paths...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="176"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="177"/>
         <source>Load Results Failed</source>
         <translation>Error al cargar los resultados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="178"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="179"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -14133,60 +14165,60 @@ The viewer will now close.</source>
 El visor se cerrará ahora.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="185"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Scanning source folder for full flight...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="201"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="202"/>
         <source>Initialising controllers...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="213"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1390"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Omitir ocultas ({count}) </translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="242"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="244"/>
         <source>Loading detection results from {n} images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="281"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="283"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Metadatos e información de la imagen.
 Haga clic en las coordenadas GPS para copiar, compartir o abrir en aplicaciones de mapas.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="313"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="315"/>
         <source>Loading first image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="328"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="330"/>
         <source>Preparing thumbnails...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="602"/>
         <source>No Dataset</source>
         <translation>Sin conjunto de datos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="597"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="603"/>
         <source>No dataset is currently loaded.</source>
         <translation>Actualmente no hay ningún conjunto de datos cargado.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="604"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="610"/>
         <source>Generate Cache</source>
         <translation>Generar caché</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="606"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="612"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -14199,39 +14231,39 @@ Esto puede tardar varios minutos según el tamaño del conjunto de datos.
 ¿Continuar?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="619"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
         <source>Initializing cache generation...</source>
         <translation>Inicializando generación de caché...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="620"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="626"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="631"/>
         <source>Generating Cache</source>
         <translation>Generando caché</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="662"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="668"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="669"/>
         <source>Failed to start cache generation:
 {error}</source>
         <translation>Error al iniciar la generación de caché:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="681"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="687"/>
         <source>Cache Generated</source>
         <translation>Caché generada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="689"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -14244,12 +14276,12 @@ Se procesaron {images} imágenes con {aois} AOI.
 El visor cargará ahora miniaturas y colores mucho más rápido.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>Cache Generation Error</source>
         <translation>Error de generación de caché</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="716"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="722"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -14258,12 +14290,12 @@ El visor cargará ahora miniaturas y colores mucho más rápido.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="896"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="902"/>
         <source>AOI Not Visible</source>
         <translation>AOI no visible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="898"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="904"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -14272,12 +14304,12 @@ To select this AOI, please clear or adjust your filters.</source>
 Para seleccionar este AOI, borre o ajuste sus filtros.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1069"/>
         <source>Update Image Dimensions</source>
         <translation>Actualizar dimensiones de imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1034"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1071"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -14286,56 +14318,56 @@ Would you like to read dimensions from the image files and update the results fi
 ¿Desea leer las dimensiones desde los archivos de imagen y actualizar el archivo de resultados?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1073"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1110"/>
         <source>Reading image dimensions ({done}/{total})...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1199"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Mostrar píxeles de interés (H o Ctrl+I)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1177"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1214"/>
         <source>Toggle AOI Circles</source>
         <translation>Alternar círculos de AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1565"/>
         <source>Missing Dependency</source>
         <translation>Dependencia faltante</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1567"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>El módulo qimage2ndarray es necesario para la función de escalado.
 Instálelo usando: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1576"/>
         <source>Upscale Error</source>
         <translation>Error de escalado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1578"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Se produjo un error al abrir el diálogo de escalado:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1904"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2001"/>
         <source>Unknown Reviewer</source>
         <translation>Revisor desconocido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2064"/>
         <source>Loading gallery...</source>
         <translation>Cargando galería...</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -232,67 +232,72 @@ Permissivo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="572"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="665"/>
         <source>Comment saved</source>
         <translation>Commento salvato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="574"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="667"/>
         <source>Comment cleared</source>
         <translation>Commento cancellato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="756"/>
         <source>Copy Data</source>
         <translation>Copia Dati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="764"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="762"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="865"/>
         <source>AOI data copied</source>
         <translation>Dati AOI copiati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="851"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="952"/>
         <source>Invalid image index</source>
         <translation>Indice immagine non valido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="856"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="957"/>
         <source>Invalid AOI index</source>
         <translation>Indice AOI non valido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="919"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1020"/>
         <source>Could not calculate AOI location. Diagnostic info copied to clipboard!</source>
         <translation>Impossibile calcolare la posizione dell&apos;AOI. Informazioni diagnostiche copiate negli appunti!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="925"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1026"/>
         <source>Could not calculate AOI location</source>
         <translation>Impossibile calcolare la posizione dell&apos;AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1380"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1481"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Ordinamento per temperatura non disponibile (nessun dato termico)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1732"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1833"/>
         <source>Cannot Delete AOI</source>
         <translation>Impossibile eliminare l&apos;AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1734"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1835"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Solo le AOI create manualmente possono essere eliminate. Le AOI rilevate dagli algoritmi non possono essere eliminate.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1743"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1844"/>
         <source>Delete AOI</source>
         <translation>Elimina AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1745"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1846"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>Sei sicuro di voler eliminare questa AOI? Questa azione non può essere annullata.</translation>
     </message>
@@ -715,6 +720,183 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
 {error}</source>
         <translation>Si è verificato un errore durante la visualizzazione dei risultati:
 {error}</translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="134"/>
+        <source>No AOI Selected</source>
+        <translation type="unfinished">Nessuna AOI selezionata</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="135"/>
+        <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
+        <translation type="unfinished">Seleziona prima un&apos;AOI cliccandoci sopra nel pannello delle miniature.</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="164"/>
+        <source>Analyzing AOIs for visual similarity...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="165"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annulla</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="169"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="152"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="246"/>
+        <source>Similarity Search Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="153"/>
+        <source>An error occurred while starting the similarity search:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="200"/>
+        <source>Analyzing AOI {done} of {total}...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="215"/>
+        <source>No Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="216"/>
+        <source>No other AOIs could be analyzed for similarity.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="247"/>
+        <source>The similarity search could not be completed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="314"/>
+        <source>Display Error</source>
+        <translation type="unfinished">Errore di visualizzazione</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="315"/>
+        <source>An error occurred while displaying results:
+{error}</source>
+        <translation type="unfinished">Si è verificato un errore durante la visualizzazione dei risultati:
+{error}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="367"/>
+        <source>Flagged {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="370"/>
+        <source>Removed flag from {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="402"/>
+        <source>Comment saved on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="405"/>
+        <source>Comment cleared on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityResultsDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="442"/>
+        <source>Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="470"/>
+        <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="491"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="495"/>
+        <source>Clear Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="499"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="547"/>
+        <source>{count} selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="505"/>
+        <source>Flag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="506"/>
+        <source>Flag all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="511"/>
+        <source>Unflag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="512"/>
+        <source>Remove the flag from all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="517"/>
+        <source>Comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="518"/>
+        <source>Add or edit the comment on all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="529"/>
+        <source>Reset View</source>
+        <translation type="unfinished">Ripristina Vista</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="532"/>
+        <source>Reset zoom and fit all thumbnails in view</source>
+        <translation type="unfinished">Ripristina lo zoom e adatta tutte le miniature alla vista</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="537"/>
+        <source>Close</source>
+        <translation type="unfinished">Chiudi</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="572"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="573"/>
+        <source>the selected AOI</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2144,39 +2326,6 @@ Gli elementi dovrebbero ora essere visibili sulla tua mappa.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>Seleziona Mappa CalTopo</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Seleziona una mappa CalTopo per esportare le AOI contrassegnate:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Cerca:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Filtra mappe per nome...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Seleziona Mappa</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Annulla</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3489,55 +3638,44 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Seleziona Colore dall&apos;Elenco</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Cerca:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filtra per nome o utilizzi…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Utilizzi</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Usa Colore</translation>
@@ -3546,13 +3684,11 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Seleziona Colore dall&apos;Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Usa Colore</translation>
@@ -3561,29 +3697,22 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Carica Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Selettore Colore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Seleziona Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3591,37 +3720,31 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>Impossibile caricare l&apos;immagine: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Errore durante il caricamento dell&apos;immagine: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (passaggio mouse)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Errore durante l&apos;impostazione dell&apos;immagine: {error}</translation>
@@ -9421,89 +9544,6 @@ poi clicca di nuovo per posizionare il secondo punto.</translation>
     </message>
 </context>
 <context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Modalità Rilevamento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Modalità:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Auto</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Telecamera Statica</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Telecamera in Movimento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algoritmo</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algoritmo:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Differenza Frame</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>Sfondo MOG2</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>Sfondo KNN</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Flusso Ottico</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Corrispondenza Caratteristiche</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Parametri Rilevamento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Sensibilità: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Area Min:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Area Max:</translation>
-    </message>
-</context>
-<context>
     <name>PDFExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="151"/>
@@ -10608,42 +10648,42 @@ Aggressivo</translation>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Soglia:&lt;/b&gt; {value}</translation>
     </message>
@@ -10651,22 +10691,22 @@ Aggressivo</translation>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Colori Recenti</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Seleziona un colore usato di recente:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>Nessun colore recente trovato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -11146,6 +11186,29 @@ Puoi cambiarlo più avanti nelle Preferenze o cliccando il nome del revisore nel
         <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="51"/>
         <source>Scanning for Results</source>
         <translation>Scansione dei Risultati</translation>
+    </message>
+</context>
+<context>
+    <name>SimilarityGalleryView</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
+        <source>Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="190"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="192"/>
+        <source>AOI {index}</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11782,14 +11845,6 @@ Formati supportati: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>File Video (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Tutti i File (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Seleziona Cartella Registrazioni</translation>
     </message>
 </context>
 <context>
@@ -14231,29 +14286,6 @@ Mostra il totale dei fotogrammi estratti al termine.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation>Riproduci/Pausa (Spazio)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation>Trascina per navigare nel video</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation>Pausa (Spazio)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation>Riproduci (Spazio)</translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -14285,13 +14317,13 @@ Quando disabilitato, mostra l&apos;immagine originale non elaborata.
 Usa per confrontare l&apos;immagine originale con i risultati del rilevamento.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="437"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="443"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="205"/>
         <source>Show Overlay</source>
         <translation>Mostra Overlay</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1151"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1188"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -14309,7 +14341,7 @@ Mostra tutte le AOI di tutte le immagini in una vista a griglia</translation>
         <translation>Mostra AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1171"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1208"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="299"/>
         <source>Open Histogram</source>
         <translation>Apri Istogramma</translation>
@@ -14356,7 +14388,7 @@ Mostra tutte le AOI di tutte le immagini in una vista a griglia</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1900"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14543,32 +14575,32 @@ L&apos;ordinamento aiuta a dare priorità alla revisione di oggetti più grandi 
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="130"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="131"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Strumento Automatico di Analisi Immagini Drone v{version} - Sponsorizzato da TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="143"/>
         <source>Reading result file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="159"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="160"/>
         <source>Checking image dimensions ({n} images)...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="169"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="170"/>
         <source>Validating image paths...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="176"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="177"/>
         <source>Load Results Failed</source>
         <translation>Caricamento Risultati Non Riuscito</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="178"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="179"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -14577,60 +14609,60 @@ The viewer will now close.</source>
 Il visualizzatore verrà chiuso.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="185"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Scanning source folder for full flight...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="201"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="202"/>
         <source>Initialising controllers...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="213"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1390"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Salta Nascoste ({count}) </translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="242"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="244"/>
         <source>Loading detection results from {n} images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="281"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="283"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Metadati e informazioni dell&apos;immagine.
 Clicca su Coordinate GPS per copiare, condividere o aprire in applicazioni di mappatura.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="313"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="315"/>
         <source>Loading first image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="328"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="330"/>
         <source>Preparing thumbnails...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="602"/>
         <source>No Dataset</source>
         <translation>Nessun Dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="597"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="603"/>
         <source>No dataset is currently loaded.</source>
         <translation>Nessun dataset è attualmente caricato.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="604"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="610"/>
         <source>Generate Cache</source>
         <translation>Genera Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="606"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="612"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -14643,39 +14675,39 @@ Questo potrebbe richiedere alcuni minuti a seconda della dimensione del dataset.
 Continuare?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="619"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
         <source>Initializing cache generation...</source>
         <translation>Inizializzazione generazione cache...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="620"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="626"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="631"/>
         <source>Generating Cache</source>
         <translation>Generazione Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="662"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="668"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="669"/>
         <source>Failed to start cache generation:
 {error}</source>
         <translation>Impossibile avviare la generazione della cache:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="681"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="687"/>
         <source>Cache Generated</source>
         <translation>Cache Generata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="689"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -14688,12 +14720,12 @@ Elaborate {images} immagini con {aois} AOI.
 Il visualizzatore ora caricherà miniature e colori molto più velocemente.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>Cache Generation Error</source>
         <translation>Errore Generazione Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="716"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="722"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -14702,12 +14734,12 @@ Il visualizzatore ora caricherà miniature e colori molto più velocemente.</tra
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="896"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="902"/>
         <source>AOI Not Visible</source>
         <translation>AOI Non Visibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="898"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="904"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -14716,12 +14748,12 @@ To select this AOI, please clear or adjust your filters.</source>
 Per selezionare questa AOI, cancella o regola i tuoi filtri.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1069"/>
         <source>Update Image Dimensions</source>
         <translation>Aggiorna Dimensioni Immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1034"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1071"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -14730,56 +14762,56 @@ Would you like to read dimensions from the image files and update the results fi
 Vuoi leggere le dimensioni dai file immagine e aggiornare il file dei risultati?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1073"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1110"/>
         <source>Reading image dimensions ({done}/{total})...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1199"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Mostra Pixel di Interesse (H o Ctrl+I)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1177"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1214"/>
         <source>Toggle AOI Circles</source>
         <translation>Attiva/disattiva Cerchi AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1565"/>
         <source>Missing Dependency</source>
         <translation>Dipendenza Mancante</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1567"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>Il modulo qimage2ndarray è richiesto per la funzione di upscale.
 Installalo usando: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1576"/>
         <source>Upscale Error</source>
         <translation>Errore di Upscale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1578"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Si è verificato un errore durante l&apos;apertura della finestra di upscale:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1904"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2001"/>
         <source>Unknown Reviewer</source>
         <translation>Revisore Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2064"/>
         <source>Loading gallery...</source>
         <translation>Caricamento galleria...</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -232,67 +232,72 @@ toegeeflijk</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="572"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="665"/>
         <source>Comment saved</source>
         <translation>Opmerking opgeslagen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="574"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="667"/>
         <source>Comment cleared</source>
         <translation>Opmerking gewist</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="756"/>
         <source>Copy Data</source>
         <translation>Gegevens kopiëren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="764"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="762"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="865"/>
         <source>AOI data copied</source>
         <translation>AOI-gegevens gekopieerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="851"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="952"/>
         <source>Invalid image index</source>
         <translation>Ongeldige afbeeldingsindex</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="856"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="957"/>
         <source>Invalid AOI index</source>
         <translation>Ongeldige AOI-index</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="919"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1020"/>
         <source>Could not calculate AOI location. Diagnostic info copied to clipboard!</source>
         <translation>Kan AOI-locatie niet berekenen. Diagnostische informatie naar klembord gekopieerd!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="925"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1026"/>
         <source>Could not calculate AOI location</source>
         <translation>Kan AOI-locatie niet berekenen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1380"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1481"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Sorteren op temperatuur niet beschikbaar (geen thermische gegevens)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1732"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1833"/>
         <source>Cannot Delete AOI</source>
         <translation>Kan AOI niet verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1734"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1835"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Alleen handmatig gemaakte AOI&apos;s kunnen worden verwijderd. Door algoritmen gedetecteerde AOI&apos;s kunnen niet worden verwijderd.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1743"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1844"/>
         <source>Delete AOI</source>
         <translation>AOI verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1745"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1846"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>Weet u zeker dat u deze AOI wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.</translation>
     </message>
@@ -715,6 +720,183 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
 {error}</source>
         <translation>Er is een fout opgetreden bij het weergeven van de resultaten:
 {error}</translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="134"/>
+        <source>No AOI Selected</source>
+        <translation type="unfinished">Geen AOI geselecteerd</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="135"/>
+        <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
+        <translation type="unfinished">Selecteer eerst een AOI door erop te klikken in het miniaturenpaneel.</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="164"/>
+        <source>Analyzing AOIs for visual similarity...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="165"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="169"/>
+        <source>Find Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="152"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="246"/>
+        <source>Similarity Search Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="153"/>
+        <source>An error occurred while starting the similarity search:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="200"/>
+        <source>Analyzing AOI {done} of {total}...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="215"/>
+        <source>No Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="216"/>
+        <source>No other AOIs could be analyzed for similarity.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="247"/>
+        <source>The similarity search could not be completed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="314"/>
+        <source>Display Error</source>
+        <translation type="unfinished">Weergavefout</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="315"/>
+        <source>An error occurred while displaying results:
+{error}</source>
+        <translation type="unfinished">Er is een fout opgetreden bij het weergeven van de resultaten:
+{error}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="367"/>
+        <source>Flagged {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="370"/>
+        <source>Removed flag from {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="402"/>
+        <source>Comment saved on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="405"/>
+        <source>Comment cleared on {count} AOI(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AOISimilarityResultsDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="442"/>
+        <source>Similar AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="470"/>
+        <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="491"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="495"/>
+        <source>Clear Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="499"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="547"/>
+        <source>{count} selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="505"/>
+        <source>Flag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="506"/>
+        <source>Flag all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="511"/>
+        <source>Unflag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="512"/>
+        <source>Remove the flag from all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="517"/>
+        <source>Comment...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="518"/>
+        <source>Add or edit the comment on all checked AOIs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="529"/>
+        <source>Reset View</source>
+        <translation type="unfinished">Weergave resetten</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="532"/>
+        <source>Reset zoom and fit all thumbnails in view</source>
+        <translation type="unfinished">Zoom resetten en alle miniaturen in beeld passen</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="537"/>
+        <source>Close</source>
+        <translation type="unfinished">Sluiten</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="572"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="573"/>
+        <source>the selected AOI</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2144,39 +2326,6 @@ De items moeten nu zichtbaar zijn op uw kaart.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>CalTopo-kaart selecteren</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Selecteer een CalTopo-kaart om gemarkeerde AOI&apos;s te exporteren:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Zoeken:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Kaarten filteren op naam...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Kaart selecteren</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Annuleren</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3489,55 +3638,44 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Kleur uit lijst selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Zoeken:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filter op naam of toepassingen…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Toepassingen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Kleur gebruiken</translation>
@@ -3546,13 +3684,11 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Kleur uit afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Kleur gebruiken</translation>
@@ -3561,29 +3697,22 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Afbeelding laden</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Kleurkiezer</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3591,37 +3720,31 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>Kan afbeelding niet laden: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Fout bij het laden van afbeelding: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (onder cursor)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Fout bij het instellen van afbeelding: {error}</translation>
@@ -9421,89 +9544,6 @@ klik daarna nogmaals om het tweede punt te plaatsen.</translation>
     </message>
 </context>
 <context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Detectiemodus</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Modus:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Automatisch</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Statische camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Bewegende camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algoritme</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algoritme:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Frameverschil</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>MOG2-achtergrond</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>KNN-achtergrond</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Optische stroming</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Kenmerkovereenkomst</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Detectieparameters</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Gevoeligheid: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Min. gebied:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Max. gebied:</translation>
-    </message>
-</context>
-<context>
     <name>PDFExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="151"/>
@@ -10608,42 +10648,42 @@ agressief</translation>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Drempel:&lt;/b&gt; {value}</translation>
     </message>
@@ -10651,22 +10691,22 @@ agressief</translation>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Recente kleuren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Selecteer een recent gebruikte kleur:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>Geen recente kleuren gevonden</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -11146,6 +11186,29 @@ U kunt deze later wijzigen in Voorkeuren of door op de beoordelaarsnaam in de vi
         <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="51"/>
         <source>Scanning for Results</source>
         <translation>Resultaten scannen</translation>
+    </message>
+</context>
+<context>
+    <name>SimilarityGalleryView</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
+        <source>Reference</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="190"/>
+        <source>AOI #{number}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="192"/>
+        <source>AOI {index}</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11782,14 +11845,6 @@ Ondersteunde formaten: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Videobestanden (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Alle bestanden (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Opnamemap selecteren</translation>
     </message>
 </context>
 <context>
@@ -14231,29 +14286,6 @@ Toont het totaal aantal geëxtraheerde frames bij voltooien.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation>Afspelen/pauzeren (spatie)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation>Sleep om door video te zoeken</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation>Pauzeren (spatie)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation>Afspelen (spatie)</translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -14285,13 +14317,13 @@ Indien uitgeschakeld, wordt de originele onbewerkte afbeelding getoond.
 Gebruik om de originele afbeelding met detectieresultaten te vergelijken.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="437"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="443"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="205"/>
         <source>Show Overlay</source>
         <translation>Overlay tonen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1151"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1188"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -14309,7 +14341,7 @@ Toont alle AOI&apos;s van alle afbeeldingen in een rasterweergave</translation>
         <translation>AOI&apos;s tonen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1171"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1208"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="299"/>
         <source>Open Histogram</source>
         <translation>Histogram openen</translation>
@@ -14356,7 +14388,7 @@ Toont alle AOI&apos;s van alle afbeeldingen in een rasterweergave</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1900"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14543,32 +14575,32 @@ Sorteren helpt bij het prioriteren van de beoordeling van grotere of nabije obje
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="130"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="131"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Geautomatiseerd drone-beeldanalyse-instrument v{version} - Gesponsord door TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="143"/>
         <source>Reading result file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="159"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="160"/>
         <source>Checking image dimensions ({n} images)...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="169"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="170"/>
         <source>Validating image paths...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="176"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="177"/>
         <source>Load Results Failed</source>
         <translation>Laden van resultaten mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="178"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="179"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -14577,60 +14609,60 @@ The viewer will now close.</source>
 De viewer wordt nu gesloten.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="185"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Scanning source folder for full flight...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="201"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="202"/>
         <source>Initialising controllers...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="213"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1390"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Verborgen overslaan ({count}) </translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="242"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="244"/>
         <source>Loading detection results from {n} images...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="281"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="283"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Afbeeldingsmetagegevens en -informatie.
 Klik op GPS-coördinaten om te kopiëren, delen of te openen in kaarttoepassingen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="313"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="315"/>
         <source>Loading first image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="328"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="330"/>
         <source>Preparing thumbnails...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="602"/>
         <source>No Dataset</source>
         <translation>Geen dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="597"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="603"/>
         <source>No dataset is currently loaded.</source>
         <translation>Er is momenteel geen dataset geladen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="604"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="610"/>
         <source>Generate Cache</source>
         <translation>Cache genereren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="606"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="612"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -14643,39 +14675,39 @@ Dit kan enkele minuten duren, afhankelijk van de grootte van de dataset.
 Doorgaan?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="619"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
         <source>Initializing cache generation...</source>
         <translation>Cachegeneratie initialiseren...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="620"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="626"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="625"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="631"/>
         <source>Generating Cache</source>
         <translation>Cache genereren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="662"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="668"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="663"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="669"/>
         <source>Failed to start cache generation:
 {error}</source>
         <translation>Kan cachegeneratie niet starten:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="681"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="687"/>
         <source>Cache Generated</source>
         <translation>Cache gegenereerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="689"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -14688,12 +14720,12 @@ The viewer will now load thumbnails and colors much faster.</source>
 De viewer laadt nu miniaturen en kleuren veel sneller.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>Cache Generation Error</source>
         <translation>Fout bij cachegeneratie</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="716"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="722"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -14702,12 +14734,12 @@ De viewer laadt nu miniaturen en kleuren veel sneller.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="896"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="902"/>
         <source>AOI Not Visible</source>
         <translation>AOI niet zichtbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="898"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="904"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -14716,12 +14748,12 @@ To select this AOI, please clear or adjust your filters.</source>
 Wis of pas uw filters aan om deze AOI te selecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1069"/>
         <source>Update Image Dimensions</source>
         <translation>Afbeeldingsafmetingen bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1034"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1071"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -14730,56 +14762,56 @@ Would you like to read dimensions from the image files and update the results fi
 Wilt u de afmetingen uit de afbeeldingsbestanden lezen en het resultatenbestand bijwerken?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1073"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1110"/>
         <source>Reading image dimensions ({done}/{total})...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1199"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Interessepixels tonen (H of Ctrl+I)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1177"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1214"/>
         <source>Toggle AOI Circles</source>
         <translation>AOI-cirkels in-/uitschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1565"/>
         <source>Missing Dependency</source>
         <translation>Ontbrekende afhankelijkheid</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1567"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>De qimage2ndarray-module is vereist voor de opschaalfunctie.
 Installeer deze met: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1576"/>
         <source>Upscale Error</source>
         <translation>Opschaalfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1578"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Er is een fout opgetreden bij het openen van het opschaaldialoogvenster:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1904"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2001"/>
         <source>Unknown Reviewer</source>
         <translation>Onbekende beoordelaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2064"/>
         <source>Loading gallery...</source>
         <translation>Galerij laden...</translation>
     </message>


### PR DESCRIPTION
## Summary

Adds a visual similarity search to the results Viewer: right-click an AOI thumbnail (or press Shift+Z) to rank every other AOI in the dataset by appearance and review the top 40 matches in a gallery dialog.

- **Similarity scoring** is a color-first blend computed from the cached 180x180 AOI thumbnails: an HSV hue/saturation histogram over a circular mask (with a chroma gate so gray pixels never pollute hue) is the dominant signal, blended with a brightness histogram, pixel-area log-ratio, and mean saturation/value stats via Bhattacharyya distances. Grayscale/thermal crops fall back to a brightness-based regime.
- **Bulk triage** in the results dialog: check tiles (Select All / Clear), then Flag, Unflag, or Comment every checked AOI at once. Bulk edits go through new AOIController setters that persist with a single XML save and refresh the single-image list and gallery; tiles show live flag/comment badges.
- Descriptors are cached in memory per Viewer session; **no XML schema changes**.

## Architecture

Follows the existing AOI neighbor-tracking pattern: context menu / shortcut -> AOISimilarityController -> QThread worker -> AOISimilarityService -> results dialog.

## Testing

- 143 targeted tests added (controller, service, results dialog, AOIController bulk setters) - all passing
- flake8 clean over app/
- Translation-ready strings extracted to all four catalogs (en/es/it/nl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
