### PR TITLE
feat: Coverage / Probability-of-Detection (POD) raster module

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr *)",
+      "PowerShell(gh pr view 112 --repo crgrove/ADIAT --json number,title,state,baseRefName,headRefName,headRepositoryOwner,author,mergeable)",
+      "PowerShell($pr = Invoke-RestMethod -Uri \"https://api.github.com/repos/crgrove/ADIAT/pulls/112\" -Headers @{ 'Accept' = 'application/vnd.github+json' }; $pr | Select-Object number, title, state, @{N='base';E={$_.base.ref}}, @{N='head';E={$_.head.label}}, mergeable, mergeable_state | Format-List)",
+      "PowerShell($repo = Invoke-RestMethod -Uri \"https://api.github.com/repos/crgrove/ADIAT\" -Headers @{ 'Accept' = 'application/vnd.github+json' }; $repo | Select-Object name, default_branch, @{N='branches_url';E={$_.branches_url}} | Format-List; $branches = Invoke-RestMethod -Uri \"https://api.github.com/repos/crgrove/ADIAT/branches\" -Headers @{ 'Accept' = 'application/vnd.github+json' }; $branches | Select-Object name | Format-Table)",
+      "PowerShell($results = Invoke-RestMethod -Uri \"https://api.github.com/search/repositories?q=ADIAT+drone\" -Headers @{ 'Accept' = 'application/vnd.github+json' }; $results.items | Select-Object full_name, description, default_branch, html_url | Format-List)",
+      "PowerShell($branches = Invoke-RestMethod -Uri \"https://api.github.com/repos/crgrove/automated-drone-image-analysis-tool/branches\" -Headers @{ 'Accept' = 'application/vnd.github+json' }; $branches | Select-Object name | Format-Table; \"---PR 112---\"; $pr = Invoke-RestMethod -Uri \"https://api.github.com/repos/crgrove/automated-drone-image-analysis-tool/pulls/112\" -Headers @{ 'Accept' = 'application/vnd.github+json' }; $pr | Select-Object number, title, state, @{N='base';E={$_.base.ref}}, @{N='head';E={$_.head.label}}, @{N='head_sha';E={$_.head.sha}}, mergeable, mergeable_state | Format-List)"
+    ]
+  }
+}

--- a/app/core/controllers/Preferences.py
+++ b/app/core/controllers/Preferences.py
@@ -12,6 +12,11 @@ from core.services.terrain import (
     PROVIDER_USGS_3DEP_LOCAL,
     DEFAULT_PROVIDER_ID,
 )
+from core.services.terrain.CanopyServiceFactory import (
+    CanopyServiceFactory,
+    CANOPY_KIND_NONE,
+    DEFAULT_CANOPY_KIND,
+)
 from helpers.PickleHelper import PickleHelper
 from helpers.TranslationMixin import TranslationMixin
 
@@ -47,6 +52,7 @@ class Preferences(TranslationMixin, QDialog, Ui_Preferences):
         self._terrain_service = None
         self._add_language_selection()
         self._add_terrain_provider_section()
+        self._add_canopy_source_section()
         self._load_settings()
         self._connect_signals()
         self._update_terrain_cache_display()
@@ -113,6 +119,54 @@ class Preferences(TranslationMixin, QDialog, Ui_Preferences):
         # Insert near the top of the dialog (just below language selection)
         self.verticalLayout_2.insertWidget(1, self.terrainProviderGroup)
 
+    def _add_canopy_source_section(self):
+        """Add a Canopy/vegetation source group: kind combo + manifest/tiles paths.
+
+        Code-built to match the sibling terrain-provider section (also code-built,
+        not in Preferences.ui); a documented CLAUDE.md 2.6 family exception.
+        """
+        self.canopySourceGroup = QGroupBox(self.tr("Canopy Data Source"), self.mainWidget)
+        layout = QVBoxLayout(self.canopySourceGroup)
+
+        combo_row = QHBoxLayout()
+        combo_label = QLabel(self.tr("Source:"), self.canopySourceGroup)
+        self.canopyKindComboBox = QComboBox(self.canopySourceGroup)
+        for kind in CanopyServiceFactory.available_kinds():
+            self.canopyKindComboBox.addItem(kind['label'], kind['id'])
+        combo_row.addWidget(combo_label)
+        combo_row.addWidget(self.canopyKindComboBox, 1)
+        layout.addLayout(combo_row)
+
+        manifest_row = QHBoxLayout()
+        self.canopyManifestLabel = QLabel(self.tr("Manifest CSV:"), self.canopySourceGroup)
+        self.canopyManifestEdit = QLineEdit(self.canopySourceGroup)
+        self.canopyManifestEdit.setPlaceholderText(self.tr("Path to the canopy manifest CSV"))
+        self.canopyManifestButton = QPushButton(self.tr("Browse..."), self.canopySourceGroup)
+        manifest_row.addWidget(self.canopyManifestLabel)
+        manifest_row.addWidget(self.canopyManifestEdit, 1)
+        manifest_row.addWidget(self.canopyManifestButton)
+        layout.addLayout(manifest_row)
+
+        tiles_row = QHBoxLayout()
+        self.canopyTilesLabel = QLabel(self.tr("Tiles directory:"), self.canopySourceGroup)
+        self.canopyTilesEdit = QLineEdit(self.canopySourceGroup)
+        self.canopyTilesEdit.setPlaceholderText(self.tr("Folder containing the GeoTIFF tiles"))
+        self.canopyTilesButton = QPushButton(self.tr("Browse..."), self.canopySourceGroup)
+        tiles_row.addWidget(self.canopyTilesLabel)
+        tiles_row.addWidget(self.canopyTilesEdit, 1)
+        tiles_row.addWidget(self.canopyTilesButton)
+        layout.addLayout(tiles_row)
+
+        fetch_row = QHBoxLayout()
+        fetch_row.addStretch()
+        self.canopyFetchButton = QPushButton(self.tr("Download tiles..."), self.canopySourceGroup)
+        self.canopyFetchButton.setToolTip(self.tr(
+            "Download DEM and/or canopy tiles for an area of interest and register them here."))
+        fetch_row.addWidget(self.canopyFetchButton)
+        layout.addLayout(fetch_row)
+
+        self.verticalLayout_2.insertWidget(2, self.canopySourceGroup)
+
     def _load_settings(self):
         """Loads the settings from SettingsService and updates the UI accordingly."""
         lang = self.parent.settings_service.get_setting('Language', 'en')
@@ -155,6 +209,15 @@ class Preferences(TranslationMixin, QDialog, Ui_Preferences):
         self.terrain3DEPTilesEdit.setText(tiles_dir)
         self._refresh_terrain_provider_visibility()
 
+        # Canopy source selection + paths
+        canopy_kind = self.parent.settings_service.get_setting('CanopyKind', DEFAULT_CANOPY_KIND) or DEFAULT_CANOPY_KIND
+        cidx = self.canopyKindComboBox.findData(canopy_kind)
+        if cidx >= 0:
+            self.canopyKindComboBox.setCurrentIndex(cidx)
+        self.canopyManifestEdit.setText(self.parent.settings_service.get_setting('CanopyManifestPath', '') or '')
+        self.canopyTilesEdit.setText(self.parent.settings_service.get_setting('CanopyTilesDir', '') or '')
+        self._refresh_canopy_visibility()
+
         drone_sensor_version = PickleHelper.get_drone_sensor_file_version()
         self.dronSensorVersionLabel.setText(
             self.tr("{version}_{date}").format(
@@ -183,6 +246,12 @@ class Preferences(TranslationMixin, QDialog, Ui_Preferences):
         self.terrain3DEPTilesEdit.editingFinished.connect(self._update_terrain_3dep_tiles)
         self.terrain3DEPManifestButton.clicked.connect(self._browse_terrain_3dep_manifest)
         self.terrain3DEPTilesButton.clicked.connect(self._browse_terrain_3dep_tiles)
+        self.canopyKindComboBox.currentIndexChanged.connect(self._update_canopy_kind)
+        self.canopyManifestEdit.editingFinished.connect(self._update_canopy_manifest)
+        self.canopyTilesEdit.editingFinished.connect(self._update_canopy_tiles)
+        self.canopyManifestButton.clicked.connect(self._browse_canopy_manifest)
+        self.canopyTilesButton.clicked.connect(self._browse_canopy_tiles)
+        self.canopyFetchButton.clicked.connect(self._open_tile_fetch_dialog)
         self.droneSensorButton.clicked.connect(self._droneSensorButton_clicked)
 
     def _update_max_aois(self):
@@ -266,6 +335,67 @@ class Preferences(TranslationMixin, QDialog, Ui_Preferences):
         if directory:
             self.terrain3DEPTilesEdit.setText(directory)
             self._update_terrain_3dep_tiles()
+
+    # ---- Canopy source ----
+
+    def _refresh_canopy_visibility(self):
+        """Show/hide the canopy path fields based on the selected source kind."""
+        needs_paths = self.canopyKindComboBox.currentData() != CANOPY_KIND_NONE
+        for w in (
+            self.canopyManifestLabel, self.canopyManifestEdit, self.canopyManifestButton,
+            self.canopyTilesLabel, self.canopyTilesEdit, self.canopyTilesButton,
+        ):
+            w.setVisible(needs_paths)
+
+    def _update_canopy_kind(self):
+        kind = self.canopyKindComboBox.currentData() or DEFAULT_CANOPY_KIND
+        self.parent.settings_service.set_setting('CanopyKind', kind)
+        self._refresh_canopy_visibility()
+
+    def _update_canopy_manifest(self):
+        self.parent.settings_service.set_setting(
+            'CanopyManifestPath', self.canopyManifestEdit.text().strip())
+
+    def _update_canopy_tiles(self):
+        self.parent.settings_service.set_setting(
+            'CanopyTilesDir', self.canopyTilesEdit.text().strip())
+
+    def _browse_canopy_manifest(self):
+        start_dir = self.canopyManifestEdit.text() or os.path.expanduser("~")
+        filename, _ = QFileDialog.getOpenFileName(
+            self, self.tr("Select canopy manifest CSV"), start_dir,
+            self.tr("CSV files (*.csv);;All files (*)"))
+        if filename:
+            self.canopyManifestEdit.setText(filename)
+            self._update_canopy_manifest()
+
+    def _browse_canopy_tiles(self):
+        start_dir = self.canopyTilesEdit.text() or os.path.expanduser("~")
+        directory = QFileDialog.getExistingDirectory(
+            self, self.tr("Select canopy tiles directory"), start_dir)
+        if directory:
+            self.canopyTilesEdit.setText(directory)
+            self._update_canopy_tiles()
+
+    def _open_tile_fetch_dialog(self):
+        """Open the Download Tiles dialog and register any downloaded paths."""
+        try:
+            from core.controllers.images.viewer.exports.TileFetchController import TileFetchController
+        except Exception as e:
+            QMessageBox.information(
+                self, self.tr("Download Tiles"),
+                self.tr("The tile downloader is unavailable:\n{error}").format(error=str(e)))
+            return
+        controller = TileFetchController(self, self.parent.settings_service, logger=None)
+        controller.run_fetch()
+        # Reflect any settings the fetch registered back into the fields.
+        self.canopyManifestEdit.setText(self.parent.settings_service.get_setting('CanopyManifestPath', '') or '')
+        self.canopyTilesEdit.setText(self.parent.settings_service.get_setting('CanopyTilesDir', '') or '')
+        canopy_kind = self.parent.settings_service.get_setting('CanopyKind', DEFAULT_CANOPY_KIND) or DEFAULT_CANOPY_KIND
+        cidx = self.canopyKindComboBox.findData(canopy_kind)
+        if cidx >= 0:
+            self.canopyKindComboBox.setCurrentIndex(cidx)
+        self._refresh_canopy_visibility()
 
     def _update_terrain_elevation(self, checked: bool):
         """Update whether terrain elevation data should be used for AOI positioning."""

--- a/app/core/controllers/Preferences.py
+++ b/app/core/controllers/Preferences.py
@@ -386,8 +386,15 @@ class Preferences(TranslationMixin, QDialog, Ui_Preferences):
                 self, self.tr("Download Tiles"),
                 self.tr("The tile downloader is unavailable:\n{error}").format(error=str(e)))
             return
+        # If a mission is loaded in the viewer, hand its images to the fetch
+        # dialog so it can auto-fill the AOI (no manual coordinates needed).
+        mission_images = None
+        viewer = getattr(self.parent, 'viewer', None)
+        if viewer is not None:
+            mission_images = getattr(viewer, 'source_images', None) or getattr(viewer, 'images', None)
+
         controller = TileFetchController(self, self.parent.settings_service, logger=None)
-        controller.run_fetch()
+        controller.run_fetch(mission_images=mission_images)
         # Reflect any settings the fetch registered back into the fields.
         self.canopyManifestEdit.setText(self.parent.settings_service.get_setting('CanopyManifestPath', '') or '')
         self.canopyTilesEdit.setText(self.parent.settings_service.get_setting('CanopyTilesDir', '') or '')

--- a/app/core/controllers/images/viewer/GPSMapController.py
+++ b/app/core/controllers/images/viewer/GPSMapController.py
@@ -48,6 +48,9 @@ class GPSMapController(QObject):
         self._pod_overlay_mode = 'pod'
         self._limit_labels = None
         self._max_overlay_dim = 2048
+        self._canopy_svc = None
+        self._canopy_svc_loaded = False
+        self._canopy_overlay_cache = None  # (spec key, pixmap, transform6)
 
     def show_map(self):
         """
@@ -85,10 +88,17 @@ class GPSMapController(QObject):
             self.map_dialog.update_gps_data(self.gps_data, current_gps_index)
             self.map_dialog.set_offline_mode(offline_only)
 
-        # Enable/disable the overlay controls based on whether a POD result exists.
+        # Enable/disable the overlay controls: POD/looks need a cached result,
+        # canopy just needs a configured canopy source. Re-check the canopy
+        # settings each open (the user may have changed them in Preferences).
         cache = self._pod_cache()
-        if hasattr(self.map_dialog, 'set_pod_available'):
-            self.map_dialog.set_pod_available(cache is not None and cache.has_result())
+        self._canopy_svc_loaded = False
+        pod_available = cache is not None and cache.has_result()
+        if hasattr(self.map_dialog, 'set_overlay_availability'):
+            self.map_dialog.set_overlay_availability(
+                pod_available, self._canopy_service() is not None)
+        elif hasattr(self.map_dialog, 'set_pod_available'):
+            self.map_dialog.set_pod_available(pod_available)
 
         self.map_dialog.show()
         self.map_dialog.raise_()
@@ -299,17 +309,11 @@ class GPSMapController(QObject):
             }
         return self._limit_labels.get(code, self.tr("Unknown"))
 
-    def _build_pod_pixmap(self, result, mode):
-        """(QPixmap, transform6) from a CoverageResult, downsampled to a display cap."""
+    def _rgba_to_pixmap(self, rgba, transform):
+        """(QPixmap, transform6) from an RGBA grid, downsampled to a display cap."""
         import numpy as np
-        from core.services.coverage.colormap import pod_to_rgba, look_count_to_rgba
 
-        if mode == 'looks':
-            rgba = look_count_to_rgba(result.look_count)
-        else:
-            rgba = pod_to_rgba(result.pod, result.look_count, result.params)
-
-        a, b, c, d, e, f = tuple(result.transform)[:6]
+        a, b, c, d, e, f = tuple(transform)[:6]
         rows, cols = rgba.shape[:2]
         shrink = max(rows, cols) / float(self._max_overlay_dim)
         if shrink > 1.0:
@@ -325,6 +329,82 @@ class GPSMapController(QObject):
         qimg = QImage(arr.tobytes(), cols, rows, 4 * cols, QImage.Format.Format_RGBA8888)
         return QPixmap.fromImage(qimg), (a, b, c, d, e, f)
 
+    def _build_pod_pixmap(self, result, mode):
+        """(QPixmap, transform6) from a CoverageResult, downsampled to a display cap."""
+        from core.services.coverage.colormap import pod_to_rgba, look_count_to_rgba
+
+        if mode == 'looks':
+            rgba = look_count_to_rgba(result.look_count)
+        else:
+            rgba = pod_to_rgba(result.pod, result.look_count, result.params)
+        return self._rgba_to_pixmap(rgba, result.transform)
+
+    def _canopy_service(self):
+        """Lazily build (and cache) the settings-configured CanopyService."""
+        if not self._canopy_svc_loaded:
+            self._canopy_svc_loaded = True
+            self._canopy_svc = None
+            try:
+                from core.services.SettingsService import SettingsService
+                from core.services.terrain.CanopyServiceFactory import create_canopy_service
+                self._canopy_svc = create_canopy_service(SettingsService())
+            except Exception as e:
+                self.logger.warning(f"Canopy overlay: service unavailable: {e}")
+        return self._canopy_svc
+
+    def _canopy_extent_spec(self):
+        """EPSG:3857 GridSpec for the canopy overlay: the cached POD grid when
+        one exists (pixel-aligned with the POD overlay), else the mission GPS
+        bounding box padded 200 m, at a resolution capped to the display size."""
+        from core.services.terrain.grid import GridSpec, spec_for_bounds_wgs84, WEB_MERCATOR_CRS
+
+        cache = self._pod_cache()
+        if cache is not None and cache.has_result():
+            result = cache.get_result()
+            rows, cols = result.pod.shape
+            if rows and cols:
+                return GridSpec(crs=WEB_MERCATOR_CRS, transform=result.transform,
+                                width=int(cols), height=int(rows))
+
+        lats = [d['latitude'] for d in self.gps_data]
+        lons = [d['longitude'] for d in self.gps_data]
+        if not lats:
+            return None
+        pad_deg = 200.0 / 111320.0
+        bounds = (min(lons) - pad_deg, min(lats) - pad_deg,
+                  max(lons) + pad_deg, max(lats) + pad_deg)
+        span_m = max((bounds[2] - bounds[0]) * 111320.0 * math.cos(math.radians(lats[0])),
+                     (bounds[3] - bounds[1]) * 111320.0)
+        res_m = max(2.0, span_m / float(self._max_overlay_dim))
+        return spec_for_bounds_wgs84(bounds, res_m)
+
+    def _build_canopy_pixmap(self):
+        """(QPixmap, transform6) of canopy height over the mission extent, or
+        None when no canopy source is configured / no tile covers the area."""
+        canopy = self._canopy_service()
+        if canopy is None:
+            return None
+        spec = self._canopy_extent_spec()
+        if spec is None:
+            return None
+
+        key = (spec.crs, tuple(spec.transform)[:6], spec.width, spec.height)
+        if self._canopy_overlay_cache and self._canopy_overlay_cache[0] == key:
+            return self._canopy_overlay_cache[1], self._canopy_overlay_cache[2]
+
+        try:
+            sample = canopy.sample_grid_spec(spec)
+        except Exception as e:
+            self.logger.warning(f"Canopy overlay: sampling failed: {e}")
+            return None
+        if sample is None or sample.chm is None:
+            return None
+
+        from core.services.coverage.colormap import chm_to_rgba
+        pixmap, transform6 = self._rgba_to_pixmap(chm_to_rgba(sample.chm), spec.transform)
+        self._canopy_overlay_cache = (key, pixmap, transform6)
+        return pixmap, transform6
+
     def enable_pod_overlay(self, mode='pod'):
         """Turn the overlay on from the cached result (called after an export run)."""
         cache = self._pod_cache()
@@ -337,19 +417,42 @@ class GPSMapController(QObject):
 
     def on_pod_display_changed(self, enabled, mode, opacity):
         """React to the dialog's overlay toggle / mode / opacity controls."""
-        cache = self._pod_cache()
-        if not enabled or cache is None or not cache.has_result() or self.map_dialog is None:
-            self._pod_overlay_enabled = False
-            if self.map_dialog is not None and hasattr(self.map_dialog, 'map_view'):
-                self.map_dialog.map_view.clear_pod_overlay()
+        if not enabled or self.map_dialog is None:
+            self._clear_pod_overlay()
             return
-        result = cache.get_result()
-        pixmap, transform6 = self._build_pod_pixmap(result, mode)
+
+        if mode == 'canopy':
+            from PySide6.QtWidgets import QApplication
+            from PySide6.QtCore import Qt
+            QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+            try:
+                built = self._build_canopy_pixmap()
+            finally:
+                QApplication.restoreOverrideCursor()
+            if built is None:
+                self._clear_pod_overlay()
+                if hasattr(self.parent, 'status_controller'):
+                    self.parent.status_controller.show_toast(
+                        self.tr("No canopy data covers this area"), 3000, color="#F44336")
+                return
+            pixmap, transform6 = built
+        else:
+            cache = self._pod_cache()
+            if cache is None or not cache.has_result():
+                self._clear_pod_overlay()
+                return
+            pixmap, transform6 = self._build_pod_pixmap(cache.get_result(), mode)
+
         self._pod_overlay_enabled = True
         self._pod_overlay_mode = mode
         view = self.map_dialog.map_view
         view.set_pod_overlay(pixmap, transform6)
         view.set_pod_overlay_opacity(opacity / 100.0)
+
+    def _clear_pod_overlay(self):
+        self._pod_overlay_enabled = False
+        if self.map_dialog is not None and hasattr(self.map_dialog, 'map_view'):
+            self.map_dialog.map_view.clear_pod_overlay()
 
     def _show_pod_inspect_menu(self, sample, lat, lon):
         view = self.map_dialog.map_view if self.map_dialog else None

--- a/app/core/controllers/images/viewer/GPSMapController.py
+++ b/app/core/controllers/images/viewer/GPSMapController.py
@@ -6,6 +6,8 @@ and coordination between the map and main viewer.
 """
 
 from PySide6.QtCore import QObject, Signal, QTimer, QPointF
+from PySide6.QtWidgets import QMenu
+from PySide6.QtGui import QCursor, QImage, QPixmap
 from helpers.LocationInfo import LocationInfo
 from helpers.MetaDataHelper import MetaDataHelper
 from core.services.LoggerService import LoggerService
@@ -42,6 +44,10 @@ class GPSMapController(QObject):
         self.logger = LoggerService()  # Create our own logger
         self.map_dialog = None
         self.gps_data = []
+        self._pod_overlay_enabled = False
+        self._pod_overlay_mode = 'pod'
+        self._limit_labels = None
+        self._max_overlay_dim = 2048
 
     def show_map(self):
         """
@@ -70,12 +76,19 @@ class GPSMapController(QObject):
             self.map_dialog = GPSMapDialog(self.parent, self.gps_data, current_gps_index, offline_only=offline_only)
             self.map_dialog.image_selected.connect(self.on_map_image_selected)
             self.map_dialog.gps_right_clicked.connect(self.on_map_gps_clicked)
+            if hasattr(self.map_dialog, 'pod_display_changed'):
+                self.map_dialog.pod_display_changed.connect(self.on_pod_display_changed)
             # Connect to dialog close event to update button state
             self.map_dialog.finished.connect(self.on_map_dialog_closed)
         else:
             # Update with latest data if dialog already exists
             self.map_dialog.update_gps_data(self.gps_data, current_gps_index)
             self.map_dialog.set_offline_mode(offline_only)
+
+        # Enable/disable the overlay controls based on whether a POD result exists.
+        cache = self._pod_cache()
+        if hasattr(self.map_dialog, 'set_pod_available'):
+            self.map_dialog.set_pod_available(cache is not None and cache.has_result())
 
         self.map_dialog.show()
         self.map_dialog.raise_()
@@ -268,6 +281,98 @@ class GPSMapController(QObject):
             self.parent.current_image = image_index
             self.parent._load_image()
 
+    # ---------------- POD coverage overlay ----------------
+
+    def _pod_cache(self):
+        return getattr(self.parent, 'pod_result_cache', None)
+
+    def _limit_label(self, code):
+        if self._limit_labels is None:
+            from core.services.coverage.contracts import (
+                LIMIT_NO_LOOKS, LIMIT_TERRAIN, LIMIT_CANOPY, LIMIT_GSD, LIMIT_NONE)
+            self._limit_labels = {
+                LIMIT_NO_LOOKS: self.tr("Not covered — no looks"),
+                LIMIT_TERRAIN: self.tr("Terrain occlusion"),
+                LIMIT_CANOPY: self.tr("Canopy"),
+                LIMIT_GSD: self.tr("Image resolution (GSD)"),
+                LIMIT_NONE: self.tr("None"),
+            }
+        return self._limit_labels.get(code, self.tr("Unknown"))
+
+    def _build_pod_pixmap(self, result, mode):
+        """(QPixmap, transform6) from a CoverageResult, downsampled to a display cap."""
+        import numpy as np
+        from core.services.coverage.colormap import pod_to_rgba, look_count_to_rgba
+
+        if mode == 'looks':
+            rgba = look_count_to_rgba(result.look_count)
+        else:
+            rgba = pod_to_rgba(result.pod, result.look_count, result.params)
+
+        a, b, c, d, e, f = tuple(result.transform)[:6]
+        rows, cols = rgba.shape[:2]
+        shrink = max(rows, cols) / float(self._max_overlay_dim)
+        if shrink > 1.0:
+            import cv2
+            new_cols = max(1, int(cols / shrink))
+            new_rows = max(1, int(rows / shrink))
+            rgba = cv2.resize(rgba, (new_cols, new_rows), interpolation=cv2.INTER_NEAREST)
+            a *= cols / new_cols
+            e *= rows / new_rows
+            rows, cols = new_rows, new_cols
+
+        arr = np.ascontiguousarray(rgba, dtype=np.uint8)
+        qimg = QImage(arr.tobytes(), cols, rows, 4 * cols, QImage.Format.Format_RGBA8888)
+        return QPixmap.fromImage(qimg), (a, b, c, d, e, f)
+
+    def enable_pod_overlay(self, mode='pod'):
+        """Turn the overlay on from the cached result (called after an export run)."""
+        cache = self._pod_cache()
+        if cache is None or not cache.has_result() or self.map_dialog is None:
+            return
+        if hasattr(self.map_dialog, 'set_pod_available'):
+            self.map_dialog.set_pod_available(True)
+        self.on_pod_display_changed(True, mode, int(self.map_dialog.map_view._pod_opacity * 100)
+                                    if hasattr(self.map_dialog, 'map_view') else 70)
+
+    def on_pod_display_changed(self, enabled, mode, opacity):
+        """React to the dialog's overlay toggle / mode / opacity controls."""
+        cache = self._pod_cache()
+        if not enabled or cache is None or not cache.has_result() or self.map_dialog is None:
+            self._pod_overlay_enabled = False
+            if self.map_dialog is not None and hasattr(self.map_dialog, 'map_view'):
+                self.map_dialog.map_view.clear_pod_overlay()
+            return
+        result = cache.get_result()
+        pixmap, transform6 = self._build_pod_pixmap(result, mode)
+        self._pod_overlay_enabled = True
+        self._pod_overlay_mode = mode
+        view = self.map_dialog.map_view
+        view.set_pod_overlay(pixmap, transform6)
+        view.set_pod_overlay_opacity(opacity / 100.0)
+
+    def _show_pod_inspect_menu(self, sample, lat, lon):
+        view = self.map_dialog.map_view if self.map_dialog else None
+        menu = QMenu(view)
+        hdr = menu.addAction(self.tr("POD: {pod}%   Looks: {looks}").format(
+            pod=round(sample['pod'] * 100), looks=sample['looks']))
+        hdr.setEnabled(False)
+        lim = menu.addAction(self.tr("Limiting factor: {factor}").format(
+            factor=self._limit_label(sample['limiting_factor'])))
+        lim.setEnabled(False)
+        frames = sample.get('frames', [])
+        if frames:
+            menu.addSeparator()
+            for idx in frames[:8]:
+                if 0 <= idx < len(self.parent.images):
+                    name = self.parent.images[idx].get('name', self.tr("Image {n}").format(n=idx + 1))
+                    act = menu.addAction(self.tr("View {name}").format(name=name))
+                    act.triggered.connect(lambda checked=False, i=idx: self.on_map_image_selected(i))
+        menu.addSeparator()
+        locate = menu.addAction(self.tr("Find location in images"))
+        locate.triggered.connect(lambda checked=False: self._reverse_locate(lat, lon))
+        menu.exec(QCursor.pos())
+
     def update_current_image(self, image_index):
         """
         Update the map to highlight a new current image.
@@ -296,9 +401,24 @@ class GPSMapController(QObject):
             self.map_dialog.update_zoom_fov(visible_rect)
 
     def on_map_gps_clicked(self, lat, lon):
+        """Handle a right-click on the map.
+
+        When the POD overlay is active and the click lands on a covered cell,
+        show a cell-inspect menu (POD, look count, limiting factor, contributing
+        frames). Otherwise fall back to the reverse image lookup.
         """
-        Handle right-click on GPS map — find image containing the coordinate
-        and center the viewer on that position.
+        if self._pod_overlay_enabled:
+            cache = self._pod_cache()
+            result = cache.get_result() if (cache and cache.has_result()) else None
+            sample = result.sample(lat, lon) if result is not None else None
+            if sample is not None:
+                self._show_pod_inspect_menu(sample, lat, lon)
+                return
+        self._reverse_locate(lat, lon)
+
+    def _reverse_locate(self, lat, lon):
+        """
+        Find the image containing the coordinate and center the viewer on it.
 
         Args:
             lat: Clicked latitude

--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -1246,6 +1246,10 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
             self.coverage_extent_export = CoverageExtentExportController(self, self.logger)
             self.unified_map_export = UnifiedMapExportController(self, self.logger)
 
+            # Session cache for the last Coverage/POD run (viewer overlay reuses it).
+            from core.services.coverage.CoverageResultCache import CoverageResultCache
+            self.pod_result_cache = CoverageResultCache()
+
             # Force the layout to update and ensure proper sizing
             if hasattr(self, 'verticalLayout_3') and self.verticalLayout_3:
                 self.verticalLayout_3.update()

--- a/app/core/controllers/images/viewer/exports/TileFetchController.py
+++ b/app/core/controllers/images/viewer/exports/TileFetchController.py
@@ -8,9 +8,10 @@ downloaded data is immediately usable.
 """
 
 import os
+import glob
 
-from PySide6.QtWidgets import QMessageBox, QDialog, QApplication
-from PySide6.QtCore import QThread, Signal
+from PySide6.QtWidgets import QMessageBox, QDialog, QApplication, QFileDialog
+from PySide6.QtCore import QThread, Signal, Qt
 
 from core.services.LoggerService import LoggerService
 from core.services.terrain.TileFetchService import TileFetchService
@@ -77,8 +78,16 @@ class TileFetchController(TranslationMixin):
         self.progress_dialog = None
         self._register = True
 
-    def run_fetch(self, default_bounds=None):
-        dialog = TileFetchDialog(self.parent, default_bounds=default_bounds)
+    def run_fetch(self, default_bounds=None, mission_images=None):
+        self._mission_images = mission_images
+        dialog = TileFetchDialog(self.parent, default_bounds=default_bounds,
+                                 has_mission=bool(mission_images))
+        dialog.use_mission_btn.clicked.connect(
+            lambda: self._fill_aoi(dialog, self._mission_images, "loaded mission"))
+        dialog.load_folder_btn.clicked.connect(lambda: self._fill_from_folder(dialog))
+        if mission_images:
+            self._fill_aoi(dialog, mission_images, "loaded mission", warn_if_empty=False)
+
         if dialog.exec() != QDialog.Accepted:
             return
 
@@ -117,6 +126,50 @@ class TileFetchController(TranslationMixin):
         QApplication.processEvents()
         if self.progress_dialog.exec() == QDialog.Rejected:
             self.thread.cancel()
+
+    _IMAGE_GLOBS = ("*.jpg", "*.jpeg", "*.JPG", "*.JPEG", "*.tif", "*.tiff", "*.png")
+
+    def _fill_aoi(self, dialog, images, source_label, warn_if_empty=True):
+        """Compute the AOI (+ buffer) from ``images`` and fill the dialog fields."""
+        if not images:
+            return
+        from core.services.coverage.aoi import (
+            compute_mission_gps_bounds, suggest_buffer_m, pad_bounds)
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            raw = compute_mission_gps_bounds(images)
+            if raw is None:
+                if warn_if_empty:
+                    QMessageBox.warning(
+                        self.parent, self.tr("No GPS Found"),
+                        self.tr("No GPS positions were found in the {source} images.").format(
+                            source=source_label))
+                return
+            buffer_m = dialog.get_buffer()
+            if buffer_m is None:
+                buffer_m = suggest_buffer_m(images)
+                dialog.set_buffer(buffer_m)
+            dialog.set_aoi(pad_bounds(raw, buffer_m))
+        finally:
+            QApplication.restoreOverrideCursor()
+
+    def _fill_from_folder(self, dialog):
+        folder = QFileDialog.getExistingDirectory(
+            self.parent, self.tr("Select image folder"))
+        if not folder:
+            return
+        paths = []
+        for pattern in self._IMAGE_GLOBS:
+            paths.extend(glob.glob(os.path.join(folder, pattern)))
+        images = [{'path': p} for p in sorted(set(paths))]
+        if not images:
+            QMessageBox.warning(
+                self.parent, self.tr("No Images"),
+                self.tr("No images were found in the selected folder."))
+            return
+        # A fresh folder -> re-suggest the buffer for it.
+        dialog.buffer_edit.clear()
+        self._fill_aoi(dialog, images, "selected folder")
 
     def _on_progress(self, current, total, message):
         if self.progress_dialog:

--- a/app/core/controllers/images/viewer/exports/TileFetchController.py
+++ b/app/core/controllers/images/viewer/exports/TileFetchController.py
@@ -1,0 +1,162 @@
+"""
+TileFetchController - drive the DEM / canopy tile download and register paths.
+
+Clones the CoverageExtent export threading pattern (QThread + ExportProgressDialog
+with progress/cancel). On success it writes each product into a subfolder and,
+if requested, registers the manifest/tiles paths into settings so the freshly
+downloaded data is immediately usable.
+"""
+
+import os
+
+from PySide6.QtWidgets import QMessageBox, QDialog, QApplication
+from PySide6.QtCore import QThread, Signal
+
+from core.services.LoggerService import LoggerService
+from core.services.terrain.TileFetchService import TileFetchService
+from core.views.images.viewer.dialogs.TileFetchDialog import TileFetchDialog
+from core.views.images.viewer.dialogs.ExportProgressDialog import ExportProgressDialog
+from helpers.TranslationMixin import TranslationMixin
+
+
+class TileFetchThread(QThread):
+    finished = Signal(dict)
+    errorOccurred = Signal(str)
+    progressUpdated = Signal(int, int, str)
+    canceled = Signal()
+
+    def __init__(self, service, bounds, output_dir, want_dem, want_canopy):
+        super().__init__()
+        self.service = service
+        self.bounds = bounds
+        self.output_dir = output_dir
+        self.want_dem = want_dem
+        self.want_canopy = want_canopy
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def is_cancelled(self):
+        return self._cancelled
+
+    def run(self):
+        try:
+            results = {}
+
+            def progress(current, total, message):
+                if not self.is_cancelled():
+                    self.progressUpdated.emit(current, total, message)
+
+            if self.want_dem and not self.is_cancelled():
+                dem_dir = os.path.join(self.output_dir, "dem")
+                results['dem'] = self.service.fetch_3dep_dem(
+                    self.bounds, dem_dir, progress_callback=progress,
+                    cancel_check=self.is_cancelled)
+            if self.want_canopy and not self.is_cancelled():
+                chm_dir = os.path.join(self.output_dir, "chm")
+                results['canopy'] = self.service.fetch_meta_canopy(
+                    self.bounds, chm_dir, progress_callback=progress,
+                    cancel_check=self.is_cancelled)
+
+            if self.is_cancelled():
+                self.canceled.emit()
+                return
+            self.finished.emit(results)
+        except Exception as e:
+            import traceback
+            self.errorOccurred.emit(f"{str(e)}\n\n{traceback.format_exc()}")
+
+
+class TileFetchController(TranslationMixin):
+    def __init__(self, parent_widget, settings_service, logger=None):
+        self.parent = parent_widget
+        self.settings_service = settings_service
+        self.logger = logger or LoggerService()
+        self.thread = None
+        self.progress_dialog = None
+        self._register = True
+
+    def run_fetch(self, default_bounds=None):
+        dialog = TileFetchDialog(self.parent, default_bounds=default_bounds)
+        if dialog.exec() != QDialog.Accepted:
+            return
+
+        bounds = dialog.get_bounds()
+        out_dir = dialog.get_output_dir()
+        if bounds is None:
+            QMessageBox.warning(self.parent, self.tr("Invalid Area"),
+                                self.tr("Please enter a valid bounding box."))
+            return
+        if not out_dir:
+            QMessageBox.warning(self.parent, self.tr("No Output Folder"),
+                                self.tr("Please choose an output folder."))
+            return
+        if not (dialog.want_dem() or dialog.want_canopy()):
+            QMessageBox.warning(self.parent, self.tr("No Dataset"),
+                                self.tr("Please select at least one dataset."))
+            return
+
+        self._register = dialog.should_register()
+        service = TileFetchService(logger=self.logger)
+
+        self.progress_dialog = ExportProgressDialog(
+            self.parent, title="Downloading Coverage Data", total_items=100)
+        self.progress_dialog.set_title("Downloading tiles...")
+
+        self.thread = TileFetchThread(service, bounds, out_dir,
+                                      dialog.want_dem(), dialog.want_canopy())
+        self.thread.finished.connect(self._on_finished)
+        self.thread.errorOccurred.connect(self._on_error)
+        self.thread.progressUpdated.connect(self._on_progress)
+        self.thread.canceled.connect(self._on_cancelled)
+        self.progress_dialog.cancel_requested.connect(self.thread.cancel)
+
+        self.thread.start()
+        self.progress_dialog.show()
+        QApplication.processEvents()
+        if self.progress_dialog.exec() == QDialog.Rejected:
+            self.thread.cancel()
+
+    def _on_progress(self, current, total, message):
+        if self.progress_dialog:
+            self.progress_dialog.update_progress(current, total, message)
+            QApplication.processEvents()
+
+    def _register_results(self, results):
+        if not self._register or self.settings_service is None:
+            return
+        dem = results.get('dem')
+        if dem is not None and dem.manifest_path:
+            self.settings_service.set_setting('Terrain3DEPManifestPath', dem.manifest_path)
+            self.settings_service.set_setting('Terrain3DEPTilesDir', dem.out_dir)
+            self.settings_service.set_setting('TerrainProviderId', 'usgs_3dep_local')
+        canopy = results.get('canopy')
+        if canopy is not None and canopy.manifest_path:
+            self.settings_service.set_setting('CanopyManifestPath', canopy.manifest_path)
+            self.settings_service.set_setting('CanopyTilesDir', canopy.out_dir)
+            self.settings_service.set_setting('CanopyKind', 'meta')
+
+    def _on_finished(self, results):
+        if self.progress_dialog:
+            self.progress_dialog.accept()
+        self._register_results(results)
+        written = sum(getattr(r, 'tiles_written', 0) for r in results.values())
+        QMessageBox.information(
+            self.parent, self.tr("Download Complete"),
+            self.tr("Downloaded {count} tiles.").format(count=written))
+
+    def _on_cancelled(self):
+        if self.thread and self.thread.isRunning():
+            self.thread.terminate()
+            self.thread.wait()
+        if self.progress_dialog and self.progress_dialog.isVisible():
+            self.progress_dialog.reject()
+
+    def _on_error(self, message):
+        if self.progress_dialog and self.progress_dialog.isVisible():
+            self.progress_dialog.reject()
+        self.logger.error(f"Tile fetch error: {message}")
+        QMessageBox.critical(
+            self.parent, self.tr("Download Error"),
+            self.tr("Tile download failed:\n{error}").format(error=message))

--- a/app/core/controllers/images/viewer/exports/UnifiedMapExportController.py
+++ b/app/core/controllers/images/viewer/exports/UnifiedMapExportController.py
@@ -338,6 +338,51 @@ class UnifiedMapExportThread(QThread):
             self.errorOccurred.emit(error_msg)
 
 
+class CoveragePodExportThread(QThread):
+    """Thread for the Probability-of-Detection pass (compute + write outputs).
+
+    Runs independently of the KML/CalTopo export so the existing export path is
+    untouched. Emits ``podCompleted`` with the CoverageResult on success.
+    """
+
+    finished = Signal()
+    errorOccurred = Signal(str)
+    progressUpdated = Signal(int, int, str)
+    canceled = Signal()
+    podCompleted = Signal(object)
+
+    def __init__(self, pod_service, images, output_dir):
+        super().__init__()
+        self.pod_service = pod_service
+        self.images = images
+        self.output_dir = output_dir
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def is_cancelled(self):
+        return self._cancelled
+
+    def run(self):
+        try:
+            from core.services.coverage.writers import write_all_outputs
+            result = self.pod_service.calculate(
+                self.images,
+                progress_callback=lambda c, t, m: self.progressUpdated.emit(c, t, m),
+                cancel_check=self.is_cancelled,
+            )
+            if result.cancelled or self.is_cancelled():
+                self.canceled.emit()
+                return
+            self.progressUpdated.emit(1, 1, "Writing POD outputs...")
+            write_all_outputs(result, self.output_dir)
+            self.podCompleted.emit(result)
+            self.finished.emit()
+        except Exception as e:
+            self.errorOccurred.emit(f"{str(e)}\n\n{traceback.format_exc()}")
+
+
 class UnifiedMapExportController(TranslationMixin):
     """
     Controller for managing unified map export functionality.
@@ -357,6 +402,9 @@ class UnifiedMapExportController(TranslationMixin):
         self.logger = logger or LoggerService()
         self.export_thread = None
         self.progress_dialog = None
+        self.pod_thread = None
+        self.pod_progress_dialog = None
+        self._pending_pod_result = None
 
     def show_export_dialog(self):
         """Show the unified map export dialog and handle export based on selections."""
@@ -374,9 +422,11 @@ class UnifiedMapExportController(TranslationMixin):
             include_flagged_aois = dialog.should_include_flagged_aois()
             include_coverage = dialog.should_include_coverage()
             include_images = dialog.should_include_images() if export_type == 'caltopo' else False
+            include_pod = dialog.should_include_pod()
+            show_pod_on_map = dialog.should_show_pod_on_map()
 
-            # Validate selections
-            if not (include_locations or include_flagged_aois or include_coverage):
+            # Validate selections (POD is a valid stand-alone selection).
+            if not (include_locations or include_flagged_aois or include_coverage or include_pod):
                 QMessageBox.warning(
                     self.parent,
                     self.tr("No Data Selected"),
@@ -386,7 +436,10 @@ class UnifiedMapExportController(TranslationMixin):
 
             # Handle export based on type
             if export_type == 'kml':
-                self._export_to_kml(include_locations, include_images_without_flagged_aois, include_flagged_aois, include_coverage)
+                kml_path = self._export_to_kml(include_locations, include_images_without_flagged_aois,
+                                               include_flagged_aois, include_coverage)
+                if include_pod and kml_path:
+                    self._run_pod_export(self._pod_dir_for_kml(kml_path), show_pod_on_map)
             else:  # caltopo
                 # Show method selection dialog
                 method_dialog = CalTopoMethodDialog(self.parent)
@@ -400,6 +453,11 @@ class UnifiedMapExportController(TranslationMixin):
                                                     include_flagged_aois, include_coverage, include_images)
                 else:  # browser
                     self._export_to_caltopo(include_locations, include_images_without_flagged_aois, include_flagged_aois, include_coverage, include_images)
+                if include_pod:
+                    pod_dir = QFileDialog.getExistingDirectory(
+                        self.parent, self.tr("Select folder for POD coverage files"))
+                    if pod_dir:
+                        self._run_pod_export(pod_dir, show_pod_on_map)
 
         except Exception as e:
             self.logger.error(f"Error in unified map export: {str(e)}")
@@ -429,7 +487,7 @@ class UnifiedMapExportController(TranslationMixin):
             )
 
             if not file_name:  # User cancelled
-                return
+                return None
 
             # Get custom altitude if available
             custom_alt = None
@@ -502,6 +560,8 @@ class UnifiedMapExportController(TranslationMixin):
             if self.progress_dialog.exec() == QDialog.Rejected:
                 self.export_thread.cancel()
 
+            return file_name
+
         except Exception as e:
             self.logger.error(f"Error exporting to KML: {str(e)}")
             QMessageBox.critical(
@@ -509,6 +569,116 @@ class UnifiedMapExportController(TranslationMixin):
                 self.tr("Export Error"),
                 self.tr("Failed to export to KML:\n{error}").format(error=str(e))
             )
+            return None
+
+    @staticmethod
+    def _pod_dir_for_kml(kml_path):
+        """Sibling subfolder next to the KML for the POD product set."""
+        import os
+        base = os.path.splitext(os.path.basename(kml_path))[0]
+        return os.path.join(os.path.dirname(kml_path), f"{base}_coverage_pod")
+
+    def _build_pod_service(self):
+        """Construct a CoveragePodService from settings (fresh TerrainService for
+        thread safety; canopy factory is optional until it ships)."""
+        from core.services.terrain.TerrainService import TerrainService
+        from core.services.coverage.params import PodParams
+        from core.services.coverage.CoveragePodService import CoveragePodService
+
+        settings = getattr(self.parent, 'settings_service', None)
+        terrain = TerrainService(settings_service=settings)
+        canopy = None
+        try:
+            from core.services.terrain.CanopyServiceFactory import create_canopy_service
+            canopy = create_canopy_service(settings)
+        except Exception:
+            canopy = None
+
+        custom_alt = None
+        if hasattr(self.parent, 'altitude_controller'):
+            custom_alt = self.parent.altitude_controller.get_effective_altitude()
+        params = PodParams.from_settings(settings)
+        return CoveragePodService(terrain, canopy, params,
+                                  custom_altitude_ft=custom_alt, logger=self.logger)
+
+    def _run_pod_export(self, output_dir, show_on_map):
+        """Run the POD pass on the full (non-hidden) image set, write outputs,
+        cache the result, and optionally show it on the viewer map."""
+        try:
+            pod_service = self._build_pod_service()
+        except Exception as e:
+            self.logger.error(f"Failed to build POD service: {e}")
+            QMessageBox.critical(
+                self.parent, self.tr("POD Error"),
+                self.tr("Could not start the POD calculation:\n{error}").format(error=str(e)))
+            return
+
+        self._pending_pod_result = None
+        self._show_pod_on_map_requested = show_on_map
+
+        self.pod_progress_dialog = ExportProgressDialog(
+            self.parent, title="Coverage / POD", total_items=len(self.parent.images) + 2)
+        self.pod_progress_dialog.set_title("Calculating probability of detection...")
+
+        self.pod_thread = CoveragePodExportThread(pod_service, self.parent.images, output_dir)
+        self.pod_thread.podCompleted.connect(self._on_pod_completed)
+        self.pod_thread.finished.connect(self._on_pod_finished)
+        self.pod_thread.errorOccurred.connect(self._on_pod_error)
+        self.pod_thread.progressUpdated.connect(self._on_pod_progress)
+        self.pod_thread.canceled.connect(self._on_pod_cancelled)
+        self.pod_progress_dialog.cancel_requested.connect(self.pod_thread.cancel)
+
+        self.pod_thread.start()
+        self.pod_progress_dialog.show()
+        QApplication.processEvents()
+        if self.pod_progress_dialog.exec() == QDialog.Rejected:
+            self.pod_thread.cancel()
+
+    def _on_pod_progress(self, current, total, message):
+        if self.pod_progress_dialog:
+            self.pod_progress_dialog.update_progress(current, total, message)
+            QApplication.processEvents()
+
+    def _on_pod_completed(self, result):
+        self._pending_pod_result = result
+        cache = getattr(self.parent, 'pod_result_cache', None)
+        if cache is not None:
+            cache.set_result(result)
+
+    def _on_pod_finished(self):
+        if self.pod_progress_dialog:
+            self.pod_progress_dialog.accept()
+        if hasattr(self.parent, 'status_controller'):
+            self.parent.status_controller.show_toast(
+                self.tr("POD coverage complete"), 3000, color="#00C853")
+        # Show on the viewer map if requested and the overlay is available.
+        if self._pending_pod_result is not None and getattr(self, '_show_pod_on_map_requested', False):
+            controller = getattr(self.parent, 'gps_map_controller', None)
+            if controller is not None and hasattr(controller, 'enable_pod_overlay'):
+                try:
+                    controller.show_map()
+                    controller.enable_pod_overlay()
+                except Exception as e:
+                    self.logger.warning(f"Could not show POD overlay: {e}")
+        self._pending_pod_result = None
+
+    def _on_pod_cancelled(self):
+        if self.pod_thread and self.pod_thread.isRunning():
+            self.pod_thread.terminate()
+            self.pod_thread.wait()
+        if self.pod_progress_dialog and self.pod_progress_dialog.isVisible():
+            self.pod_progress_dialog.reject()
+        if hasattr(self.parent, 'status_controller'):
+            self.parent.status_controller.show_toast(
+                self.tr("POD calculation cancelled"), 3000, color="#FFA726")
+
+    def _on_pod_error(self, error_message):
+        if self.pod_progress_dialog and self.pod_progress_dialog.isVisible():
+            self.pod_progress_dialog.reject()
+        self.logger.error(f"POD export error: {error_message}")
+        QMessageBox.critical(
+            self.parent, self.tr("POD Error"),
+            self.tr("POD calculation failed:\n{error}").format(error=error_message))
 
     def _export_to_caltopo(self, include_locations, include_images_without_flagged_aois, include_flagged_aois, include_coverage, include_images=True):
         """

--- a/app/core/services/coverage/CoveragePodService.py
+++ b/app/core/services/coverage/CoveragePodService.py
@@ -13,6 +13,7 @@ over unchanged.
 """
 
 import math
+import time
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -59,6 +60,7 @@ class CoveragePodService:
         meters_per_unit = 1.0
         cell_size_3857 = self.params.grid_res_m
         processed = 0
+        timings = {'geom': 0.0, 'dem': 0.0, 'canopy': 0.0, 'kernel': 0.0}
 
         for idx, image in enumerate(images):
             if cancel_check and cancel_check():
@@ -74,7 +76,9 @@ class CoveragePodService:
                 continue
 
             try:
+                t0 = time.perf_counter()
                 fg = self._frame_geometry(image)
+                t_geom = time.perf_counter() - t0
                 if fg is None:
                     skipped.append((name, SKIP_NO_POSE))
                     continue
@@ -88,13 +92,17 @@ class CoveragePodService:
                     accumulator = MissionAccumulator(cell_size_3857, self.params, self.logger)
 
                 spec = compute_frame_spec(fg, self.params, cell_size_3857)
+                t0 = time.perf_counter()
                 dem_sample = self.terrain.sample_grid_spec(spec)
+                t_dem = time.perf_counter() - t0
                 if dem_sample is None:
                     skipped.append((name, SKIP_NO_DEM))
                     continue
                 dem = dem_sample.data
 
+                t0 = time.perf_counter()
                 chm, cover = self._sample_canopy(spec)
+                t_canopy = time.perf_counter() - t0
 
                 cam_x, cam_y = lonlat_to_mercator(fg.lon, fg.lat)
                 nadir_elev = dem_sample.sample_bilinear(cam_x, cam_y)
@@ -108,6 +116,7 @@ class CoveragePodService:
                 fg.cam_elev_m = cam_z
                 cam_xyz = (cam_x, cam_y, cam_z)
 
+                t0 = time.perf_counter()
                 mask, gsd = compute_target_mask_and_gsd(
                     dem, spec, fg, cam_xyz, self.params, meters_per_unit)
                 if not mask.any():
@@ -117,6 +126,7 @@ class CoveragePodService:
                 pod, factor = frame_pod_kernel(
                     dem, chm, cover, spec.transform, cam_xyz, mask, gsd,
                     self.params, meters_per_unit=meters_per_unit, return_factors=True)
+                t_kernel = time.perf_counter() - t0
 
                 placed = accumulator.add_frame(
                     idx, pod, spec, fg.yaw_deg, fg.pitch_deg, fg.bearing_confidence,
@@ -127,9 +137,25 @@ class CoveragePodService:
 
                 cam_points.append((cam_x, cam_y))
                 processed += 1
+
+                timings['geom'] += t_geom
+                timings['dem'] += t_dem
+                timings['canopy'] += t_canopy
+                timings['kernel'] += t_kernel
+                if processed <= 3 or processed % 25 == 0:
+                    self.logger.info(
+                        f"POD frame '{name}' ({dem.shape[1]}x{dem.shape[0]} cells): "
+                        f"geom={t_geom * 1000:.0f}ms dem={t_dem * 1000:.0f}ms "
+                        f"canopy={t_canopy * 1000:.0f}ms kernel={t_kernel * 1000:.0f}ms")
             except Exception as e:
                 self.logger.error(f"POD frame '{name}' failed: {e}")
                 skipped.append((name, SKIP_ERROR))
+
+        if processed:
+            self.logger.info(
+                f"POD timing totals over {processed} frames: "
+                f"geom={timings['geom']:.1f}s dem={timings['dem']:.1f}s "
+                f"canopy={timings['canopy']:.1f}s kernel={timings['kernel']:.1f}s")
 
         if accumulator is None:
             return self._empty_result(processed, skipped)
@@ -165,9 +191,26 @@ class CoveragePodService:
         path = image.get('path', '')
         if not path:
             return None
+        # Read metadata cheaply: piexif for EXIF and the direct byte-parser for
+        # XMP, so we never spawn one ExifTool process per image (the dominant
+        # per-frame cost over a large mission).
+        from helpers.MetaDataHelper import MetaDataHelper
+        from helpers.LocationInfo import LocationInfo
+        exif_data = MetaDataHelper.get_exif_data_piexif(path)
+        fg = self._build_frame_geometry(image, path, exif_data,
+                                        MetaDataHelper.get_xmp_data_direct(path))
+        # Safety net: if the fast XMP parse missed pose/AGL for a GPS-tagged image,
+        # retry that one image with the full (ExifTool) reader before giving up.
+        if fg is None and LocationInfo.get_gps(exif_data=exif_data):
+            fg = self._build_frame_geometry(image, path, exif_data,
+                                            MetaDataHelper.get_xmp_data_merged(path))
+        return fg
+
+    def _build_frame_geometry(self, image, path, exif_data, xmp_data):
         svc = ImageService(path, image.get('mask_path', ''),
                            img_array=_DUMMY_IMG,
-                           calculated_bearing=image.get('bearing'))
+                           calculated_bearing=image.get('bearing'),
+                           exif_data=exif_data, xmp_data=xmp_data)
         # Drop the dummy pixels so FrameGeometry reads image size from EXIF
         # (frames never need the decoded pixels -> skip the 20 MP decode cost).
         svc.img_array = None

--- a/app/core/services/coverage/CoveragePodService.py
+++ b/app/core/services/coverage/CoveragePodService.py
@@ -1,0 +1,238 @@
+"""
+CoveragePodService - orchestrate the per-frame POD pipeline onto a mission grid.
+
+For each image: collect FrameGeometry, sample the DEM (and canopy) to the frame's
+lattice-snapped EPSG:3857 grid, resolve camera elevation by the datum rule
+(DEM(nadir) + AGL), ray-march the per-frame POD, and accumulate. Finalize
+combines angular bins, polygonizes coverage gaps, and assembles stats.
+
+Return conventions mirror ``CoverageExtentService.calculate_coverage_extents``
+(progress_callback(current, total, message), cancel_check() -> bool, a
+``cancelled`` result) so the existing coordinator-worker/export wiring carries
+over unchanged.
+"""
+
+import math
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from core.services.LoggerService import LoggerService
+from core.services.image.ImageService import ImageService
+from core.services.terrain.grid import lonlat_to_mercator, mercator_units_per_meter
+from core.services.coverage.params import PodParams
+from core.services.coverage.accumulator import MissionAccumulator
+from core.services.coverage.kernel import compute_frame_spec, compute_target_mask_and_gsd, frame_pod_kernel
+from core.services.coverage.writers import compute_gap_polygons, build_stats
+from core.services.coverage.contracts import (
+    CoverageResult,
+    SKIP_HIDDEN,
+    SKIP_NO_POSE,
+    SKIP_PITCH_TOO_SHALLOW,
+    SKIP_NO_DEM,
+    SKIP_NO_DEM_AT_NADIR,
+    SKIP_EMPTY_FOOTPRINT,
+    SKIP_OUTSIDE_BUDGET,
+    SKIP_ERROR,
+)
+
+_DUMMY_IMG = np.zeros((1, 1, 3), dtype=np.uint8)
+_FINALIZE_TICKS = 2
+
+
+class CoveragePodService:
+    def __init__(self, terrain, canopy=None, params: Optional[PodParams] = None,
+                 custom_altitude_ft: Optional[float] = None,
+                 logger: Optional[LoggerService] = None):
+        self.terrain = terrain
+        self.canopy = canopy
+        self.params = params or PodParams()
+        self.custom_altitude_ft = custom_altitude_ft
+        self.logger = logger or LoggerService()
+
+    def calculate(self, images: List[Dict[str, Any]], progress_callback=None,
+                  cancel_check=None) -> CoverageResult:
+        total = len(images)
+        skipped = []
+        accumulator = None
+        cam_points = []
+        meters_per_unit = 1.0
+        cell_size_3857 = self.params.grid_res_m
+        processed = 0
+
+        for idx, image in enumerate(images):
+            if cancel_check and cancel_check():
+                return self._cancelled_result(processed, skipped)
+            if progress_callback:
+                name = image.get('name', f"Image {idx + 1}")
+                progress_callback(idx, total + _FINALIZE_TICKS,
+                                  f"Calculating POD for {name}...")
+
+            name = image.get('name', str(idx))
+            if image.get('hidden', False):
+                skipped.append((name, SKIP_HIDDEN))
+                continue
+
+            try:
+                fg = self._frame_geometry(image)
+                if fg is None:
+                    skipped.append((name, SKIP_NO_POSE))
+                    continue
+                if fg.pitch_deg > self.params.min_pitch_deg:
+                    skipped.append((name, SKIP_PITCH_TOO_SHALLOW))
+                    continue
+
+                if accumulator is None:
+                    meters_per_unit = math.cos(math.radians(fg.lat))
+                    cell_size_3857 = self.params.grid_res_m * mercator_units_per_meter(fg.lat)
+                    accumulator = MissionAccumulator(cell_size_3857, self.params, self.logger)
+
+                spec = compute_frame_spec(fg, self.params, cell_size_3857)
+                dem_sample = self.terrain.sample_grid_spec(spec)
+                if dem_sample is None:
+                    skipped.append((name, SKIP_NO_DEM))
+                    continue
+                dem = dem_sample.data
+
+                chm, cover = self._sample_canopy(spec)
+
+                cam_x, cam_y = lonlat_to_mercator(fg.lon, fg.lat)
+                nadir_elev = dem_sample.sample_bilinear(cam_x, cam_y)
+                if nadir_elev is None or math.isnan(nadir_elev):
+                    finite = dem[np.isfinite(dem)]
+                    if finite.size == 0:
+                        skipped.append((name, SKIP_NO_DEM_AT_NADIR))
+                        continue
+                    nadir_elev = float(np.median(finite))
+                cam_z = nadir_elev + fg.agl_m
+                fg.cam_elev_m = cam_z
+                cam_xyz = (cam_x, cam_y, cam_z)
+
+                mask, gsd = compute_target_mask_and_gsd(
+                    dem, spec, fg, cam_xyz, self.params, meters_per_unit)
+                if not mask.any():
+                    skipped.append((name, SKIP_EMPTY_FOOTPRINT))
+                    continue
+
+                pod, factor = frame_pod_kernel(
+                    dem, chm, cover, spec.transform, cam_xyz, mask, gsd,
+                    self.params, meters_per_unit=meters_per_unit, return_factors=True)
+
+                placed = accumulator.add_frame(
+                    idx, pod, spec, fg.yaw_deg, fg.pitch_deg, fg.bearing_confidence,
+                    frame_factor=factor)
+                if not placed:
+                    skipped.append((name, SKIP_OUTSIDE_BUDGET))
+                    continue
+
+                cam_points.append((cam_x, cam_y))
+                processed += 1
+            except Exception as e:
+                self.logger.error(f"POD frame '{name}' failed: {e}")
+                skipped.append((name, SKIP_ERROR))
+
+        if accumulator is None:
+            return self._empty_result(processed, skipped)
+
+        if progress_callback:
+            progress_callback(total, total + _FINALIZE_TICKS,
+                              "Combining looks across angles...")
+        pod, look_count, limiting, frame_index, transform = accumulator.finalize()
+        if cancel_check and cancel_check():
+            return self._cancelled_result(processed, skipped)
+
+        if progress_callback:
+            progress_callback(total + 1, total + _FINALIZE_TICKS,
+                              "Finding coverage gaps...")
+        hull = self._flight_hull(cam_points)
+        gaps = compute_gap_polygons(pod, look_count, transform, hull,
+                                    self.params.gap_threshold)
+        stats = build_stats(
+            pod, look_count, transform, skipped, gaps, self.params,
+            canopy_source=self._canopy_source_name(),
+            terrain_info=self._terrain_info(),
+            generated_at=self._now_iso())
+
+        return CoverageResult(
+            pod=pod, look_count=look_count, transform=transform,
+            image_count=processed, skipped=skipped, stats=stats,
+            gap_polygons=gaps, cancelled=False, limiting_factor=limiting,
+            frame_index=frame_index, params=self.params)
+
+    # ---- helpers ----
+
+    def _frame_geometry(self, image):
+        path = image.get('path', '')
+        if not path:
+            return None
+        svc = ImageService(path, image.get('mask_path', ''),
+                           img_array=_DUMMY_IMG,
+                           calculated_bearing=image.get('bearing'))
+        # Drop the dummy pixels so FrameGeometry reads image size from EXIF
+        # (frames never need the decoded pixels -> skip the 20 MP decode cost).
+        svc.img_array = None
+        return svc.get_frame_geometry(
+            custom_altitude_ft=self.custom_altitude_ft,
+            bearing_quality=image.get('bearing_quality'),
+            agl_override_ft=image.get('wingtra_agl_ft'))
+
+    def _sample_canopy(self, spec):
+        if self.canopy is None:
+            return None, None
+        try:
+            sample = self.canopy.sample_grid_spec(spec)
+        except Exception as e:
+            self.logger.warning(f"Canopy sample failed: {e}")
+            return None, None
+        if sample is None:
+            return None, None
+        return getattr(sample, 'chm', None), getattr(sample, 'cover', None)
+
+    def _flight_hull(self, cam_points):
+        if len(cam_points) < 3:
+            return None
+        try:
+            from shapely.geometry import MultiPoint
+            return MultiPoint(cam_points).convex_hull
+        except Exception:
+            return None
+
+    def _canopy_source_name(self):
+        if self.canopy is None:
+            return "none"
+        return getattr(self.canopy, 'source_name', 'canopy')
+
+    def _terrain_info(self):
+        try:
+            return self.terrain.provider.get_datum_info()
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _now_iso():
+        import datetime
+        return datetime.datetime.now().isoformat(timespec="seconds")
+
+    def _empty_result(self, processed, skipped):
+        from affine import Affine
+        empty = np.zeros((0, 0), dtype=np.float32)
+        return CoverageResult(
+            pod=empty, look_count=empty.astype(np.uint16), transform=Affine.identity(),
+            image_count=processed, skipped=skipped,
+            stats={"skipped_counts": self._reason_counts(skipped)},
+            gap_polygons=[], cancelled=False, params=self.params)
+
+    def _cancelled_result(self, processed, skipped):
+        from affine import Affine
+        empty = np.zeros((0, 0), dtype=np.float32)
+        return CoverageResult(
+            pod=empty, look_count=empty.astype(np.uint16), transform=Affine.identity(),
+            image_count=processed, skipped=skipped, stats={}, gap_polygons=[],
+            cancelled=True, params=self.params)
+
+    @staticmethod
+    def _reason_counts(skipped):
+        counts = {}
+        for _, r in skipped:
+            counts[r] = counts.get(r, 0) + 1
+        return counts

--- a/app/core/services/coverage/CoverageResultCache.py
+++ b/app/core/services/coverage/CoverageResultCache.py
@@ -1,0 +1,23 @@
+"""
+CoverageResultCache - in-session cache for the last CoveragePodService run.
+
+Mirrors the HeatmapService lifecycle idiom (is-valid / get / invalidate) so the
+viewer overlay can re-render the cached POD product without recomputing.
+"""
+
+
+class CoverageResultCache:
+    def __init__(self):
+        self._result = None
+
+    def set_result(self, result) -> None:
+        self._result = result
+
+    def get_result(self):
+        return self._result
+
+    def has_result(self) -> bool:
+        return self._result is not None
+
+    def invalidate(self) -> None:
+        self._result = None

--- a/app/core/services/coverage/__init__.py
+++ b/app/core/services/coverage/__init__.py
@@ -1,0 +1,79 @@
+"""
+Coverage / Probability-of-Detection (POD) module.
+
+Per-frame POD grids (terrain visibility x canopy transmittance x GSD adequacy)
+accumulated onto a mission-wide EPSG:3857 grid. See the module design spec.
+"""
+
+from .params import PodParams
+from .contracts import (
+    CoverageResult,
+    FrameIndex,
+    SKIP_HIDDEN,
+    SKIP_NO_POSE,
+    SKIP_PITCH_TOO_SHALLOW,
+    SKIP_NO_DEM,
+    SKIP_NO_DEM_AT_NADIR,
+    SKIP_EMPTY_FOOTPRINT,
+    SKIP_OUTSIDE_BUDGET,
+    SKIP_ERROR,
+    LIMIT_NO_LOOKS,
+    LIMIT_TERRAIN,
+    LIMIT_CANOPY,
+    LIMIT_GSD,
+    LIMIT_NONE,
+)
+from .kernel import (
+    build_camera_rotation,
+    project_footprint_corners,
+    compute_frame_spec,
+    compute_target_mask_and_gsd,
+    frame_pod_kernel,
+)
+from .accumulator import MissionAccumulator
+from .colormap import pod_to_rgba, look_count_to_rgba
+from .writers import (
+    write_pod_geotiff,
+    write_looks_geotiff,
+    compute_gap_polygons,
+    write_gaps_geojson,
+    build_stats,
+    write_all_outputs,
+)
+from .CoveragePodService import CoveragePodService
+from .CoverageResultCache import CoverageResultCache
+
+__all__ = [
+    'PodParams',
+    'CoverageResult',
+    'FrameIndex',
+    'SKIP_HIDDEN',
+    'SKIP_NO_POSE',
+    'SKIP_PITCH_TOO_SHALLOW',
+    'SKIP_NO_DEM',
+    'SKIP_NO_DEM_AT_NADIR',
+    'SKIP_EMPTY_FOOTPRINT',
+    'SKIP_OUTSIDE_BUDGET',
+    'SKIP_ERROR',
+    'LIMIT_NO_LOOKS',
+    'LIMIT_TERRAIN',
+    'LIMIT_CANOPY',
+    'LIMIT_GSD',
+    'LIMIT_NONE',
+    'build_camera_rotation',
+    'project_footprint_corners',
+    'compute_frame_spec',
+    'compute_target_mask_and_gsd',
+    'frame_pod_kernel',
+    'MissionAccumulator',
+    'pod_to_rgba',
+    'look_count_to_rgba',
+    'write_pod_geotiff',
+    'write_looks_geotiff',
+    'compute_gap_polygons',
+    'write_gaps_geojson',
+    'build_stats',
+    'write_all_outputs',
+    'CoveragePodService',
+    'CoverageResultCache',
+]

--- a/app/core/services/coverage/__init__.py
+++ b/app/core/services/coverage/__init__.py
@@ -42,6 +42,12 @@ from .writers import (
 )
 from .CoveragePodService import CoveragePodService
 from .CoverageResultCache import CoverageResultCache
+from .aoi import (
+    estimate_download_aoi,
+    compute_mission_gps_bounds,
+    suggest_buffer_m,
+    pad_bounds,
+)
 
 __all__ = [
     'PodParams',
@@ -76,4 +82,8 @@ __all__ = [
     'write_all_outputs',
     'CoveragePodService',
     'CoverageResultCache',
+    'estimate_download_aoi',
+    'compute_mission_gps_bounds',
+    'suggest_buffer_m',
+    'pad_bounds',
 ]

--- a/app/core/services/coverage/accumulator.py
+++ b/app/core/services/coverage/accumulator.py
@@ -1,0 +1,192 @@
+"""
+MissionAccumulator - combine per-frame POD grids onto a mission-wide grid.
+
+Holds one running-max POD grid per angular bin (looks from the same view
+direction do not compound), a uint16 look-count, a coarse frame index, and a
+best-look limiting-factor grid. The mission grid grows lazily on the shared
+EPSG:3857 lattice (frames are integer-offset co-registered), clamped by a memory
+budget. ``finalize`` combines the bins:
+
+    POD = C * (1 - prod_b (1 - bin_b))
+
+The mission grid is snapped to a coarse ``cell_size * frame_index_block`` lattice
+so growth always shifts the origin by whole frame-index blocks, keeping the
+coarse frame index exactly re-keyable.
+"""
+
+import math
+
+import numpy as np
+
+from core.services.LoggerService import LoggerService
+from core.services.terrain.grid import (
+    GridSpec,
+    make_lattice_spec,
+    integer_offset,
+    WEB_MERCATOR_CRS,
+)
+from core.services.coverage.contracts import FrameIndex, LIMIT_NO_LOOKS
+
+# float32 bins (n) + uint16 look + uint8 factor + float32 best_pod per cell.
+_BYTES_PER_CELL_BASE = 2 + 1 + 4  # look + factor + best_pod
+
+
+class MissionAccumulator:
+    def __init__(self, cell_size_3857: float, params, logger=None):
+        self.cell_size = float(cell_size_3857)
+        self.params = params
+        self.logger = logger or LoggerService()
+        self.n_bins = int(params.angle_bins)
+        self.block = int(params.frame_index_block)
+        self._spec = None
+        self._bins = None          # (n_bins, H, W) float32
+        self._look = None          # (H, W) uint16
+        self._best_pod = None      # (H, W) float32
+        self._best_factor = None   # (H, W) uint8
+        self._frame_index = FrameIndex(self.block, params.frame_index_max_per_block)
+
+    @staticmethod
+    def bin_for_frame(yaw_deg: float, pitch_deg: float, params) -> int:
+        """Angular bin: 4 azimuth quadrants x {nadir, oblique}."""
+        off_nadir = 90.0 + pitch_deg              # 0 at nadir (pitch -90)
+        ring = 0 if off_nadir <= params.nadir_split_deg else 1
+        quad = int((((yaw_deg % 360.0) + 45.0) % 360.0) // 90.0)
+        return ring * 4 + quad
+
+    def _bytes_per_cell(self) -> int:
+        return self.n_bins * 4 + _BYTES_PER_CELL_BASE
+
+    def _budget_ok(self, spec: GridSpec) -> bool:
+        need = spec.width * spec.height * self._bytes_per_cell()
+        return need <= self.params.mem_budget_mb * 1_000_000
+
+    def _snap_mission(self, bounds) -> GridSpec:
+        """Snap bounds outward to the coarse cell*block lattice, as a cell-sized spec."""
+        coarse = self.cell_size * self.block
+        minx, miny, maxx, maxy = bounds
+        left = math.floor(minx / coarse) * coarse
+        right = math.ceil(maxx / coarse) * coarse
+        bottom = math.floor(miny / coarse) * coarse
+        top = math.ceil(maxy / coarse) * coarse
+        return make_lattice_spec((left, bottom, right, top), self.cell_size,
+                                 crs=WEB_MERCATOR_CRS)
+
+    def _allocate(self, spec: GridSpec):
+        H, W = spec.height, spec.width
+        self._spec = spec
+        self._bins = np.zeros((self.n_bins, H, W), dtype=np.float32)
+        self._look = np.zeros((H, W), dtype=np.uint16)
+        self._best_pod = np.zeros((H, W), dtype=np.float32)
+        self._best_factor = np.zeros((H, W), dtype=np.uint8)
+
+    def _contains(self, frame_spec: GridSpec) -> bool:
+        try:
+            r0, c0 = integer_offset(frame_spec, self._spec)
+        except ValueError:
+            return False
+        return (r0 >= 0 and c0 >= 0
+                and r0 + frame_spec.height <= self._spec.height
+                and c0 + frame_spec.width <= self._spec.width)
+
+    def _grow_to_union(self, frame_spec: GridSpec) -> bool:
+        """Grow to cover ``frame_spec`` (+ a one-frame margin in each growing
+        direction). Returns False if that would exceed the memory budget."""
+        ominx, ominy, omaxx, omaxy = self._spec.bounds
+        fminx, fminy, fmaxx, fmaxy = frame_spec.bounds
+        mx = fmaxx - fminx
+        my = fmaxy - fminy
+        new_minx = min(ominx, fminx - mx)
+        new_miny = min(ominy, fminy - my)
+        new_maxx = max(omaxx, fmaxx + mx)
+        new_maxy = max(omaxy, fmaxy + my)
+        new_spec = self._snap_mission((new_minx, new_miny, new_maxx, new_maxy))
+        if not self._budget_ok(new_spec):
+            self.logger.warning(
+                f"MissionAccumulator: growth to {new_spec.width}x{new_spec.height} "
+                f"exceeds {self.params.mem_budget_mb} MB budget; frame skipped."
+            )
+            return False
+
+        r0, c0 = integer_offset(self._spec, new_spec)  # block-aligned by construction
+        H, W = new_spec.height, new_spec.width
+        oh, ow = self._spec.height, self._spec.width
+
+        bins = np.zeros((self.n_bins, H, W), dtype=np.float32)
+        look = np.zeros((H, W), dtype=np.uint16)
+        best_pod = np.zeros((H, W), dtype=np.float32)
+        best_factor = np.zeros((H, W), dtype=np.uint8)
+        bins[:, r0:r0 + oh, c0:c0 + ow] = self._bins
+        look[r0:r0 + oh, c0:c0 + ow] = self._look
+        best_pod[r0:r0 + oh, c0:c0 + ow] = self._best_pod
+        best_factor[r0:r0 + oh, c0:c0 + ow] = self._best_factor
+
+        # r0/c0 are whole blocks (coarse-lattice mission origins), so the coarse
+        # frame index re-keys by an exact block shift.
+        self._frame_index.shift_origin(r0 // self.block, c0 // self.block)
+
+        self._spec = new_spec
+        self._bins = bins
+        self._look = look
+        self._best_pod = best_pod
+        self._best_factor = best_factor
+        return True
+
+    def add_frame(self, frame_idx: int, frame_pod: np.ndarray, frame_spec: GridSpec,
+                  yaw_deg: float, pitch_deg: float, bearing_confidence: float,
+                  frame_factor=None) -> bool:
+        """Apply per-frame policy (cap + low-confidence haircut) and accumulate.
+
+        Returns False when the frame falls outside the memory-budget-clamped grid.
+        """
+        capped = np.minimum(frame_pod, self.params.pod_frame_cap)
+        if bearing_confidence < 0.5:
+            capped = capped * self.params.low_confidence_haircut
+
+        if self._spec is None:
+            self._allocate(self._snap_mission(frame_spec.bounds))
+        if not self._contains(frame_spec):
+            if not self._grow_to_union(frame_spec):
+                return False
+
+        r0, c0 = integer_offset(frame_spec, self._spec)
+        h, w = frame_pod.shape
+        b = self.bin_for_frame(yaw_deg, pitch_deg, self.params)
+
+        bin_view = self._bins[b, r0:r0 + h, c0:c0 + w]
+        np.maximum(bin_view, capped, out=bin_view)
+
+        pos = frame_pod > 0
+        look_view = self._look[r0:r0 + h, c0:c0 + w]
+        look_view[pos] += 1
+
+        best_view = self._best_pod[r0:r0 + h, c0:c0 + w]
+        better = capped > best_view
+        best_view[better] = capped[better]
+        if frame_factor is not None:
+            fac_view = self._best_factor[r0:r0 + h, c0:c0 + w]
+            fac_view[better] = frame_factor[better]
+
+        self._frame_index.add(frame_idx, r0, c0, pos)
+        return True
+
+    def finalize(self):
+        """Combine bins into the mission POD product.
+
+        Returns (pod float32, look_count uint16, limiting_factor uint8,
+        frame_index, transform). Empty 0x0 arrays if nothing accumulated.
+        """
+        if self._spec is None:
+            from affine import Affine
+            empty = np.zeros((0, 0), dtype=np.float32)
+            return (empty, empty.astype(np.uint16), empty.astype(np.uint8),
+                    self._frame_index, Affine.identity())
+
+        acc = np.ones(self._bins.shape[1:], dtype=np.float64)
+        for b in range(self.n_bins):
+            acc *= (1.0 - self._bins[b])
+        pod = (self.params.common_mode_ceiling * (1.0 - acc)).astype(np.float32)
+
+        limiting = self._best_factor.copy()
+        limiting[self._look == 0] = LIMIT_NO_LOOKS
+
+        return pod, self._look, limiting, self._frame_index, self._spec.transform

--- a/app/core/services/coverage/aoi.py
+++ b/app/core/services/coverage/aoi.py
@@ -1,0 +1,116 @@
+"""
+aoi - derive a download area-of-interest from a mission's images.
+
+Reads each image's EXIF GPS to bound the camera positions, and sizes a buffer
+that covers the image footprints (which extend past the nadir points, especially
+for oblique frames) by reusing the POD kernel's flat-plane footprint projection.
+Service layer only (no Qt).
+"""
+
+import math
+
+from core.services.LoggerService import LoggerService
+from core.services.coverage.params import PodParams
+
+_logger = LoggerService()
+_DEFAULT_BUFFER_M = 500.0
+_MIN_BUFFER_M = 100.0
+
+
+def _image_path(image):
+    if isinstance(image, dict):
+        return image.get('path', '')
+    return str(image) if image else ''
+
+
+def image_gps(path):
+    """(lat, lon) from an image's EXIF GPS, or None."""
+    if not path:
+        return None
+    try:
+        from helpers.MetaDataHelper import MetaDataHelper
+        from helpers.LocationInfo import LocationInfo
+        exif = MetaDataHelper.get_exif_data_piexif(path)
+        gps = LocationInfo.get_gps(exif_data=exif)
+        if gps:
+            return gps['latitude'], gps['longitude']
+    except Exception:
+        pass
+    return None
+
+
+def compute_mission_gps_bounds(images):
+    """(min_lon, min_lat, max_lon, max_lat) over all image GPS, or None."""
+    lons, lats = [], []
+    for image in images:
+        gps = image_gps(_image_path(image))
+        if gps is not None:
+            lats.append(gps[0])
+            lons.append(gps[1])
+    if not lats:
+        return None
+    return (min(lons), min(lats), max(lons), max(lats))
+
+
+def _frame_geometry(path):
+    """FrameGeometry for one image without decoding its pixels, or None."""
+    try:
+        import numpy as np
+        from core.services.image.ImageService import ImageService
+        svc = ImageService(path, '', img_array=np.zeros((1, 1, 3), dtype=np.uint8))
+        svc.img_array = None
+        return svc.get_frame_geometry()
+    except Exception:
+        return None
+
+
+def suggest_buffer_m(images, params=None, sample_limit=24):
+    """Suggest a buffer (meters) covering image footprints.
+
+    Samples up to ``sample_limit`` images evenly across the mission, projects
+    each footprint, and takes the largest reach (capped at ``max_range_m``).
+    """
+    params = params or PodParams()
+    from core.services.coverage.kernel import project_footprint_corners
+
+    paths = [p for p in (_image_path(i) for i in images) if p]
+    if not paths:
+        return _DEFAULT_BUFFER_M
+    step = max(1, len(paths) // max(1, sample_limit))
+    sampled = paths[::step][:sample_limit]
+
+    reaches = []
+    for path in sampled:
+        fg = _frame_geometry(path)
+        if fg is None:
+            continue
+        try:
+            corners = project_footprint_corners(fg, params)
+            reaches.append(max(math.hypot(e, n) for e, n in corners))
+        except Exception:
+            continue
+    if not reaches:
+        return _DEFAULT_BUFFER_M
+    buffer_m = max(reaches)
+    buffer_m = min(buffer_m, params.max_range_m)
+    buffer_m = max(buffer_m, _MIN_BUFFER_M)
+    # Round up to a tidy 50 m step.
+    return math.ceil(buffer_m / 50.0) * 50.0
+
+
+def pad_bounds(bounds_wgs84, buffer_m):
+    """Expand a WGS84 bbox outward by ``buffer_m`` meters on all sides."""
+    min_lon, min_lat, max_lon, max_lat = bounds_wgs84
+    mid_lat = (min_lat + max_lat) / 2.0
+    dlat = buffer_m / 111320.0
+    dlon = buffer_m / (111320.0 * max(0.05, math.cos(math.radians(mid_lat))))
+    return (min_lon - dlon, min_lat - dlat, max_lon + dlon, max_lat + dlat)
+
+
+def estimate_download_aoi(images, params=None, sample_limit=24):
+    """(padded_bounds, raw_bounds, buffer_m) for a mission, or None if no GPS."""
+    raw = compute_mission_gps_bounds(images)
+    if raw is None:
+        return None
+    buffer_m = suggest_buffer_m(images, params=params, sample_limit=sample_limit)
+    return pad_bounds(raw, buffer_m), raw, buffer_m

--- a/app/core/services/coverage/colormap.py
+++ b/app/core/services/coverage/colormap.py
@@ -1,0 +1,67 @@
+"""
+colormap - shared RGBA lookup tables for the POD / look-count products.
+
+One hand-rolled viridis LUT feeds both the GeoTIFF writer and the in-viewer
+overlay, so the two products are pixel-identical. Viridis is perceptually
+uniform and colorblind-safe, and its bright high end reads well over dark
+satellite basemaps; the dark low end is neutralized by the alpha ramp. No
+matplotlib dependency (viridis control points are inlined).
+"""
+
+import numpy as np
+
+# Standard viridis control points (t, r, g, b).
+_VIRIDIS_ANCHORS = [
+    (0.00, 68, 1, 84),
+    (0.25, 59, 82, 139),
+    (0.50, 33, 145, 140),
+    (0.75, 94, 201, 98),
+    (1.00, 253, 231, 37),
+]
+
+# Discrete look-count -> RGBA steps (>=5 saturates to the last).
+_LOOKS_STEPS = [
+    (255, 245, 157, 140),  # 1 look
+    (174, 213, 129, 160),  # 2
+    (77, 182, 172, 175),   # 3
+    (66, 165, 245, 190),   # 4
+    (94, 53, 177, 205),    # 5+
+]
+
+
+def _build_pod_lut(display_floor: float) -> np.ndarray:
+    """(256, 4) uint8 RGBA. Index = round(pod * 255). Alpha 0 below the floor,
+    then a 90->200 ramp above it."""
+    lut = np.zeros((256, 4), dtype=np.uint8)
+    t = np.linspace(0.0, 1.0, 256)
+    xs = [a[0] for a in _VIRIDIS_ANCHORS]
+    for ch in range(3):
+        ys = [a[1 + ch] for a in _VIRIDIS_ANCHORS]
+        lut[:, ch] = np.clip(np.interp(t, xs, ys), 0, 255).astype(np.uint8)
+    floor_i = int(round(max(0.0, min(1.0, display_floor)) * 255))
+    alpha = np.zeros(256, dtype=np.float64)
+    if floor_i < 255:
+        alpha[floor_i:] = np.linspace(90, 200, 256 - floor_i)
+    lut[:, 3] = alpha.astype(np.uint8)
+    return lut
+
+
+def pod_to_rgba(pod: np.ndarray, look_count: np.ndarray, params) -> np.ndarray:
+    """float32 POD grid -> (H, W, 4) uint8 RGBA; fully transparent where
+    look_count == 0."""
+    lut = _build_pod_lut(params.pod_display_floor)
+    idx = np.clip(np.round(np.nan_to_num(pod, nan=0.0) * 255.0), 0, 255).astype(np.uint8)
+    rgba = lut[idx]
+    rgba[look_count == 0] = 0
+    return rgba
+
+
+def look_count_to_rgba(look_count: np.ndarray) -> np.ndarray:
+    """uint16 look-count grid -> (H, W, 4) uint8 RGBA (discrete, transparent at 0)."""
+    H, W = look_count.shape
+    rgba = np.zeros((H, W, 4), dtype=np.uint8)
+    lc = np.clip(look_count.astype(np.int32), 0, len(_LOOKS_STEPS))
+    for n, color in enumerate(_LOOKS_STEPS, start=1):
+        sel = (lc == n) if n < len(_LOOKS_STEPS) else (lc >= n)
+        rgba[sel] = color
+    return rgba

--- a/app/core/services/coverage/colormap.py
+++ b/app/core/services/coverage/colormap.py
@@ -19,6 +19,15 @@ _VIRIDIS_ANCHORS = [
     (1.00, 253, 231, 37),
 ]
 
+# Sequential light->dark green ramp for the canopy-height overlay
+# (t = height / max_height_m).
+_CANOPY_ANCHORS = [
+    (0.00, 247, 252, 185),  # grass / very low vegetation: pale yellow-green
+    (0.35, 120, 198, 121),  # shrub / young trees
+    (0.70, 35, 132, 67),    # mature canopy
+    (1.00, 0, 60, 30),      # tall timber
+]
+
 # Discrete look-count -> RGBA steps (>=5 saturates to the last).
 _LOOKS_STEPS = [
     (255, 245, 157, 140),  # 1 look
@@ -53,6 +62,26 @@ def pod_to_rgba(pod: np.ndarray, look_count: np.ndarray, params) -> np.ndarray:
     idx = np.clip(np.round(np.nan_to_num(pod, nan=0.0) * 255.0), 0, 255).astype(np.uint8)
     rgba = lut[idx]
     rgba[look_count == 0] = 0
+    return rgba
+
+
+def chm_to_rgba(chm: np.ndarray, max_height_m: float = 35.0,
+                min_height_m: float = 0.5) -> np.ndarray:
+    """float canopy-height grid (meters) -> (H, W, 4) uint8 RGBA.
+
+    Transparent where the height is NaN or below ``min_height_m`` (open ground,
+    roads), then a light->dark green ramp saturating at ``max_height_m`` with
+    alpha rising alongside height so tall canopy reads strongest.
+    """
+    h = np.nan_to_num(np.asarray(chm, dtype=np.float32), nan=0.0)
+    t = np.clip(h / max(max_height_m, 1e-6), 0.0, 1.0)
+    rgba = np.zeros(t.shape + (4,), dtype=np.uint8)
+    xs = [a[0] for a in _CANOPY_ANCHORS]
+    for ch in range(3):
+        ys = [a[1 + ch] for a in _CANOPY_ANCHORS]
+        rgba[..., ch] = np.clip(np.interp(t, xs, ys), 0, 255).astype(np.uint8)
+    rgba[..., 3] = (110.0 + 90.0 * t).astype(np.uint8)
+    rgba[h < min_height_m] = 0
     return rgba
 
 

--- a/app/core/services/coverage/contracts.py
+++ b/app/core/services/coverage/contracts.py
@@ -1,0 +1,118 @@
+"""
+Coverage/POD result contracts: CoverageResult, FrameIndex, and stable
+skip-reason / limiting-factor constants.
+
+Pure data + numpy/pyproj/affine only (service layer — no Qt). The mission raster
+and its metadata cross the worker->GUI boundary as a single ``CoverageResult``.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+# --- skip-reason keys (stable; recorded in stats.json/logs, translated at display) ---
+SKIP_HIDDEN = "hidden"
+SKIP_NO_POSE = "no_pose"                 # missing GPS / intrinsics / AGL
+SKIP_PITCH_TOO_SHALLOW = "pitch_too_shallow"
+SKIP_NO_DEM = "no_dem"                   # no DEM coverage for the footprint
+SKIP_NO_DEM_AT_NADIR = "no_dem_at_nadir"
+SKIP_EMPTY_FOOTPRINT = "empty_footprint"
+SKIP_OUTSIDE_BUDGET = "outside_mission_grid_budget"
+SKIP_ERROR = "error"
+
+# --- limiting-factor codes (uint8 grid produced by the accumulator) ---
+LIMIT_NO_LOOKS = 0    # never seen -> fly it
+LIMIT_TERRAIN = 1     # hard occlusion dominated
+LIMIT_CANOPY = 2      # canopy transmittance dominated
+LIMIT_GSD = 3         # resolution/adequacy dominated
+LIMIT_NONE = 4        # near cap; nothing actionable
+
+
+class FrameIndex:
+    """Coarse per-cell contributing-frame index.
+
+    Buckets ``block_cells x block_cells`` blocks of the mission grid to a list of
+    contributing frame ids (positions in the ``images`` list == viewer indices),
+    capped at ``max_per_block``. Memory is O(covered blocks), not O(cells).
+    """
+
+    def __init__(self, block_cells: int, max_per_block: int):
+        self.block_cells = int(block_cells)
+        self.max_per_block = int(max_per_block)
+        self._blocks = {}  # (block_row, block_col) -> list[int]
+
+    def _add_to_block(self, frame_idx: int, br: int, bc: int):
+        lst = self._blocks.get((br, bc))
+        if lst is None:
+            self._blocks[(br, bc)] = [frame_idx]
+            return
+        if frame_idx not in lst and len(lst) < self.max_per_block:
+            lst.append(frame_idx)
+
+    def add(self, frame_idx: int, row0: int, col0: int, any_pod_mask: np.ndarray):
+        """Record ``frame_idx`` for every block touched by ``any_pod_mask``.
+
+        ``row0``/``col0`` are the mission-grid indices of ``any_pod_mask[0, 0]``.
+        """
+        ys, xs = np.nonzero(any_pod_mask)
+        if ys.size == 0:
+            return
+        brs = (row0 + ys) // self.block_cells
+        bcs = (col0 + xs) // self.block_cells
+        for br, bc in set(zip(brs.tolist(), bcs.tolist())):
+            self._add_to_block(frame_idx, int(br), int(bc))
+
+    def shift_origin(self, row_delta_blocks: int, col_delta_blocks: int):
+        """Re-key all blocks after the mission grid grows (origin moves)."""
+        if not (row_delta_blocks or col_delta_blocks):
+            return
+        self._blocks = {
+            (br + row_delta_blocks, bc + col_delta_blocks): v
+            for (br, bc), v in self._blocks.items()
+        }
+
+    def frames_at(self, row: int, col: int) -> List[int]:
+        block = (int(row) // self.block_cells, int(col) // self.block_cells)
+        return sorted(self._blocks.get(block, []))
+
+
+@dataclass
+class CoverageResult:
+    """Mission-wide POD product (spec section 3.4 + additive UI fields)."""
+
+    pod: np.ndarray                        # float32 (rows, cols) 0-1; 0 where look_count == 0
+    look_count: np.ndarray                 # uint16
+    transform: object                      # affine.Affine, EPSG:3857 (b=d=0, a=-e)
+    image_count: int
+    skipped: List[Tuple[str, str]]         # (image_name, reason_key)
+    stats: dict
+    gap_polygons: list                     # shapely Polygons, EPSG:3857
+    cancelled: bool
+    crs: str = "EPSG:3857"
+    limiting_factor: Optional[np.ndarray] = None    # uint8, same shape as pod
+    frame_index: Optional[FrameIndex] = None
+    params: object = None
+    _transformer: object = field(default=None, repr=False, compare=False)
+
+    def sample(self, lat: float, lon: float) -> Optional[dict]:
+        """Return {'pod', 'looks', 'limiting_factor', 'frames'} at a WGS84 point.
+
+        Returns None when the point lies outside the mission grid.
+        """
+        if self._transformer is None:
+            from pyproj import Transformer
+            self._transformer = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
+        x, y = self._transformer.transform(lon, lat)
+        col, row = (~self.transform) * (x, y)
+        r, c = int(row), int(col)
+        if not (0 <= r < self.pod.shape[0] and 0 <= c < self.pod.shape[1]):
+            return None
+        frames = self.frame_index.frames_at(r, c) if self.frame_index is not None else []
+        lf = int(self.limiting_factor[r, c]) if self.limiting_factor is not None else LIMIT_NO_LOOKS
+        return {
+            "pod": float(self.pod[r, c]),
+            "looks": int(self.look_count[r, c]),
+            "limiting_factor": lf,
+            "frames": frames,
+        }

--- a/app/core/services/coverage/kernel.py
+++ b/app/core/services/coverage/kernel.py
@@ -1,0 +1,286 @@
+"""
+kernel - pure-numpy geometry for the per-frame POD grid.
+
+Contains, for one frame:
+* ``build_camera_rotation`` - the camera->NED rotation, matching
+  ``AOIService._calculate_ground_position`` exactly so footprints agree with the
+  FOV the viewer already draws.
+* ``project_footprint_corners`` / ``compute_frame_spec`` - size the frame-local
+  EPSG:3857 grid (flat-plane corners + the nadir point + a buffer).
+* ``compute_target_mask_and_gsd`` - which co-registered cells the frustum sees,
+  and the per-cell ground sample distance.
+* ``frame_pod_kernel`` - the ray-march: terrain visibility x canopy
+  transmittance x GSD adequacy (spec section 3.5).
+
+All horizontal math is in EPSG:3857 units; ``meters_per_unit = cos(lat_ref)``
+converts horizontal deltas to true ground meters (vertical is already meters).
+No Qt, no I/O, no logging side effects.
+"""
+
+import math
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from core.services.terrain.grid import (
+    GridSpec,
+    make_lattice_spec,
+    lonlat_to_mercator,
+    mercator_units_per_meter,
+    WEB_MERCATOR_CRS,
+)
+from core.services.coverage.contracts import (
+    LIMIT_TERRAIN,
+    LIMIT_CANOPY,
+    LIMIT_GSD,
+    LIMIT_NONE,
+)
+
+
+def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float) -> np.ndarray:
+    """3x3 rotation from camera frame (X=right, Y=down, Z=optical) to NED.
+
+    Mirrors ``AOIService._calculate_ground_position`` step 2 (+ Rodrigues roll
+    about the heading axis) so this kernel and the viewer FOV stay consistent.
+    """
+    opt_elevation = math.radians(pitch_deg)
+    opt_azimuth = math.radians(yaw_deg)
+
+    opt_axis_ned = np.array([
+        math.cos(opt_elevation) * math.cos(opt_azimuth),
+        math.cos(opt_elevation) * math.sin(opt_azimuth),
+        -math.sin(opt_elevation),
+    ])
+    up_ned = np.array([
+        -math.sin(opt_elevation) * math.cos(opt_azimuth),
+        -math.sin(opt_elevation) * math.sin(opt_azimuth),
+        -math.cos(opt_elevation),
+    ])
+    cam_y_ned = -up_ned
+    cam_x_ned = np.cross(opt_axis_ned, up_ned)
+    cam_x_ned = cam_x_ned / np.linalg.norm(cam_x_ned)
+
+    R = np.column_stack([cam_x_ned, cam_y_ned, opt_axis_ned])
+
+    if roll_deg != 0.0:
+        roll_rad = math.radians(roll_deg)
+        heading_axis = np.array([math.cos(opt_azimuth), math.sin(opt_azimuth), 0.0])
+        kx, ky, kz = heading_axis
+        K = np.array([
+            [0.0, -kz, ky],
+            [kz, 0.0, -kx],
+            [-ky, kx, 0.0],
+        ])
+        R_roll = np.eye(3) + math.sin(roll_rad) * K + (1.0 - math.cos(roll_rad)) * (K @ K)
+        R = R_roll @ R
+    return R
+
+
+def _frustum_half_extents(fg) -> Tuple[float, float]:
+    """(hw, hh): image half-width/half-height as tan(half-FOV) = (sensor/2)/focal."""
+    sw, sh = fg.sensor_mm
+    hw = (sw / 2.0) / fg.focal_mm
+    hh = (sh / 2.0) / fg.focal_mm
+    return hw, hh
+
+
+def project_footprint_corners(fg, params) -> List[Tuple[float, float]]:
+    """Flat-plane ground offsets (east_m, north_m) of the 4 image corners.
+
+    Rays that miss the ground (pointing up/at the horizon) or land beyond
+    ``max_range_m`` are clamped to ``max_range_m`` along their ground azimuth.
+    Used only to size the frame bbox.
+    """
+    hw, hh = _frustum_half_extents(fg)
+    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg)
+    corners = []
+    for sx in (-hw, hw):
+        for sy in (-hh, hh):
+            ray_cam = np.array([sx, sy, 1.0])
+            ray_cam = ray_cam / np.linalg.norm(ray_cam)
+            ray_ned = R @ ray_cam
+            down = ray_ned[2]
+            if down <= 1e-6:
+                # Points up/horizon: clamp along the ground azimuth of the ray.
+                az = math.atan2(ray_ned[1], ray_ned[0])
+                corners.append((math.sin(az) * params.max_range_m,
+                                math.cos(az) * params.max_range_m))
+                continue
+            t = fg.agl_m / down
+            north = ray_ned[0] * t
+            east = ray_ned[1] * t
+            ground_range = math.hypot(north, east)
+            if ground_range > params.max_range_m:
+                scale = params.max_range_m / ground_range
+                north *= scale
+                east *= scale
+            corners.append((east, north))
+    return corners
+
+
+def compute_frame_spec(fg, params, cell_size_3857: float) -> GridSpec:
+    """Lattice-snapped EPSG:3857 GridSpec covering the frame footprint.
+
+    The bbox is the hull of the nadir point and the (clamped) flat-plane
+    corners, buffered by ``footprint_buffer_m``. The nadir point is always
+    included so oblique frames' line-of-sight corridor (between camera and
+    footprint) is sampled for occlusion.
+    """
+    nadir_x, nadir_y = lonlat_to_mercator(fg.lon, fg.lat)
+    units_per_m = mercator_units_per_meter(fg.lat)
+
+    xs = [nadir_x]
+    ys = [nadir_y]
+    for east_m, north_m in project_footprint_corners(fg, params):
+        xs.append(nadir_x + east_m * units_per_m)
+        ys.append(nadir_y + north_m * units_per_m)
+
+    buf = params.footprint_buffer_m * units_per_m
+    bounds = (min(xs) - buf, min(ys) - buf, max(xs) + buf, max(ys) + buf)
+    return make_lattice_spec(bounds, cell_size_3857, crs=WEB_MERCATOR_CRS)
+
+
+def compute_target_mask_and_gsd(dem: np.ndarray, spec: GridSpec, fg,
+                                cam_xyz: Tuple[float, float, float], params,
+                                meters_per_unit: float
+                                ) -> Tuple[np.ndarray, np.ndarray]:
+    """Back-project every cell into the camera; return (mask, gsd_cm).
+
+    ``mask`` is True where the cell (at its DEM elevation) falls inside the
+    sensor frustum, within ``max_range_m``, and has finite DEM. ``gsd_cm`` is the
+    per-cell ground sample distance in centimeters (meaningful only where masked).
+    """
+    cam_x, cam_y, cam_z = cam_xyz
+    xs, ys = spec.cell_centers()  # (W,), (H,)
+    de = (xs[np.newaxis, :] - cam_x) * meters_per_unit      # (1, W) east meters
+    dn = (ys[:, np.newaxis] - cam_y) * meters_per_unit      # (H, 1) north meters
+    dd = cam_z - dem                                        # (H, W) down meters
+
+    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg)
+    Rt = R.T  # camera <- NED
+    # p_cam = R^T @ [north, east, down]
+    px = Rt[0, 0] * dn + Rt[0, 1] * de + Rt[0, 2] * dd
+    py = Rt[1, 0] * dn + Rt[1, 1] * de + Rt[1, 2] * dd
+    pz = Rt[2, 0] * dn + Rt[2, 1] * de + Rt[2, 2] * dd
+
+    hw, hh = _frustum_half_extents(fg)
+    r = np.sqrt(dn * dn + de * de + dd * dd)               # slant range (H, W)
+
+    with np.errstate(invalid='ignore'):
+        in_frustum = (pz > 1e-9) & (np.abs(px) <= pz * hw) & (np.abs(py) <= pz * hh)
+        mask = in_frustum & np.isfinite(dem) & (r <= params.max_range_m)
+
+    sw = fg.sensor_mm[0]
+    img_w = fg.image_size[0]
+    pel_m = (sw / img_w) * 1e-3
+    f_m = fg.focal_mm * 1e-3
+    with np.errstate(invalid='ignore', divide='ignore'):
+        sin_g = np.clip(dd / r, 0.05, 1.0)
+        gsd_cm = (100.0 * r * (pel_m / f_m) / np.sqrt(sin_g)).astype(np.float32)
+
+    return mask, gsd_cm
+
+
+def frame_pod_kernel(dem: np.ndarray, chm: Optional[np.ndarray], cover: Optional[np.ndarray],
+                     transform, cam_xyz: Tuple[float, float, float],
+                     target_mask: np.ndarray, gsd_cm: np.ndarray, params,
+                     meters_per_unit: float = 1.0, return_factors: bool = False):
+    """Per-frame POD = terrain_visible x canopy_transmittance x gsd_adequacy.
+
+    ``dem``/``chm``/``cover`` are co-registered (H, W) grids on ``transform``
+    (EPSG:3857); ``chm``/``cover`` may be None (transmittance = 1). Returns a
+    float32 (H, W) POD array, nonzero only in ``target_mask`` cells.
+
+    When ``return_factors`` is True, returns ``(pod, factor)`` where ``factor``
+    is a uint8 (H, W) grid of the dominant limiting factor per target cell
+    (LIMIT_TERRAIN / LIMIT_CANOPY / LIMIT_GSD / LIMIT_NONE), for cell inspection.
+    """
+    H, W = dem.shape
+    out = np.zeros((H, W), dtype=np.float32)
+    factor = np.zeros((H, W), dtype=np.uint8) if return_factors else None
+    rows, cols = np.nonzero(target_mask)
+    if rows.size == 0:
+        return (out, factor) if return_factors else out
+
+    spec = GridSpec(crs=WEB_MERCATOR_CRS, transform=transform, width=W, height=H)
+    xs, ys = spec.cell_centers()
+    cam_x, cam_y, cam_z = cam_xyz
+    cell_m = transform.a * meters_per_unit
+    k_ext = params.extinction_k
+    gsd_full = params.gsd_full_cm
+    gsd_max = params.gsd_max_cm
+
+    K = params.ray_samples
+    u = (np.arange(K, dtype=np.float64) + 0.5) / K
+    t = 1.0 - (1.0 - u) ** 2                                     # (K,) camera(0) -> target(1)
+    t_edges = 1.0 - (1.0 - np.arange(K + 1, dtype=np.float64) / K) ** 2
+    dt = np.diff(t_edges)                                         # (K,)
+
+    from scipy.ndimage import map_coordinates
+
+    chunk = max(1, int(params.kernel_chunk_cells))
+    for start in range(0, rows.size, chunk):
+        rsel = rows[start:start + chunk]
+        csel = cols[start:start + chunk]
+        tx = xs[csel]                                            # (n,)
+        ty = ys[rsel]
+        tz = dem[rsel, csel]
+        n = rsel.size
+
+        # Ray points (n, K) from camera to each target cell.
+        sx = cam_x + (tx - cam_x)[:, None] * t[None, :]
+        sy = cam_y + (ty - cam_y)[:, None] * t[None, :]
+        sz = cam_z + (tz - cam_z)[:, None] * t[None, :]
+
+        rr, cc = spec.world_to_index(sx, sy)                    # (n, K) each
+        ground = map_coordinates(dem, [rr.ravel(), cc.ravel()], order=1,
+                                 mode='constant', cval=np.nan).reshape(n, K)
+
+        ground_range = np.hypot((tx - cam_x) * meters_per_unit,
+                                (ty - cam_y) * meters_per_unit)  # (n,)
+        ray_len = np.hypot(ground_range, cam_z - tz)             # (n,)
+
+        # Terrain visibility: any DEM sample rises above the ray (excluding the
+        # last cell near the target, which is the target's own ground).
+        near_ok = (1.0 - t)[None, :] * ground_range[:, None] > cell_m
+        with np.errstate(invalid='ignore'):
+            blocked = ((ground > sz + params.los_epsilon_m) & near_ok).any(axis=1)
+
+        # Canopy transmittance (Beer-Lambert over foliage path length).
+        if chm is not None:
+            chm_s = map_coordinates(chm, [rr.ravel(), cc.ravel()], order=1,
+                                    mode='constant', cval=np.nan).reshape(n, K)
+            chm_s = np.nan_to_num(chm_s, nan=0.0)
+            if cover is not None:
+                cover_s = map_coordinates(cover, [rr.ravel(), cc.ravel()], order=1,
+                                          mode='constant', cval=np.nan).reshape(n, K)
+                cover_s = np.clip(np.nan_to_num(cover_s, nan=0.0), 0.0, 1.0)
+            else:
+                cover_s = np.ones((n, K), dtype=np.float64)
+            with np.errstate(invalid='ignore'):
+                in_layer = (sz >= ground - 0.01) & (sz <= ground + chm_s)
+            # Midpoint Riemann sum of the foliage indicator along the ray. This
+            # carries an O(1/K) bias at the sharp canopy boundary; it is a near-
+            # constant factor that extinction_k absorbs during field calibration.
+            contrib = np.where(in_layer, cover_s, 0.0) * dt[None, :]
+            l_eff = contrib.sum(axis=1) * ray_len
+            trans = np.exp(-k_ext * l_eff)
+        else:
+            trans = np.ones(n, dtype=np.float64)
+
+        gsd_vals = gsd_cm[rsel, csel].astype(np.float64)
+        denom = (gsd_max - gsd_full) if (gsd_max > gsd_full) else 1e-9
+        adequacy = np.clip((gsd_max - gsd_vals) / denom, 0.0, 1.0)
+
+        pod_vals = np.where(blocked, 0.0, trans * adequacy)
+        out[rsel, csel] = pod_vals.astype(np.float32)
+
+        if return_factors:
+            fac = np.full(rsel.size, LIMIT_NONE, dtype=np.uint8)
+            canopy_worse = trans <= adequacy
+            fac[(~blocked) & canopy_worse & (trans < 0.999)] = LIMIT_CANOPY
+            fac[(~blocked) & (~canopy_worse) & (adequacy < 0.999)] = LIMIT_GSD
+            fac[blocked] = LIMIT_TERRAIN
+            factor[rsel, csel] = fac
+
+    return (out, factor) if return_factors else out

--- a/app/core/services/coverage/params.py
+++ b/app/core/services/coverage/params.py
@@ -1,0 +1,69 @@
+"""
+PodParams - tunable parameters for the Coverage/Probability-of-Detection pipeline.
+
+Spec-defined knobs (section 6) plus a small number of engine-internal knobs that
+the spec's prose implies but does not tabulate. Defaults are the calibrated
+product; only a few are exposed to end users via settings (see from_settings).
+"""
+
+from dataclasses import dataclass, asdict, replace
+
+
+@dataclass(frozen=True)
+class PodParams:
+    # --- spec section 6 ---
+    grid_res_m: float = 3.0             # working cell size (true ground meters)
+    ray_samples: int = 48              # samples per line-of-sight ray
+    extinction_k: float = 0.06         # Beer-Lambert coefficient, 1/m
+    gsd_full_cm: float = 2.0           # GSD at/below which adequacy = 1
+    gsd_max_cm: float = 10.0           # GSD at/above which adequacy = 0
+    max_range_m: float = 800.0         # clamp for very oblique frames
+    min_pitch_deg: float = -10.0       # skip frames with pitch shallower than this (> min_pitch_deg)
+    gap_threshold: float = 0.25        # POD below this -> gap polygon
+    pod_frame_cap: float = 0.85        # max POD any single frame can claim
+    common_mode_ceiling: float = 0.90  # mission ceiling C (correlated failure modes)
+    angle_bins: int = 8                # 4 azimuth quadrants x {nadir, oblique}
+    pod_display_floor: float = 0.05    # transparency floor in RGBA output
+
+    # --- engine knobs beyond spec section 6 (documented deviations) ---
+    los_epsilon_m: float = 0.5         # DEM-noise tolerance in the blocked test
+    footprint_buffer_m: float = 50.0   # bbox margin around the flat-plane footprint
+    nadir_split_deg: float = 30.0      # off-nadir angle separating nadir/oblique rings
+    low_confidence_haircut: float = 0.7  # frame POD multiplier when bearing_confidence < 0.5
+    kernel_chunk_cells: int = 16384    # ray-march memory bound (target cells per chunk)
+    frame_index_block: int = 8         # cells per side of a coarse frame-index block
+    frame_index_max_per_block: int = 64
+    mem_budget_mb: int = 512           # accumulator lazy-growth clamp
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def thermal(cls) -> "PodParams":
+        """Thermal preset (spec section 6 note): same two adequacy knobs, thermal values."""
+        return cls(gsd_full_cm=6.0, gsd_max_cm=25.0)
+
+    @classmethod
+    def from_settings(cls, settings_service) -> "PodParams":
+        """Build params from user settings, keeping non-exposed knobs at defaults.
+
+        Only a small, safe subset is user-tunable; everything else stays the
+        calibrated default. ``settings_service`` may be None (returns defaults).
+        """
+        if settings_service is None:
+            return cls()
+
+        preset = settings_service.get_setting('PodGsdPreset', 'rgb')
+        base = cls.thermal() if preset == 'thermal' else cls()
+
+        def _f(key, default):
+            try:
+                return float(settings_service.get_setting(key, default))
+            except (TypeError, ValueError):
+                return default
+
+        return replace(
+            base,
+            grid_res_m=_f('PodGridResM', base.grid_res_m),
+            gap_threshold=_f('PodGapThreshold', base.gap_threshold),
+        )

--- a/app/core/services/coverage/writers.py
+++ b/app/core/services/coverage/writers.py
@@ -1,0 +1,193 @@
+"""
+writers - serialize a CoverageResult to the four mission products.
+
+* coverage_pod.tif    - RGBA colormapped GeoTIFF (EPSG:3857), auto-places in
+                        CalTopo Map Sheets.
+* coverage_looks.tif  - uint16 look-count raster (binary coverage = count >= 1).
+* coverage_gaps.geojson - WGS84 polygons where POD < gap_threshold inside the
+                        flight-track hull (the re-tasking product).
+* stats.json          - areas at POD thresholds, mean POD, skip reasons, canopy
+                        source, terrain datum.
+
+Also exposes ``compute_gap_polygons`` / ``build_stats`` used by
+CoveragePodService so the CoverageResult is self-contained. Pure service layer
+(rasterio / shapely / pyproj); no Qt.
+"""
+
+import json
+import math
+import os
+
+import numpy as np
+
+from core.services.LoggerService import LoggerService
+from core.services.coverage.colormap import pod_to_rgba
+from core.services.terrain.grid import mercator_to_lonlat
+
+_logger = LoggerService()
+
+
+def _to_wgs84_transformer():
+    from pyproj import Transformer
+    return Transformer.from_crs("EPSG:3857", "EPSG:4326", always_xy=True).transform
+
+
+def _grid_center_lat(transform, shape) -> float:
+    rows, cols = shape
+    cx = transform.c + transform.a * cols / 2.0
+    cy = transform.f + transform.e * rows / 2.0
+    _, lat = mercator_to_lonlat(cx, cy)
+    return lat
+
+
+def _true_cell_area_m2(transform, center_lat: float) -> float:
+    """Cell area corrected for Web Mercator inflation (cos^2 lat)."""
+    return abs(transform.a * transform.e) * math.cos(math.radians(center_lat)) ** 2
+
+
+def write_pod_geotiff(path, rgba: np.ndarray, transform, params=None,
+                      crs: str = "EPSG:3857") -> None:
+    import rasterio
+    from rasterio.enums import ColorInterp
+
+    rows, cols = rgba.shape[:2]
+    profile = dict(
+        driver="GTiff", height=rows, width=cols, count=4, dtype="uint8",
+        crs=crs, transform=transform, photometric="RGB",
+        compress="deflate", zlevel=6,
+        tiled=True, blockxsize=256, blockysize=256,
+    )
+    with rasterio.open(path, "w", **profile) as dst:
+        # Declare the 4th band as alpha before writing so GDAL records
+        # ExtraSamples=alpha (viewers/CalTopo honor this for transparency).
+        dst.colorinterp = [ColorInterp.red, ColorInterp.green,
+                           ColorInterp.blue, ColorInterp.alpha]
+        dst.write(np.moveaxis(rgba, 2, 0))
+        tags = {"ADIAT_PRODUCT": "coverage_pod"}
+        if params is not None:
+            tags["ADIAT_PARAMS"] = json.dumps(params.to_dict())
+        dst.update_tags(**tags)
+
+
+def write_looks_geotiff(path, look_count: np.ndarray, transform,
+                        crs: str = "EPSG:3857") -> None:
+    import rasterio
+
+    profile = dict(
+        driver="GTiff", height=look_count.shape[0], width=look_count.shape[1],
+        count=1, dtype="uint16", crs=crs, transform=transform, nodata=0,
+        compress="deflate", predictor=2, tiled=True, blockxsize=256, blockysize=256,
+    )
+    with rasterio.open(path, "w", **profile) as dst:
+        dst.write(look_count.astype("uint16"), 1)
+        dst.update_tags(ADIAT_PRODUCT="coverage_looks")
+
+
+def compute_gap_polygons(pod, look_count, transform, hull_3857, gap_threshold,
+                         min_area_cells: int = 4):
+    """Polygons (EPSG:3857) where POD < gap_threshold inside the flight hull."""
+    import rasterio.features
+    from shapely.geometry import shape
+
+    gap_mask = pod < gap_threshold
+    if hull_3857 is not None:
+        inside = rasterio.features.geometry_mask(
+            [hull_3857], out_shape=pod.shape, transform=transform, invert=True)
+        gap_mask = gap_mask & inside
+    if not gap_mask.any():
+        return []
+
+    cell_area = abs(transform.a * transform.e)
+    polys = []
+    for geom, val in rasterio.features.shapes(
+            gap_mask.astype(np.uint8), mask=gap_mask, transform=transform):
+        p = shape(geom)
+        if p.area >= min_area_cells * cell_area:
+            polys.append(p)
+    return polys
+
+
+def write_gaps_geojson(path, gap_polygons, gap_threshold) -> None:
+    from shapely.geometry import mapping
+    from shapely.ops import transform as shp_transform
+
+    to_wgs84 = _to_wgs84_transformer()
+    features = []
+    for p in gap_polygons:
+        g = shp_transform(to_wgs84, p)
+        lat_c = g.centroid.y
+        area = p.area * math.cos(math.radians(lat_c)) ** 2
+        features.append({
+            "type": "Feature",
+            "properties": {"kind": "coverage_gap",
+                           "area_sqm": round(area, 1),
+                           "pod_threshold": gap_threshold},
+            "geometry": mapping(g),
+        })
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"type": "FeatureCollection", "features": features}, fh)
+
+
+def build_stats(pod, look_count, transform, skipped, gap_polygons, params,
+                canopy_source, terrain_info, generated_at=None) -> dict:
+    center_lat = _grid_center_lat(transform, pod.shape)
+    cell_area = _true_cell_area_m2(transform, center_lat)
+    covered = look_count > 0
+
+    reason_counts = {}
+    for _, reason in skipped:
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+    gap_area = sum(p.area for p in gap_polygons) * math.cos(math.radians(center_lat)) ** 2
+
+    return {
+        "generated_at": generated_at,
+        "params": params.to_dict() if params is not None else {},
+        "grid": {
+            "crs": "EPSG:3857",
+            "rows": int(pod.shape[0]),
+            "cols": int(pod.shape[1]),
+            "transform": list(transform)[:6],
+            "grid_res_m": params.grid_res_m if params is not None else None,
+        },
+        "area_sqm": {
+            "looks_ge_1": float(covered.sum() * cell_area),
+            "pod_ge_0_25": float((pod >= 0.25).sum() * cell_area),
+            "pod_ge_0_50": float((pod >= 0.50).sum() * cell_area),
+            "pod_ge_0_75": float((pod >= 0.75).sum() * cell_area),
+        },
+        "mean_pod_covered": float(pod[covered].mean()) if covered.any() else 0.0,
+        "skipped": [{"image": n, "reason": r} for n, r in skipped],
+        "skipped_counts": reason_counts,
+        "gaps": {"count": len(gap_polygons), "area_sqm": float(gap_area)},
+        "canopy": {"source": canopy_source},
+        "terrain": terrain_info,
+    }
+
+
+def write_all_outputs(result, out_dir: str) -> dict:
+    """Write the four spec-named products into ``out_dir``. Returns {name: path}."""
+    os.makedirs(out_dir, exist_ok=True)
+    paths = {}
+
+    pod_path = os.path.join(out_dir, "coverage_pod.tif")
+    rgba = pod_to_rgba(result.pod, result.look_count, result.params)
+    write_pod_geotiff(pod_path, rgba, result.transform, result.params)
+    paths["pod"] = pod_path
+
+    looks_path = os.path.join(out_dir, "coverage_looks.tif")
+    write_looks_geotiff(looks_path, result.look_count, result.transform)
+    paths["looks"] = looks_path
+
+    gaps_path = os.path.join(out_dir, "coverage_gaps.geojson")
+    gap_threshold = result.params.gap_threshold if result.params is not None else 0.25
+    write_gaps_geojson(gaps_path, result.gap_polygons, gap_threshold)
+    paths["gaps"] = gaps_path
+
+    stats_path = os.path.join(out_dir, "stats.json")
+    with open(stats_path, "w", encoding="utf-8") as fh:
+        json.dump(result.stats, fh, indent=2)
+    paths["stats"] = stats_path
+
+    _logger.info(f"CoveragePod: wrote {len(paths)} products to {out_dir}")
+    return paths

--- a/app/core/services/coverage/writers.py
+++ b/app/core/services/coverage/writers.py
@@ -3,6 +3,8 @@ writers - serialize a CoverageResult to the four mission products.
 
 * coverage_pod.tif    - RGBA colormapped GeoTIFF (EPSG:3857), auto-places in
                         CalTopo Map Sheets.
+* coverage_pod_values.tif - float32 POD probabilities 0-1 (NaN = no looks), the
+                        GIS-queryable counterpart of the RGBA render.
 * coverage_looks.tif  - uint16 look-count raster (binary coverage = count >= 1).
 * coverage_gaps.geojson - WGS84 polygons where POD < gap_threshold inside the
                         flight-track hull (the re-tasking product).
@@ -64,6 +66,32 @@ def write_pod_geotiff(path, rgba: np.ndarray, transform, params=None,
                            ColorInterp.blue, ColorInterp.alpha]
         dst.write(np.moveaxis(rgba, 2, 0))
         tags = {"ADIAT_PRODUCT": "coverage_pod"}
+        if params is not None:
+            tags["ADIAT_PARAMS"] = json.dumps(params.to_dict())
+        dst.update_tags(**tags)
+
+
+def write_pod_values_geotiff(path, pod: np.ndarray, look_count: np.ndarray,
+                             transform, params=None,
+                             crs: str = "EPSG:3857") -> None:
+    """Single-band float32 POD values (0-1), NaN where never looked at.
+
+    The analyzable counterpart of the RGBA visualization: GIS tools can query,
+    threshold, and restyle actual probabilities from this band.
+    """
+    import rasterio
+
+    data = pod.astype("float32").copy()
+    data[look_count == 0] = np.nan
+    profile = dict(
+        driver="GTiff", height=data.shape[0], width=data.shape[1],
+        count=1, dtype="float32", crs=crs, transform=transform,
+        nodata=float("nan"), compress="deflate",
+        tiled=True, blockxsize=256, blockysize=256,
+    )
+    with rasterio.open(path, "w", **profile) as dst:
+        dst.write(data, 1)
+        tags = {"ADIAT_PRODUCT": "coverage_pod_values"}
         if params is not None:
             tags["ADIAT_PARAMS"] = json.dumps(params.to_dict())
         dst.update_tags(**tags)
@@ -166,7 +194,7 @@ def build_stats(pod, look_count, transform, skipped, gap_polygons, params,
 
 
 def write_all_outputs(result, out_dir: str) -> dict:
-    """Write the four spec-named products into ``out_dir``. Returns {name: path}."""
+    """Write the mission products into ``out_dir``. Returns {name: path}."""
     os.makedirs(out_dir, exist_ok=True)
     paths = {}
 
@@ -174,6 +202,11 @@ def write_all_outputs(result, out_dir: str) -> dict:
     rgba = pod_to_rgba(result.pod, result.look_count, result.params)
     write_pod_geotiff(pod_path, rgba, result.transform, result.params)
     paths["pod"] = pod_path
+
+    values_path = os.path.join(out_dir, "coverage_pod_values.tif")
+    write_pod_values_geotiff(values_path, result.pod, result.look_count,
+                             result.transform, result.params)
+    paths["pod_values"] = values_path
 
     looks_path = os.path.join(out_dir, "coverage_looks.tif")
     write_looks_geotiff(looks_path, result.look_count, result.transform)

--- a/app/core/services/image/FrameGeometry.py
+++ b/app/core/services/image/FrameGeometry.py
@@ -1,0 +1,160 @@
+"""
+FrameGeometry - a public camera pose + intrinsics snapshot for one image frame.
+
+Promoted out of ``ImageService._get_projection_context`` so the Coverage/POD
+pipeline (and, eventually, CoverageExtentService) can collect a frame's geometry
+once, in one place. It carries pose (lat/lon/AGL/yaw/pitch/roll) and intrinsics
+(focal, sensor, image size, principal point) but deliberately performs **no**
+terrain access: ``cam_elev_m`` is left for the caller to resolve against the
+frame's own DEM so the datum rule ``cam_elev = DEM(nadir) + AGL`` holds by
+construction (a constant vertical datum offset cancels).
+
+Lives in the image package (pose/intrinsics is image metadata), keeping the
+dependency flow one-way: coverage -> image, never the reverse.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, TYPE_CHECKING
+
+from helpers.LocationInfo import LocationInfo
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids importing ImageService
+    from core.services.image.ImageService import ImageService
+
+# BearingResult.confidence is never set != 1.0 by BearingCalculationService and is
+# not persisted in ADIAT_Data.xml (only bearing / bearing_source / bearing_quality
+# are). So the persisted quality string is the actual confidence signal available
+# for track-interpolated ("calculated") yaw.
+BEARING_QUALITY_CONFIDENCE = {
+    'good': 0.9,
+    'turn_inferred': 0.6,
+    'gap': 0.4,
+    'hover_estimate': 0.3,
+}
+DEFAULT_CALCULATED_CONFIDENCE = 0.5   # 'calculated' yaw with unknown/absent quality
+NO_YAW_CONFIDENCE = 0.25              # no yaw metadata at all -> assumed 0 deg
+
+
+@dataclass
+class FrameGeometry:
+    """Camera pose + intrinsics for a single frame (see module docstring)."""
+
+    lat: float                                   # camera nadir point (EXIF GPS)
+    lon: float
+    agl_m: float                                 # reported AGL (or custom override)
+    yaw_deg: float                               # camera yaw, 0=N, 90=E
+    pitch_deg: float                             # 0 = horizon, -90 = nadir
+    roll_deg: float                              # gimbal roll; 0 when |roll|>90 (inverted-gimbal flag)
+    focal_mm: float
+    sensor_mm: Tuple[float, float]               # (width_mm, height_mm)
+    image_size: Tuple[int, int]                  # (width_px, height_px)
+    principal_point_mm: Optional[Tuple[float, float]]  # None -> image center
+    yaw_source: str                              # 'gimbal' | 'flight' | 'calculated' | 'default'
+    bearing_confidence: float                    # 1.0 for gimbal/flight; mapped for 'calculated'; 0.25 for 'default'
+    asl_alt_m: Optional[float] = None            # raw EXIF ASL altitude (datum fallback only)
+    cam_elev_m: Optional[float] = None           # filled by the caller: DEM(nadir) + agl_m
+
+    @classmethod
+    def from_image_service(cls, image_service: "ImageService",
+                           custom_altitude_ft: Optional[float] = None,
+                           bearing_quality: Optional[str] = None,
+                           agl_override_ft: Optional[float] = None
+                           ) -> Optional["FrameGeometry"]:
+        """Collect pose + intrinsics from an ``ImageService``.
+
+        Returns ``None`` when GPS, intrinsics, image size, or a positive AGL is
+        unavailable. Performs no terrain access (``cam_elev_m`` stays ``None``).
+
+        Args:
+            image_service: the source ImageService.
+            custom_altitude_ft: overrides XMP AGL when > 0 (feet).
+            bearing_quality: persisted ``bearing_quality`` string for the frame,
+                used to set confidence when yaw falls back to track interpolation.
+            agl_override_ft: highest-priority AGL override in feet (e.g. a
+                Wingtra per-image AGL); takes precedence over ``custom_altitude_ft``.
+        """
+        try:
+            gps = LocationInfo.get_gps(exif_data=image_service.exif_data)
+            if not gps:
+                return None
+            lat = gps['latitude']
+            lon = gps['longitude']
+
+            intrinsics = image_service.get_camera_intrinsics()
+            if intrinsics is None:
+                return None
+
+            image_size = cls._resolve_image_size(image_service)
+            if image_size is None:
+                return None
+
+            agl_m = cls._resolve_agl_m(image_service, custom_altitude_ft, agl_override_ft)
+            if agl_m is None or agl_m <= 0:
+                return None
+
+            yaw_deg, yaw_source = image_service.get_camera_yaw_with_source()
+            if yaw_deg is None:
+                yaw_deg = 0.0
+                yaw_source = 'default'
+
+            pitch_deg = image_service.get_camera_pitch()
+            if pitch_deg is None:
+                pitch_deg = -90.0
+
+            roll_deg = image_service.get_gimbal_roll() or 0.0
+            if abs(roll_deg) > 90.0:
+                roll_deg = 0.0
+
+            return cls(
+                lat=lat,
+                lon=lon,
+                agl_m=agl_m,
+                yaw_deg=yaw_deg,
+                pitch_deg=pitch_deg,
+                roll_deg=roll_deg,
+                focal_mm=intrinsics['focal_length_mm'],
+                sensor_mm=(intrinsics['sensor_width_mm'], intrinsics['sensor_height_mm']),
+                image_size=image_size,
+                principal_point_mm=None,
+                yaw_source=yaw_source,
+                bearing_confidence=cls._confidence_for(yaw_source, bearing_quality),
+                asl_alt_m=image_service.get_asl_altitude('m'),
+                cam_elev_m=None,
+            )
+        except Exception:
+            return None
+
+    @staticmethod
+    def _resolve_image_size(image_service) -> Optional[Tuple[int, int]]:
+        """(width_px, height_px) from the loaded array, else EXIF dimensions."""
+        arr = getattr(image_service, 'img_array', None)
+        if arr is not None:
+            h, w = arr.shape[:2]
+            return int(w), int(h)
+        try:
+            import piexif
+            exif = image_service.exif_data.get("Exif", {})
+            w = exif.get(piexif.ExifIFD.PixelXDimension)
+            h = exif.get(piexif.ExifIFD.PixelYDimension)
+            if w and h:
+                return int(w), int(h)
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
+    def _resolve_agl_m(image_service, custom_altitude_ft, agl_override_ft) -> Optional[float]:
+        """Reported AGL in meters by priority: override -> custom -> XMP AGL."""
+        if agl_override_ft is not None and agl_override_ft > 0:
+            return agl_override_ft / 3.28084
+        if custom_altitude_ft is not None and custom_altitude_ft > 0:
+            return custom_altitude_ft / 3.28084
+        return image_service.get_relative_altitude('m')
+
+    @staticmethod
+    def _confidence_for(yaw_source: str, bearing_quality: Optional[str]) -> float:
+        if yaw_source in ('gimbal', 'flight'):
+            return 1.0
+        if yaw_source == 'calculated':
+            return BEARING_QUALITY_CONFIDENCE.get(bearing_quality, DEFAULT_CALCULATED_CONFIDENCE)
+        return NO_YAW_CONFIDENCE

--- a/app/core/services/image/ImageService.py
+++ b/app/core/services/image/ImageService.py
@@ -22,7 +22,8 @@ from helpers.LocationInfo import LocationInfo
 class ImageService:
     """Service to calculate various drone and image attributes based on metadata."""
 
-    def __init__(self, path, mask_path=None, img_array=None, calculated_bearing=None):
+    def __init__(self, path, mask_path=None, img_array=None, calculated_bearing=None,
+                 exif_data=None, xmp_data=None):
         """
         Initializes the ImageService by extracting Exif and XMP metadata.
 
@@ -33,9 +34,13 @@ class ImageService:
                                               If provided, skips loading from disk.
             calculated_bearing (float, optional): Calculated bearing in degrees [0, 360).
                                                  Used as fallback if EXIF bearing is missing.
+            exif_data (dict, optional): Pre-read EXIF data. Skips the piexif read when given.
+            xmp_data (dict, optional): Pre-read XMP data. Skips the (ExifTool) XMP read when
+                                       given — used by bulk callers (e.g. the POD pass) to
+                                       avoid launching one ExifTool process per image.
         """
-        self.exif_data = MetaDataHelper.get_exif_data_piexif(path)
-        self.xmp_data = MetaDataHelper.get_xmp_data_merged(path)
+        self.exif_data = exif_data if exif_data is not None else MetaDataHelper.get_exif_data_piexif(path)
+        self.xmp_data = xmp_data if xmp_data is not None else MetaDataHelper.get_xmp_data_merged(path)
         self.drone_make = MetaDataHelper.get_drone_make(self.exif_data)
         self.path = path
         self.mask_path = mask_path

--- a/app/core/services/image/ImageService.py
+++ b/app/core/services/image/ImageService.py
@@ -175,7 +175,23 @@ class ImageService:
         Returns:
             float or None: Camera yaw in degrees (0-360), or None if unavailable.
         """
+        return self.get_camera_yaw_with_source()[0]
+
+    def get_camera_yaw_with_source(self):
+        """
+        Get the camera yaw together with the source that provided it.
+
+        Same priority chain and roll-flip normalization as :meth:`get_camera_yaw`,
+        but also reports which rung of the chain fired so callers (e.g.
+        FrameGeometry) can attach a confidence to track-interpolated yaw.
+
+        Returns:
+            tuple[float | None, str | None]: (yaw_deg in [0, 360), source) where
+            source is 'gimbal', 'flight', 'calculated', or None when no yaw is
+            available.
+        """
         yaw = None
+        source = None
 
         # Prefer gimbal yaw if available (actual camera direction)
         if self.xmp_data is not None and self.drone_make is not None:
@@ -183,19 +199,24 @@ class ImageService:
             if gimbal_yaw is not None:
                 try:
                     yaw = float(gimbal_yaw)
+                    source = 'gimbal'
                 except (TypeError, ValueError):
                     pass
 
         # Fall back to flight yaw (drone body direction)
         if yaw is None:
-            yaw = self._get_drone_orientation()
+            flight_yaw = self._get_drone_orientation()
+            if flight_yaw is not None:
+                yaw = flight_yaw
+                source = 'flight'
 
         # Final fallback: use calculated bearing if available
         if yaw is None and self.calculated_bearing is not None:
             yaw = self.calculated_bearing
+            source = 'calculated'
 
         if yaw is None:
-            return None
+            return None, None
 
         # Normalize to 0-360 range
         if yaw < 0:
@@ -210,7 +231,7 @@ class ImageService:
         if gimbal_roll is not None and abs(gimbal_roll) > 90:
             yaw = (yaw + 180) % 360
 
-        return yaw
+        return yaw, source
 
     def get_camera_intrinsics(self):
         """
@@ -387,11 +408,42 @@ class ImageService:
 
     # ---------------- terrain helpers ----------------
 
+    def get_frame_geometry(self, custom_altitude_ft=None, bearing_quality=None,
+                           agl_override_ft=None):
+        """Collect this image's camera pose + intrinsics as a FrameGeometry.
+
+        A public, terrain-free snapshot (see
+        :class:`core.services.image.FrameGeometry.FrameGeometry`) consumed by the
+        Coverage/POD pipeline and, internally, by :meth:`_get_projection_context`.
+        Cached per ``(custom_altitude_ft, agl_override_ft)``. Returns None when
+        GPS, intrinsics, image size, or a positive AGL is unavailable.
+        """
+        cache_key = (custom_altitude_ft, agl_override_ft)
+        cache = getattr(self, '_frame_geometry_cache', None)
+        if cache is None:
+            cache = {}
+            self._frame_geometry_cache = cache
+        if cache_key in cache:
+            return cache[cache_key]
+
+        from core.services.image.FrameGeometry import FrameGeometry
+        fg = FrameGeometry.from_image_service(
+            self,
+            custom_altitude_ft=custom_altitude_ft,
+            bearing_quality=bearing_quality,
+            agl_override_ft=agl_override_ft,
+        )
+        cache[cache_key] = fg
+        return fg
+
     def _get_projection_context(self, custom_altitude_ft=None):
         """Collect drone pose, intrinsics and per-image terrain data needed for
         per-pixel projection. Caches the result on the instance so repeated
         per-pixel queries (e.g. dragging the person-reference overlay) don't
         re-read EXIF or re-query the DEM for the drone position.
+
+        Built on top of :meth:`get_frame_geometry` (pose + intrinsics), then
+        augmented with the terrain reconciliation fields.
 
         Returns:
             dict or None: projection context, or None if any required data is
@@ -403,36 +455,20 @@ class ImageService:
             return cached
 
         try:
-            gps_coords = LocationInfo.get_gps(exif_data=self.exif_data)
-            if not gps_coords:
-                return None
-            drone_lat = gps_coords['latitude']
-            drone_lon = gps_coords['longitude']
-
-            intrinsics = self.get_camera_intrinsics()
-            if intrinsics is None:
-                return None
-
+            # Preserve the historical guard: this path requires the pixel array
+            # (per-pixel projection callers always have it loaded).
             if self.img_array is None:
                 return None
-            img_h, img_w = self.img_array.shape[:2]
 
-            yaw = self.get_camera_yaw() or 0.0
-            pitch = self.get_camera_pitch()
-            if pitch is None:
-                pitch = -90.0
-            roll = self.get_gimbal_roll() or 0.0
-            if abs(roll) > 90.0:
-                roll = 0.0
-
-            if custom_altitude_ft is not None and custom_altitude_ft > 0:
-                reported_agl = custom_altitude_ft / 3.28084
-            else:
-                reported_agl = self.get_relative_altitude('m') or 0.0
-            if reported_agl <= 0:
+            fg = self.get_frame_geometry(custom_altitude_ft=custom_altitude_ft)
+            if fg is None:
                 return None
 
-            absolute_alt = self.get_asl_altitude('m')
+            drone_lat = fg.lat
+            drone_lon = fg.lon
+            img_h, img_w = self.img_array.shape[:2]
+            reported_agl = fg.agl_m
+            absolute_alt = fg.asl_alt_m
 
             # Lazy import to avoid pulling the terrain stack when unused.
             try:
@@ -462,12 +498,12 @@ class ImageService:
                 'img_h': img_h,
                 'cx': img_w / 2.0,
                 'cy': img_h / 2.0,
-                'focal_mm': intrinsics['focal_length_mm'],
-                'sensor_w_mm': intrinsics['sensor_width_mm'],
-                'sensor_h_mm': intrinsics['sensor_height_mm'],
-                'pitch': pitch,
-                'yaw': yaw,
-                'roll': roll,
+                'focal_mm': fg.focal_mm,
+                'sensor_w_mm': fg.sensor_mm[0],
+                'sensor_h_mm': fg.sensor_mm[1],
+                'pitch': fg.pitch_deg,
+                'yaw': fg.yaw_deg,
+                'roll': fg.roll_deg,
                 'reported_agl': reported_agl,
                 'drone_terrain_elev_m': drone_terrain_elev_m,
                 'drone_absolute_elev_m': drone_absolute_elev_m,

--- a/app/core/services/terrain/CanopyService.py
+++ b/app/core/services/terrain/CanopyService.py
@@ -1,0 +1,319 @@
+"""
+CanopyService - local-GeoTIFF canopy provider for the Coverage/POD pipeline.
+
+Clones the USGS3DEPProvider structure (manifest CSV -> STRtree bbox index ->
+LRU of open rasterio datasets) but returns a two-band ``CanopySample`` (canopy
+height + cover fraction) co-registered to the DEM's GridSpec so the ray-march
+kernel indexes DEM/CHM/cover identically.
+
+Supported tile products (a per-tile ``product`` column in the manifest):
+  * landfire_evh    - LANDFIRE Existing Vegetation Height class codes -> meters
+  * landfire_evc    - LANDFIRE Existing Vegetation Cover class codes -> fraction
+  * landfire_cc_pct - plain percent canopy cover (0-100) -> fraction
+  * meta_chm        - Meta/WRI continuous canopy height (meters); cover derived
+
+Class codes are decoded to physical units on the source tile FIRST, then
+bilinearly resampled (interpolating raw categorical codes would be meaningless).
+Canopy height is above-ground by construction, so no geoid/datum handling.
+"""
+
+from collections import OrderedDict
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from core.services.LoggerService import LoggerService
+
+KIND_LANDFIRE = 'landfire'
+KIND_META = 'meta'
+
+PRODUCT_EVH = 'landfire_evh'
+PRODUCT_EVC = 'landfire_evc'
+PRODUCT_CC_PCT = 'landfire_cc_pct'
+PRODUCT_META_CHM = 'meta_chm'
+
+_HEIGHT_PRODUCTS = {PRODUCT_EVH, PRODUCT_META_CHM}
+_COVER_PRODUCTS = {PRODUCT_EVC, PRODUCT_CC_PCT}
+
+
+@dataclass
+class CanopySample:
+    chm: np.ndarray        # (rows, cols) float32, canopy height above ground in meters
+    cover: np.ndarray      # (rows, cols) float32, cover fraction 0-1
+    transform: object      # affine.Affine (== spec.transform)
+    crs: str
+    cover_derived: bool    # True when cover was synthesized from CHM (stopgap)
+    source_name: str
+
+
+def evh_code_to_meters(codes: np.ndarray) -> np.ndarray:
+    """LANDFIRE EVH class codes -> canopy height (meters), NaN for fill/nodata.
+
+    Tree 101-199 -> code-100; shrub 201-299 -> (code-200)*0.1;
+    herb 301-310 -> (code-300)*0.1; non-veg/sparse -> 0; 99 or <0 -> NaN.
+    """
+    c = codes.astype(np.float64)
+    out = np.zeros(c.shape, dtype=np.float32)
+    tree = (c >= 101) & (c <= 199)
+    shrub = (c >= 201) & (c <= 299)
+    herb = (c >= 301) & (c <= 310)
+    out[tree] = (c[tree] - 100.0).astype(np.float32)
+    out[shrub] = ((c[shrub] - 200.0) * 0.1).astype(np.float32)
+    out[herb] = ((c[herb] - 300.0) * 0.1).astype(np.float32)
+    out[(c == 99) | (c < 0)] = np.nan
+    return out
+
+
+def evc_code_to_fraction(codes: np.ndarray) -> np.ndarray:
+    """LANDFIRE EVC class codes -> cover fraction 0-1, NaN for fill/nodata.
+
+    Tree 110-199, shrub 210-299, herb 310-399 encode cover percent as
+    (code - lifeform_base); non-veg/sparse -> 0; fill/<100 sentinels -> NaN.
+    """
+    c = codes.astype(np.float64)
+    out = np.zeros(c.shape, dtype=np.float32)
+    tree = (c >= 110) & (c <= 199)
+    shrub = (c >= 210) & (c <= 299)
+    herb = (c >= 310) & (c <= 399)
+    out[tree] = ((c[tree] - 100.0) / 100.0).astype(np.float32)
+    out[shrub] = ((c[shrub] - 200.0) / 100.0).astype(np.float32)
+    out[herb] = ((c[herb] - 300.0) / 100.0).astype(np.float32)
+    out = np.clip(out, 0.0, 1.0)
+    out[(c == 99) | (c < 0)] = np.nan
+    return out
+
+
+class CanopyService:
+    DATASET_LRU_SIZE = 16
+
+    def __init__(self, manifest_csv: str, tiles_dir: str, kind: str = KIND_LANDFIRE,
+                 h_ref_m: float = 20.0, c_max: float = 0.9,
+                 logger: Optional[LoggerService] = None):
+        """
+        Args:
+            manifest_csv: CSV with columns filename, product, minX, minY, maxX, maxY
+                (WGS84 bboxes). A missing 'product' column falls back to ``kind``.
+            tiles_dir: folder holding the GeoTIFFs referenced by 'filename'.
+            kind: default product family ('landfire' or 'meta') when the manifest
+                omits a per-tile product column.
+            h_ref_m/c_max: CHM->cover stopgap (cover ~ clip(chm/h_ref,0,1)*c_max).
+        """
+        self.logger = logger or LoggerService()
+        self.manifest_path = Path(manifest_csv)
+        self.tiles_dir = Path(tiles_dir)
+        self.kind = kind
+        self.h_ref_m = float(h_ref_m)
+        self.c_max = float(c_max)
+        self._tiles = []            # {filename, full_path, product, minX..maxY}
+        self._strtree = None
+        self._strtree_geoms = []
+        self._open_datasets: "OrderedDict[str, object]" = OrderedDict()
+        self._load_manifest()
+
+    @property
+    def source_name(self) -> str:
+        if self.kind == KIND_META:
+            return "Meta/WRI Canopy Height 1m (cover derived)"
+        return "LANDFIRE EVH+EVC 30m"
+
+    def _default_product(self) -> str:
+        return PRODUCT_META_CHM if self.kind == KIND_META else PRODUCT_EVH
+
+    def _load_manifest(self):
+        try:
+            import pandas as pd
+            from shapely.geometry import box
+            from shapely.strtree import STRtree
+        except ImportError as e:
+            self.logger.error(f"CanopyService missing dependency: {e}")
+            return
+
+        if not self.manifest_path.is_file():
+            self.logger.error(f"CanopyService: manifest not found at {self.manifest_path}")
+            return
+
+        try:
+            df = pd.read_csv(self.manifest_path)
+        except Exception as e:
+            self.logger.error(f"CanopyService: failed to read manifest: {e}")
+            return
+
+        required = {'filename', 'minX', 'minY', 'maxX', 'maxY'}
+        missing = required - set(df.columns)
+        if missing:
+            self.logger.error(f"CanopyService: manifest missing required columns {missing}")
+            return
+
+        has_product = 'product' in df.columns
+        if not has_product and self.kind == KIND_LANDFIRE:
+            self.logger.error(
+                "CanopyService: LANDFIRE manifest missing the 'product' column; "
+                "EVH and EVC tiles are indistinguishable. Refusing to load.")
+            return
+
+        for _, row in df.iterrows():
+            filename = str(row['filename'])
+            product = str(row['product']) if has_product else self._default_product()
+            self._tiles.append({
+                'filename': filename,
+                'full_path': str(self.tiles_dir / filename),
+                'product': product,
+                'minX': float(row['minX']), 'minY': float(row['minY']),
+                'maxX': float(row['maxX']), 'maxY': float(row['maxY']),
+            })
+            self._strtree_geoms.append(
+                box(float(row['minX']), float(row['minY']),
+                    float(row['maxX']), float(row['maxY'])))
+
+        if self._strtree_geoms:
+            self._strtree = STRtree(self._strtree_geoms)
+        self.logger.info(
+            f"CanopyService: indexed {len(self._tiles)} tiles from {self.manifest_path}")
+
+    def lookup_tiles_bbox(self, min_lon, min_lat, max_lon, max_lat) -> list:
+        if self._strtree is None:
+            return None
+        from shapely.geometry import box
+        query = box(min_lon, min_lat, max_lon, max_lat)
+        candidates = self._strtree.query(query)
+        tiles = []
+        seen = set()
+        for c in candidates:
+            if hasattr(c, 'intersects'):
+                geom = c
+                idx = self._strtree_geoms.index(geom)
+            else:
+                idx = int(c)
+                geom = self._strtree_geoms[idx]
+            if idx in seen:
+                continue
+            if geom.intersects(query):
+                seen.add(idx)
+                tiles.append(self._tiles[idx])
+        return tiles
+
+    def _get_dataset(self, full_path: str):
+        if full_path in self._open_datasets:
+            self._open_datasets.move_to_end(full_path)
+            return self._open_datasets[full_path]
+        try:
+            import rasterio
+        except ImportError:
+            self.logger.error("CanopyService: rasterio is required for sampling")
+            return None
+        try:
+            ds = rasterio.open(full_path)
+        except Exception as e:
+            self.logger.warning(f"CanopyService: failed to open {full_path}: {e}")
+            return None
+        self._open_datasets[full_path] = ds
+        if len(self._open_datasets) > self.DATASET_LRU_SIZE:
+            _, evicted = self._open_datasets.popitem(last=False)
+            try:
+                evicted.close()
+            except Exception:
+                pass
+        return ds
+
+    @staticmethod
+    def _decode(product: str, raw: np.ndarray, nodata) -> np.ndarray:
+        """Decode a source tile's raw band to physical units (meters or fraction)."""
+        arr = raw.astype(np.float32)
+        if product == PRODUCT_EVH:
+            return evh_code_to_meters(arr)
+        if product == PRODUCT_EVC:
+            return evc_code_to_fraction(arr)
+        if product == PRODUCT_CC_PCT:
+            out = np.clip(arr, 0.0, 100.0) / 100.0
+            out[arr < 0] = np.nan
+            return out.astype(np.float32)
+        # meta_chm: continuous meters, clamp and drop negatives/nodata.
+        out = arr.copy()
+        if nodata is not None:
+            out[out == nodata] = np.nan
+        out[out < 0] = np.nan
+        return np.clip(out, 0.0, 60.0).astype(np.float32)
+
+    def sample_grid_spec(self, spec) -> Optional[CanopySample]:
+        """Return a CanopySample co-registered to ``spec``, or None if no tile
+        intersects the footprint."""
+        tiles = self.lookup_tiles_bbox(*spec.wgs84_bounds())
+        if not tiles:
+            return None
+        try:
+            import rasterio  # noqa: F401
+            from rasterio.warp import reproject, Resampling
+        except ImportError as e:
+            self.logger.error(f"CanopyService: rasterio required for sample_grid_spec: {e}")
+            return None
+
+        chm = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
+        cover = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
+        got_height = got_cover = False
+
+        for tile in tiles:
+            ds = self._get_dataset(tile['full_path'])
+            if ds is None:
+                continue
+            product = tile['product']
+            nodata = ds.nodatavals[0] if ds.nodatavals else None
+            try:
+                src = self._decode(product, ds.read(1), nodata)
+            except Exception as e:
+                self.logger.warning(f"CanopyService: decode failed for {tile['filename']}: {e}")
+                continue
+            target = chm if product in _HEIGHT_PRODUCTS else cover
+            tmp = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
+            try:
+                reproject(
+                    source=src, destination=tmp,
+                    src_transform=ds.transform, src_crs=ds.crs, src_nodata=np.nan,
+                    dst_transform=spec.transform, dst_crs=spec.crs, dst_nodata=np.nan,
+                    resampling=Resampling.bilinear)
+            except Exception as e:
+                self.logger.warning(f"CanopyService: reproject failed for {tile['filename']}: {e}")
+                continue
+            merged = np.where(np.isnan(target) & ~np.isnan(tmp), tmp, target)
+            if product in _HEIGHT_PRODUCTS:
+                chm = merged
+                got_height = True
+            else:
+                cover = merged
+                got_cover = True
+
+        if not (got_height or got_cover):
+            return None
+
+        # No-canopy cells default to 0 height (L_eff == 0 -> transmittance 1).
+        chm = np.where(np.isnan(chm), 0.0, chm).astype(np.float32)
+
+        cover_derived = False
+        if not got_cover or np.isnan(cover).all():
+            cover = np.clip(chm / self.h_ref_m, 0.0, 1.0) * self.c_max
+            cover_derived = True
+        else:
+            # Derive only where cover is missing but canopy is present.
+            need = np.isnan(cover) & (chm > 0)
+            if need.any():
+                cover = cover.copy()
+                cover[need] = np.clip(chm[need] / self.h_ref_m, 0.0, 1.0) * self.c_max
+                cover_derived = True
+            cover = np.where(np.isnan(cover), 0.0, cover)
+        cover = cover.astype(np.float32)
+
+        return CanopySample(chm=chm, cover=cover, transform=spec.transform,
+                            crs=spec.crs, cover_derived=cover_derived,
+                            source_name=self.source_name)
+
+    def reset(self):
+        self.close()
+
+    def close(self):
+        for ds in self._open_datasets.values():
+            try:
+                ds.close()
+            except Exception:
+                pass
+        self._open_datasets.clear()

--- a/app/core/services/terrain/CanopyService.py
+++ b/app/core/services/terrain/CanopyService.py
@@ -260,7 +260,14 @@ class CanopyService:
             product = tile['product']
             nodata = ds.nodatavals[0] if ds.nodatavals else None
             try:
-                src = self._decode(product, ds.read(1), nodata)
+                # Read ONLY the window under the footprint. Meta/WRI canopy COGs
+                # are ~65536x65536 (16 GB) -- a full ds.read(1) would OOM; the
+                # windowed read touches only the AOI.
+                from core.services.terrain.grid import read_window
+                raw, win_transform = read_window(ds, spec, nodata)
+                if raw is None:
+                    continue
+                src = self._decode(product, raw, nodata)
             except Exception as e:
                 self.logger.warning(f"CanopyService: decode failed for {tile['filename']}: {e}")
                 continue
@@ -269,7 +276,7 @@ class CanopyService:
             try:
                 reproject(
                     source=src, destination=tmp,
-                    src_transform=ds.transform, src_crs=ds.crs, src_nodata=np.nan,
+                    src_transform=win_transform, src_crs=ds.crs, src_nodata=np.nan,
                     dst_transform=spec.transform, dst_crs=spec.crs, dst_nodata=np.nan,
                     resampling=Resampling.bilinear)
             except Exception as e:

--- a/app/core/services/terrain/CanopyServiceFactory.py
+++ b/app/core/services/terrain/CanopyServiceFactory.py
@@ -1,0 +1,56 @@
+"""
+CanopyServiceFactory - construct a CanopyService from user settings.
+
+Canopy is a separate axis from the terrain elevation provider (both can be
+active at once), so it has its own factory and settings keys, mirroring the
+Terrain3DEP* pattern. Returns None when unconfigured, which the POD pipeline
+treats as "no canopy" (transmittance = 1).
+"""
+
+from core.services.LoggerService import LoggerService
+
+CANOPY_KIND_NONE = 'none'
+CANOPY_KIND_LANDFIRE = 'landfire'
+CANOPY_KIND_META = 'meta'
+DEFAULT_CANOPY_KIND = CANOPY_KIND_NONE
+
+
+class CanopyServiceFactory:
+    @staticmethod
+    def create_from_settings(settings_service):
+        """Build a CanopyService from settings, or None if unconfigured."""
+        if settings_service is None:
+            return None
+        kind = settings_service.get_setting('CanopyKind', DEFAULT_CANOPY_KIND) or DEFAULT_CANOPY_KIND
+        if kind == CANOPY_KIND_NONE:
+            return None
+
+        manifest = settings_service.get_setting('CanopyManifestPath', '')
+        tiles_dir = settings_service.get_setting('CanopyTilesDir', '')
+        if not manifest or not tiles_dir:
+            LoggerService().warning("CanopyServiceFactory: paths unset; canopy disabled.")
+            return None
+
+        try:
+            from core.services.terrain.CanopyService import CanopyService
+            return CanopyService(manifest, tiles_dir, kind=kind)
+        except Exception as e:
+            LoggerService().error(f"CanopyServiceFactory: failed ({e}); canopy disabled.")
+            return None
+
+    @staticmethod
+    def available_kinds():
+        """Drives the Preferences combo. [{id, label, requires_paths}]."""
+        return [
+            {'id': CANOPY_KIND_NONE,
+             'label': 'None (no canopy attenuation)', 'requires_paths': False},
+            {'id': CANOPY_KIND_LANDFIRE,
+             'label': 'LANDFIRE EVH + EVC (local GeoTIFFs, 30 m)', 'requires_paths': True},
+            {'id': CANOPY_KIND_META,
+             'label': 'Meta/WRI Canopy Height (local GeoTIFFs, 1 m)', 'requires_paths': True},
+        ]
+
+
+def create_canopy_service(settings_service):
+    """Module-level alias (the export layer references this name)."""
+    return CanopyServiceFactory.create_from_settings(settings_service)

--- a/app/core/services/terrain/ElevationProvider.py
+++ b/app/core/services/terrain/ElevationProvider.py
@@ -42,6 +42,10 @@ class ElevationProvider(ABC):
         providers don't have anything to load up-front."""
         return None
 
+    # Upper bound on cells the slow (per-point) grid fallback will sample before
+    # refusing, so a mis-sized bbox can't spin for an hour of point queries.
+    SLOW_GRID_CELL_LIMIT = 250_000
+
     def sample_elevation(self, lat: float, lon: float) -> Optional[float]:
         """Return orthometric elevation in meters at lat/lon, or None if unavailable.
 
@@ -53,6 +57,57 @@ class ElevationProvider(ABC):
             f"{self.__class__.__name__} did not override sample_elevation; "
             "this is required for non-tile providers."
         )
+
+    def sample_grid(self, bounds_wgs84: Tuple[float, float, float, float],
+                    resolution_m: float):
+        """Return an elevation grid covering ``bounds_wgs84`` at ~``resolution_m``.
+
+        Convenience wrapper: derives a lattice-snapped EPSG:3857 ``GridSpec`` and
+        delegates to :meth:`sample_grid_spec`. ``bounds_wgs84`` is
+        (min_lon, min_lat, max_lon, max_lat).
+        """
+        from .grid import spec_for_bounds_wgs84
+        return self.sample_grid_spec(spec_for_bounds_wgs84(bounds_wgs84, resolution_m))
+
+    def sample_grid_spec(self, spec):
+        """Return a ``GridSample`` for ``spec``, or None if unavailable.
+
+        Default slow path: loop :meth:`sample_elevation` over cell centers. Works
+        for any provider that implements ``sample_elevation``; providers with a
+        fast windowed path (e.g. local GeoTIFF) override this. Returns None when
+        ``sample_elevation`` is unimplemented (tile-based providers — their fast
+        path lives on ``TerrainService``) or when the grid exceeds
+        ``SLOW_GRID_CELL_LIMIT``.
+        """
+        import numpy as np
+        from .grid import GridSample, mercator_to_lonlat
+
+        n_cells = spec.width * spec.height
+        if n_cells > self.SLOW_GRID_CELL_LIMIT:
+            logger = getattr(self, 'logger', None)
+            if logger is not None:
+                logger.warning(
+                    f"{self.__class__.__name__}: grid {spec.width}x{spec.height} exceeds "
+                    f"slow-path limit {self.SLOW_GRID_CELL_LIMIT}; refusing."
+                )
+            return None
+
+        xs, ys = spec.cell_centers()
+        data = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
+        try:
+            for i, y in enumerate(ys):
+                for j, x in enumerate(xs):
+                    lon, lat = mercator_to_lonlat(float(x), float(y))
+                    value = self.sample_elevation(lat, lon)
+                    if value is not None:
+                        data[i, j] = value
+        except NotImplementedError:
+            return None
+
+        datum = self.get_datum_info()
+        datum_note = f"{datum.get('type', '')} {datum.get('name', '')}".strip()
+        return GridSample(data=data, transform=spec.transform, crs=spec.crs,
+                          datum_note=datum_note)
 
     def get_tile_url(self, z: int, x: int, y: int) -> str:
         """Get the URL for a specific tile (tile-based providers only)."""

--- a/app/core/services/terrain/TerrainService.py
+++ b/app/core/services/terrain/TerrainService.py
@@ -255,6 +255,44 @@ class TerrainService:
             results.append(self.get_elevation(lat, lon, offline_only))
         return results
 
+    def sample_grid(self, bounds_wgs84, resolution_m: float, offline_only: bool = False):
+        """Sample an elevation grid covering ``bounds_wgs84`` at ~``resolution_m``.
+
+        Convenience wrapper deriving a lattice-snapped EPSG:3857 ``GridSpec`` and
+        delegating to :meth:`sample_grid_spec`. Returns a ``GridSample`` or None.
+        """
+        from .grid import spec_for_bounds_wgs84
+        return self.sample_grid_spec(spec_for_bounds_wgs84(bounds_wgs84, resolution_m),
+                                     offline_only=offline_only)
+
+    def sample_grid_spec(self, spec, offline_only: bool = False):
+        """Sample the active provider onto ``spec`` (EPSG:3857 GridSpec).
+
+        Dispatches by provider kind, mirroring :meth:`get_elevation`:
+        local_geotiff providers use their windowed-reproject fast path; tiled_web
+        providers go through the Terrarium mosaic sampler; any other provider
+        falls back to the ABC per-point slow path. Returns a ``GridSample`` or
+        None when terrain is disabled or no data covers the grid.
+        """
+        if not self._enabled:
+            return None
+
+        kind = self.provider.get_provider_kind()
+        if kind == 'local_geotiff':
+            # The provider's windowed-reproject path is authoritative; if no tile
+            # covers the grid the per-point slow path would also find nothing.
+            return self.provider.sample_grid_spec(spec)
+
+        if kind == 'tiled_web':
+            from .TerrariumGridSampler import sample_grid_tiled
+            sample = sample_grid_tiled(self.provider, self.cache, spec, self.zoom,
+                                       offline_only=offline_only)
+            if sample is not None:
+                return sample
+
+        # Last resort: ABC per-point slow path (works for any sample_elevation provider).
+        return self.provider.sample_grid_spec(spec)
+
     def get_effective_altitude_agl(
         self,
         drone_lat: float,

--- a/app/core/services/terrain/TerrariumGridSampler.py
+++ b/app/core/services/terrain/TerrariumGridSampler.py
@@ -1,0 +1,130 @@
+"""
+TerrariumGridSampler - grid sampling for the tiled-web Terrarium provider.
+
+Terrarium PNG tiles are Web Mercator, so sampling a grid is pure pixel
+arithmetic (no reprojection): assemble the covering tiles into a mosaic, decode
+the RGB elevation encoding vectorized, then resample to the requested GridSpec
+with bilinear interpolation.
+
+This lives as a module-level function rather than a provider method because the
+provider does not own the tile cache — TerrainService drives the tiled path,
+exactly as it does for point queries in ``TerrainService.get_elevation``.
+"""
+
+import math
+from typing import Optional
+
+import numpy as np
+
+from core.services.LoggerService import LoggerService
+from .grid import GridSpec, GridSample, WEB_MERCATOR_ORIGIN_SHIFT
+
+TILE_SIZE = 256
+# A single frame footprint at zoom 12 spans a handful of tiles; a request needing
+# more than this is almost certainly mis-sized and would blow up memory.
+MAX_TILES = 64
+
+_logger = LoggerService()
+
+
+def _global_pixel_bounds(spec: GridSpec, zoom: int):
+    """Global Web-Mercator pixel coords (at ``zoom``) of the spec's bounds.
+
+    Returns (px_min, py_min, px_max, py_max) as floats. y increases downward.
+    """
+    world = TILE_SIZE * (2.0 ** zoom)
+    scale = world / (2.0 * WEB_MERCATOR_ORIGIN_SHIFT)
+    minx, miny, maxx, maxy = spec.bounds
+    px_min = (minx + WEB_MERCATOR_ORIGIN_SHIFT) * scale
+    px_max = (maxx + WEB_MERCATOR_ORIGIN_SHIFT) * scale
+    py_min = (WEB_MERCATOR_ORIGIN_SHIFT - maxy) * scale  # top edge -> smaller y
+    py_max = (WEB_MERCATOR_ORIGIN_SHIFT - miny) * scale
+    return px_min, py_min, px_max, py_max
+
+
+def _decode_tile(img) -> np.ndarray:
+    """Vectorized Terrarium decode of a PIL tile -> (H, W) float32 meters."""
+    arr = np.asarray(img.convert('RGB'), dtype=np.float32)
+    return arr[..., 0] * 256.0 + arr[..., 1] + arr[..., 2] / 256.0 - 32768.0
+
+
+def sample_grid_tiled(provider, cache, spec: GridSpec, zoom: int,
+                      offline_only: bool = False) -> Optional[GridSample]:
+    """Sample a Web-Mercator tiled provider onto ``spec``.
+
+    Args:
+        provider: the tiled_web ElevationProvider (used for datum info + tile math).
+        cache: a TerrainCacheService returning PIL tiles via get_tile/get_tile_if_cached.
+        spec: the target EPSG:3857 GridSpec.
+        zoom: tile zoom level (usually TerrainService.zoom).
+        offline_only: only use already-cached tiles when True.
+
+    Returns:
+        GridSample, or None if no tiles are available or the request is too large.
+    """
+    if cache is None:
+        return None
+
+    px_min, py_min, px_max, py_max = _global_pixel_bounds(spec, zoom)
+    x0 = int(math.floor(px_min / TILE_SIZE))
+    x1 = int(math.floor((px_max - 1e-9) / TILE_SIZE))
+    y0 = int(math.floor(py_min / TILE_SIZE))
+    y1 = int(math.floor((py_max - 1e-9) / TILE_SIZE))
+
+    n_tiles = (x1 - x0 + 1) * (y1 - y0 + 1)
+    if n_tiles <= 0:
+        return None
+    if n_tiles > MAX_TILES:
+        _logger.warning(
+            f"TerrariumGridSampler: {n_tiles} tiles for grid exceeds MAX_TILES={MAX_TILES}; refusing."
+        )
+        return None
+
+    mosaic_h = (y1 - y0 + 1) * TILE_SIZE
+    mosaic_w = (x1 - x0 + 1) * TILE_SIZE
+    mosaic = np.full((mosaic_h, mosaic_w), np.nan, dtype=np.float32)
+
+    got_any = False
+    for ty in range(y0, y1 + 1):
+        for tx in range(x0, x1 + 1):
+            if offline_only:
+                tile = cache.get_tile_if_cached(zoom, tx, ty)
+            else:
+                tile = cache.get_tile(zoom, tx, ty)
+            if tile is None:
+                continue
+            block = _decode_tile(tile)
+            ry = (ty - y0) * TILE_SIZE
+            rx = (tx - x0) * TILE_SIZE
+            mosaic[ry:ry + TILE_SIZE, rx:rx + TILE_SIZE] = block
+            got_any = True
+
+    if not got_any:
+        return None
+
+    # Fractional mosaic pixel coordinates of each spec cell center.
+    xs, ys = spec.cell_centers()
+    world = TILE_SIZE * (2.0 ** zoom)
+    scale = world / (2.0 * WEB_MERCATOR_ORIGIN_SHIFT)
+    # global pixel of each center, minus mosaic origin
+    gx = (xs + WEB_MERCATOR_ORIGIN_SHIFT) * scale - x0 * TILE_SIZE
+    gy = (WEB_MERCATOR_ORIGIN_SHIFT - ys) * scale - y0 * TILE_SIZE
+    grid_x, grid_y = np.meshgrid(gx, gy)  # (H, W)
+
+    from scipy.ndimage import map_coordinates
+    # Match ADIAT's point sampler (TerrariumProvider.decode_elevation_bilinear):
+    # the continuous global-pixel coordinate is used directly, so an integer
+    # coordinate lands on that pixel's value (no half-pixel center offset). This
+    # keeps grid samples consistent with get_elevation() at the same location.
+    sampled = map_coordinates(
+        mosaic,
+        [grid_y, grid_x],
+        order=1,
+        mode='constant',
+        cval=np.nan,
+    ).astype(np.float32)
+
+    datum = provider.get_datum_info()
+    datum_note = f"{datum.get('type', '')} {datum.get('name', '')}".strip()
+    return GridSample(data=sampled, transform=spec.transform, crs=spec.crs,
+                      datum_note=datum_note)

--- a/app/core/services/terrain/TileFetchService.py
+++ b/app/core/services/terrain/TileFetchService.py
@@ -1,0 +1,241 @@
+"""
+TileFetchService - download DEM / canopy tiles for an AOI and write the manifest.
+
+* USGS 3DEP DEM  - ArcGIS ImageServer exportImage, tiled to keep each request
+  under a pixel cap; writes GeoTIFF tiles + the manifest the USGS3DEPProvider
+  reads. (No API key.)
+* Meta/WRI CHM   - Bing-quadkey z9 COG tiles from the public S3 bucket; writes
+  the COG bytes as local tiles + the manifest CanopyService reads.
+
+Both mirror the SAR-Preflight fetch patterns (single blind retry for 3DEP;
+linear-backoff retry with skip-on-404 for canopy). Network / file I/O only; no
+Qt. A ``requests.Session`` may be injected for tests.
+"""
+
+import csv
+import math
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from core.services.LoggerService import LoggerService
+
+
+@dataclass
+class FetchResult:
+    product: str
+    out_dir: str
+    manifest_path: Optional[str]
+    tiles_written: int = 0
+    tiles_failed: int = 0
+    tiles_skipped: int = 0
+    errors: List[Tuple[str, str]] = field(default_factory=list)
+    cancelled: bool = False
+
+
+class TileFetchService:
+    META_CHM_URL = ("https://dataforgood-fb-data.s3.amazonaws.com/forests/v1/"
+                    "alsgedi_global_v6_float/chm/{quadkey}.tif")
+    DEP_EXPORT_URL = ("https://elevation.nationalmap.gov/arcgis/rest/services/"
+                      "3DEPElevation/ImageServer/exportImage")
+    MAX_RETRIES = 4
+    BACKOFF_MS = 300
+    METERS_PER_DEG = 111320.0
+
+    def __init__(self, logger: Optional[LoggerService] = None, session=None,
+                 timeout: float = 60.0, backoff_ms: Optional[int] = None):
+        self.logger = logger or LoggerService()
+        self._session = session
+        self.timeout = timeout
+        self.backoff_ms = self.BACKOFF_MS if backoff_ms is None else backoff_ms
+
+    @property
+    def session(self):
+        if self._session is None:
+            import requests
+            self._session = requests.Session()
+            self._session.headers.update({'User-Agent': 'ADIAT/1.0 (Drone Image Analysis Tool)'})
+        return self._session
+
+    # ---- slippy / quadkey math ----
+
+    @staticmethod
+    def lnglat_to_tile_xy(lon: float, lat: float, z: int) -> Tuple[int, int]:
+        lat_rad = math.radians(lat)
+        n = 2 ** z
+        x = int((lon + 180.0) / 360.0 * n)
+        y = int((1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n)
+        x = max(0, min(x, n - 1))
+        y = max(0, min(y, n - 1))
+        return x, y
+
+    @staticmethod
+    def tile_xy_to_quadkey(x: int, y: int, z: int) -> str:
+        qk = []
+        for i in range(z, 0, -1):
+            digit = 0
+            mask = 1 << (i - 1)
+            if x & mask:
+                digit += 1
+            if y & mask:
+                digit += 2
+            qk.append(str(digit))
+        return "".join(qk)
+
+    @staticmethod
+    def tile_xy_to_bounds(x: int, y: int, z: int) -> Tuple[float, float, float, float]:
+        n = 2.0 ** z
+        lon0 = x / n * 360.0 - 180.0
+        lon1 = (x + 1) / n * 360.0 - 180.0
+        lat1 = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * y / n))))
+        lat0 = math.degrees(math.atan(math.sinh(math.pi * (1 - 2 * (y + 1) / n))))
+        return (lon0, lat0, lon1, lat1)
+
+    @classmethod
+    def tiles_covering_bbox(cls, bounds_wgs84, z: int) -> List[Tuple[int, int]]:
+        min_lon, min_lat, max_lon, max_lat = bounds_wgs84
+        x0, y0 = cls.lnglat_to_tile_xy(min_lon, max_lat, z)   # NW
+        x1, y1 = cls.lnglat_to_tile_xy(max_lon, min_lat, z)   # SE
+        tiles = []
+        for x in range(min(x0, x1), max(x0, x1) + 1):
+            for y in range(min(y0, y1), max(y0, y1) + 1):
+                tiles.append((x, y))
+        return tiles
+
+    # ---- HTTP ----
+
+    def _get_with_retry(self, url, params=None):
+        """GET with linear backoff. Returns bytes, or None for absent (403/404)
+        or exhausted retries."""
+        for attempt in range(self.MAX_RETRIES):
+            if attempt > 0 and self.backoff_ms:
+                time.sleep(self.backoff_ms * attempt / 1000.0)
+            try:
+                resp = self.session.get(url, params=params, timeout=self.timeout)
+            except Exception as e:
+                self.logger.warning(f"TileFetch: request error {url}: {e}")
+                continue
+            if resp.status_code == 200:
+                return resp.content
+            if resp.status_code in (403, 404):
+                return None
+            self.logger.warning(f"TileFetch: HTTP {resp.status_code} for {url}")
+        return None
+
+    @staticmethod
+    def _write_manifest(rows, manifest_path, include_product):
+        fields = ['filename']
+        if include_product:
+            fields.append('product')
+        fields += ['minX', 'minY', 'maxX', 'maxY']
+        # Merge with any existing manifest (dedupe by filename) for incremental AOIs.
+        existing = {}
+        if os.path.exists(manifest_path):
+            try:
+                with open(manifest_path, newline='') as fh:
+                    for r in csv.DictReader(fh):
+                        existing[r['filename']] = r
+            except Exception:
+                existing = {}
+        for r in rows:
+            existing[r['filename']] = r
+        with open(manifest_path, 'w', newline='') as fh:
+            w = csv.DictWriter(fh, fieldnames=fields)
+            w.writeheader()
+            for r in existing.values():
+                w.writerow({k: r.get(k, '') for k in fields})
+
+    # ---- 3DEP DEM ----
+
+    def fetch_3dep_dem(self, bounds_wgs84, out_dir, image_sr: int = 4326,
+                       tile_px: int = 2048, native_res_m: float = 1.0,
+                       progress_callback=None, cancel_check=None) -> FetchResult:
+        min_lon, min_lat, max_lon, max_lat = bounds_wgs84
+        os.makedirs(out_dir, exist_ok=True)
+        mid_lat = (min_lat + max_lat) / 2.0
+        m_per_deg_lon = self.METERS_PER_DEG * max(0.05, math.cos(math.radians(mid_lat)))
+
+        # Ground span of one sub-tile at the target resolution.
+        dlat_tile = tile_px * native_res_m / self.METERS_PER_DEG
+        dlon_tile = tile_px * native_res_m / m_per_deg_lon
+        n_x = max(1, math.ceil((max_lon - min_lon) / dlon_tile))
+        n_y = max(1, math.ceil((max_lat - min_lat) / dlat_tile))
+
+        result = FetchResult(product='usgs_3dep_dem', out_dir=out_dir, manifest_path=None)
+        rows = []
+        total = n_x * n_y
+        done = 0
+        for j in range(n_y):
+            for i in range(n_x):
+                if cancel_check and cancel_check():
+                    result.cancelled = True
+                    return result
+                w = min_lon + i * dlon_tile
+                e = min(max_lon, w + dlon_tile)
+                s = min_lat + j * dlat_tile
+                north = min(max_lat, s + dlat_tile)
+                cols = max(1, min(tile_px, round((e - w) * m_per_deg_lon / native_res_m)))
+                rows_px = max(1, min(tile_px, round((north - s) * self.METERS_PER_DEG / native_res_m)))
+                params = {
+                    'bbox': f"{w},{s},{e},{north}", 'bboxSR': 4326, 'imageSR': image_sr,
+                    'size': f"{cols},{rows_px}", 'format': 'tiff', 'pixelType': 'F32',
+                    'interpolation': 'RSP_BilinearInterpolation', 'f': 'image',
+                }
+                filename = f"dem_{j}_{i}.tif"
+                content = self._get_with_retry(self.DEP_EXPORT_URL, params=params)
+                if content is None:
+                    # one blind retry (endpoint occasionally 502s)
+                    content = self._get_with_retry(self.DEP_EXPORT_URL, params=params)
+                if content is None:
+                    result.tiles_failed += 1
+                    result.errors.append((filename, "download failed"))
+                else:
+                    Path(out_dir, filename).write_bytes(content)
+                    rows.append({'filename': filename, 'minX': w, 'minY': s,
+                                 'maxX': e, 'maxY': north})
+                    result.tiles_written += 1
+                done += 1
+                if progress_callback:
+                    progress_callback(done, total, f"Downloading DEM tile {done}/{total}...")
+
+        if rows:
+            manifest = os.path.join(out_dir, "dem_manifest.csv")
+            self._write_manifest(rows, manifest, include_product=False)
+            result.manifest_path = manifest
+        return result
+
+    # ---- Meta/WRI canopy ----
+
+    def fetch_meta_canopy(self, bounds_wgs84, out_dir, zoom: int = 9,
+                          progress_callback=None, cancel_check=None) -> FetchResult:
+        os.makedirs(out_dir, exist_ok=True)
+        tiles = self.tiles_covering_bbox(bounds_wgs84, zoom)
+        result = FetchResult(product='meta_chm', out_dir=out_dir, manifest_path=None)
+        rows = []
+        total = len(tiles)
+        for done, (x, y) in enumerate(tiles, start=1):
+            if cancel_check and cancel_check():
+                result.cancelled = True
+                return result
+            qk = self.tile_xy_to_quadkey(x, y, zoom)
+            url = self.META_CHM_URL.format(quadkey=qk)
+            filename = f"chm_{qk}.tif"
+            content = self._get_with_retry(url)
+            if content is None:
+                result.tiles_skipped += 1
+            else:
+                Path(out_dir, filename).write_bytes(content)
+                lon0, lat0, lon1, lat1 = self.tile_xy_to_bounds(x, y, zoom)
+                rows.append({'filename': filename, 'product': 'meta_chm',
+                             'minX': lon0, 'minY': lat0, 'maxX': lon1, 'maxY': lat1})
+                result.tiles_written += 1
+            if progress_callback:
+                progress_callback(done, total, f"Downloading canopy tile {done}/{total}...")
+
+        if rows:
+            manifest = os.path.join(out_dir, "chm_manifest.csv")
+            self._write_manifest(rows, manifest, include_product=True)
+            result.manifest_path = manifest
+        return result

--- a/app/core/services/terrain/USGS3DEPProvider.py
+++ b/app/core/services/terrain/USGS3DEPProvider.py
@@ -178,6 +178,8 @@ class USGS3DEPProvider(ElevationProvider):
             self.logger.error(f"USGS3DEPProvider: rasterio required for sample_grid_spec: {e}")
             return None
 
+        from .grid import read_window
+
         dest = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
         merged_any = False
         for tile in tiles:
@@ -185,14 +187,21 @@ class USGS3DEPProvider(ElevationProvider):
             if ds is None:
                 continue
             src_nodata = ds.nodatavals[0] if ds.nodatavals else None
+            # Read only the footprint window so large 3DEP tiles never load in full.
+            raw, win_transform = read_window(ds, spec, src_nodata)
+            if raw is None:
+                continue
+            src = raw.astype(np.float32)
+            if src_nodata is not None:
+                src[src == src_nodata] = np.nan
             tmp = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
             try:
                 reproject(
-                    source=rasterio.band(ds, 1),
+                    source=src,
                     destination=tmp,
-                    src_transform=ds.transform,
+                    src_transform=win_transform,
                     src_crs=ds.crs,
-                    src_nodata=src_nodata,
+                    src_nodata=np.nan,
                     dst_transform=spec.transform,
                     dst_crs=spec.crs,
                     dst_nodata=np.nan,

--- a/app/core/services/terrain/USGS3DEPProvider.py
+++ b/app/core/services/terrain/USGS3DEPProvider.py
@@ -127,6 +127,96 @@ class USGS3DEPProvider(ElevationProvider):
                 return self._tiles[idx]
         return None
 
+    def lookup_tiles_bbox(self, min_lon: float, min_lat: float,
+                          max_lon: float, max_lat: float) -> list:
+        """Return all manifest entries whose lat/lon bbox intersects the query bbox.
+
+        Unlike :meth:`lookup_tile` (a single containing tile for a point), the
+        grid path needs every tile overlapping the footprint so the mosaic is
+        complete.
+        """
+        if self._strtree is None:
+            return None
+        from shapely.geometry import box
+        query = box(min_lon, min_lat, max_lon, max_lat)
+        candidates = self._strtree.query(query)
+        tiles = []
+        seen = set()
+        for c in candidates:
+            # STRtree.query returns geoms in shapely 1.x, indices in 2.x.
+            if hasattr(c, 'intersects'):
+                geom = c
+                idx = self._strtree_geoms.index(geom)
+            else:
+                idx = int(c)
+                geom = self._strtree_geoms[idx]
+            if idx in seen:
+                continue
+            if geom.intersects(query):
+                seen.add(idx)
+                tiles.append(self._tiles[idx])
+        return tiles
+
+    def sample_grid_spec(self, spec):
+        """Windowed-reproject fast path: mosaic intersecting tiles onto ``spec``.
+
+        Reprojects each intersecting local GeoTIFF into the requested EPSG:3857
+        grid with bilinear resampling, merging first-writer-wins. Returns None
+        when no tile intersects or rasterio is unavailable.
+        """
+        import numpy as np
+        from .grid import GridSample
+
+        tiles = self.lookup_tiles_bbox(*spec.wgs84_bounds())
+        if not tiles:
+            return None
+
+        try:
+            import rasterio  # noqa: F401
+            from rasterio.warp import reproject, Resampling
+        except ImportError as e:
+            self.logger.error(f"USGS3DEPProvider: rasterio required for sample_grid_spec: {e}")
+            return None
+
+        dest = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
+        merged_any = False
+        for tile in tiles:
+            ds = self._get_dataset(tile['full_path'])
+            if ds is None:
+                continue
+            src_nodata = ds.nodatavals[0] if ds.nodatavals else None
+            tmp = np.full((spec.height, spec.width), np.nan, dtype=np.float32)
+            try:
+                reproject(
+                    source=rasterio.band(ds, 1),
+                    destination=tmp,
+                    src_transform=ds.transform,
+                    src_crs=ds.crs,
+                    src_nodata=src_nodata,
+                    dst_transform=spec.transform,
+                    dst_crs=spec.crs,
+                    dst_nodata=np.nan,
+                    resampling=Resampling.bilinear,
+                )
+            except Exception as e:
+                self.logger.warning(
+                    f"USGS3DEPProvider: reproject failed for {tile['filename']}: {e}"
+                )
+                continue
+            dest = np.where(np.isnan(dest), tmp, dest)
+            merged_any = True
+
+        if not merged_any:
+            return None
+
+        # Mask residual 3DEP nodata sentinels that survived as finite values.
+        dest[np.abs(dest) > 1e6] = np.nan
+
+        datum = self.get_datum_info()
+        datum_note = f"{datum.get('type', '')} {datum.get('name', '')} ({datum.get('geoid_model', '')})".strip()
+        return GridSample(data=dest, transform=spec.transform, crs=spec.crs,
+                          datum_note=datum_note)
+
     def _get_dataset(self, full_path: str):
         """LRU-cached rasterio dataset open."""
         if full_path in self._open_datasets:

--- a/app/core/services/terrain/__init__.py
+++ b/app/core/services/terrain/__init__.py
@@ -15,6 +15,27 @@ from .TerrainProviderFactory import (
     DEFAULT_PROVIDER_ID,
 )
 from .USGS3DEPProvider import USGS3DEPProvider
+from .CanopyService import CanopyService, CanopySample
+from .CanopyServiceFactory import (
+    CanopyServiceFactory,
+    create_canopy_service,
+    CANOPY_KIND_NONE,
+    CANOPY_KIND_LANDFIRE,
+    CANOPY_KIND_META,
+)
+from .TileFetchService import TileFetchService, FetchResult
+from .grid import (
+    GridSpec,
+    GridSample,
+    make_lattice_spec,
+    spec_for_bounds_wgs84,
+    integer_offset,
+    lonlat_to_mercator,
+    mercator_to_lonlat,
+    mercator_units_per_meter,
+    WEB_MERCATOR_CRS,
+    WEB_MERCATOR_ORIGIN_SHIFT,
+)
 
 __all__ = [
     'TerrainService',
@@ -27,4 +48,23 @@ __all__ = [
     'PROVIDER_TERRARIUM',
     'PROVIDER_USGS_3DEP_LOCAL',
     'DEFAULT_PROVIDER_ID',
+    'CanopyService',
+    'CanopySample',
+    'CanopyServiceFactory',
+    'create_canopy_service',
+    'CANOPY_KIND_NONE',
+    'CANOPY_KIND_LANDFIRE',
+    'CANOPY_KIND_META',
+    'TileFetchService',
+    'FetchResult',
+    'GridSpec',
+    'GridSample',
+    'make_lattice_spec',
+    'spec_for_bounds_wgs84',
+    'integer_offset',
+    'lonlat_to_mercator',
+    'mercator_to_lonlat',
+    'mercator_units_per_meter',
+    'WEB_MERCATOR_CRS',
+    'WEB_MERCATOR_ORIGIN_SHIFT',
 ]

--- a/app/core/services/terrain/grid.py
+++ b/app/core/services/terrain/grid.py
@@ -1,0 +1,227 @@
+"""
+grid - Web Mercator grid contracts and lattice helpers for terrain sampling.
+
+The Coverage/POD pipeline samples DEM, canopy-height (CHM) and canopy-cover
+rasters onto a shared, co-registered grid so the ray-march kernel can index all
+three with identical (row, col) arithmetic. To make that possible every grid is:
+
+* EPSG:3857 (Web Mercator), north-up, square cells, and
+* snapped to a single global lattice whose cell edges fall on integer multiples
+  of the cell size measured from the 3857 origin.
+
+Any two ``GridSpec`` built with the same cell size are therefore integer-offset
+co-registered by construction (see :func:`integer_offset`).
+
+Web Mercator inflates horizontal ground distance by ``1 / cos(lat)``. This module
+only carries the geometry; callers that need true ground meters multiply
+horizontal deltas by ``meters_per_unit = cos(lat_ref)`` (the reciprocal of
+:func:`mercator_units_per_meter`).
+
+Only ``affine`` (a pure-Python dependency of rasterio) and numpy are imported at
+module load; nothing here needs rasterio/pyproj, so importing this module is
+cheap and safe even when the heavy geo stack is unavailable.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+from affine import Affine
+
+WEB_MERCATOR_R = 6378137.0
+WEB_MERCATOR_CRS = "EPSG:3857"
+# Half the Web Mercator world extent in meters (pi * R). Grid coordinates live in
+# roughly [-ORIGIN_SHIFT, +ORIGIN_SHIFT] on both axes.
+WEB_MERCATOR_ORIGIN_SHIFT = math.pi * WEB_MERCATOR_R
+
+
+def lonlat_to_mercator(lon: float, lat: float) -> Tuple[float, float]:
+    """Closed-form EPSG:4326 -> EPSG:3857 (no rasterio/pyproj needed)."""
+    x = WEB_MERCATOR_R * math.radians(lon)
+    y = WEB_MERCATOR_R * math.asinh(math.tan(math.radians(lat)))
+    return x, y
+
+
+def mercator_to_lonlat(x: float, y: float) -> Tuple[float, float]:
+    """Closed-form EPSG:3857 -> EPSG:4326."""
+    lon = math.degrees(x / WEB_MERCATOR_R)
+    lat = math.degrees(math.atan(math.sinh(y / WEB_MERCATOR_R)))
+    return lon, lat
+
+
+def mercator_units_per_meter(lat: float) -> float:
+    """EPSG:3857 units per true ground meter at ``lat`` (== 1 / cos(lat))."""
+    return 1.0 / math.cos(math.radians(lat))
+
+
+@dataclass(frozen=True)
+class GridSpec:
+    """A fully-determined raster grid: north-up, square cells.
+
+    ``transform`` maps *pixel corners* to CRS coordinates (rasterio convention),
+    so cell center ``(i, j)`` sits at
+    ``(minx + (j + 0.5) * cell, maxy - (i + 0.5) * cell)``.
+    """
+
+    crs: str
+    transform: Affine
+    width: int
+    height: int
+
+    @property
+    def cell_size(self) -> float:
+        """Cell size in CRS units (``transform.a``; ``-transform.e`` matches)."""
+        return self.transform.a
+
+    @property
+    def bounds(self) -> Tuple[float, float, float, float]:
+        """(minx, miny, maxx, maxy) in the grid CRS."""
+        minx = self.transform.c
+        maxy = self.transform.f
+        maxx = minx + self.transform.a * self.width
+        miny = maxy + self.transform.e * self.height
+        return (minx, miny, maxx, maxy)
+
+    def cell_centers(self) -> Tuple[np.ndarray, np.ndarray]:
+        """(xs[width], ys[height]) center coordinates in the grid CRS."""
+        minx, _, _, maxy = self.bounds
+        cell = self.transform.a
+        xs = minx + (np.arange(self.width, dtype=np.float64) + 0.5) * cell
+        ys = maxy - (np.arange(self.height, dtype=np.float64) + 0.5) * cell
+        return xs, ys
+
+    def wgs84_bounds(self) -> Tuple[float, float, float, float]:
+        """(min_lon, min_lat, max_lon, max_lat); closed-form for EPSG:3857.
+
+        Raises ``ValueError`` for non-3857 grids (the POD pipeline is 3857-only).
+        """
+        if self.crs != WEB_MERCATOR_CRS:
+            raise ValueError(
+                f"wgs84_bounds only supports {WEB_MERCATOR_CRS}, got {self.crs}"
+            )
+        minx, miny, maxx, maxy = self.bounds
+        min_lon, min_lat = mercator_to_lonlat(minx, miny)
+        max_lon, max_lat = mercator_to_lonlat(maxx, maxy)
+        return (min_lon, min_lat, max_lon, max_lat)
+
+    def world_to_index(self, x, y) -> Tuple[np.ndarray, np.ndarray]:
+        """Fractional (rows, cols) in *pixel-center* space for map_coordinates.
+
+        ``cols = (x - minx) / cell - 0.5``; ``rows = (maxy - y) / cell - 0.5``.
+        Accepts scalars or arrays; returns numpy arrays.
+        """
+        minx, _, _, maxy = self.bounds
+        cell = self.transform.a
+        cols = (np.asarray(x, dtype=np.float64) - minx) / cell - 0.5
+        rows = (maxy - np.asarray(y, dtype=np.float64)) / cell - 0.5
+        return rows, cols
+
+
+@dataclass
+class GridSample:
+    """A sampled elevation (or other scalar) grid at a known transform."""
+
+    data: np.ndarray            # (rows, cols) float32, np.nan = nodata
+    transform: Affine
+    crs: str
+    datum_note: str             # e.g. "orthometric NAVD88 (GEOID18)"
+
+    @property
+    def spec(self) -> GridSpec:
+        rows, cols = self.data.shape[:2]
+        return GridSpec(crs=self.crs, transform=self.transform,
+                        width=int(cols), height=int(rows))
+
+    def sample_bilinear(self, x: float, y: float) -> Optional[float]:
+        """Bilinear sample at a single (x, y) in the grid CRS.
+
+        Returns ``None`` when the point is out of the grid or any of the four
+        surrounding cells is nodata (NaN).
+        """
+        spec = self.spec
+        rows, cols = spec.world_to_index(x, y)
+        row_f = float(rows)
+        col_f = float(cols)
+        r0 = int(math.floor(row_f))
+        c0 = int(math.floor(col_f))
+        if r0 < 0 or c0 < 0 or r0 + 1 >= self.data.shape[0] or c0 + 1 >= self.data.shape[1]:
+            return None
+        fr = row_f - r0
+        fc = col_f - c0
+        d = self.data
+        v00 = float(d[r0, c0])
+        v01 = float(d[r0, c0 + 1])
+        v10 = float(d[r0 + 1, c0])
+        v11 = float(d[r0 + 1, c0 + 1])
+        if any(math.isnan(v) for v in (v00, v01, v10, v11)):
+            return None
+        top = v00 * (1 - fc) + v01 * fc
+        bot = v10 * (1 - fc) + v11 * fc
+        return top * (1 - fr) + bot * fr
+
+
+def make_lattice_spec(bounds_3857: Tuple[float, float, float, float],
+                      cell_size: float, crs: str = WEB_MERCATOR_CRS) -> GridSpec:
+    """Snap ``bounds_3857`` OUTWARD to the global lattice and return a GridSpec.
+
+    Lattice edges fall on integer multiples of ``cell_size`` from the CRS origin,
+    so two specs built with the same ``cell_size`` are integer-offset
+    co-registered. Always yields a grid at least 1x1.
+    """
+    if cell_size <= 0:
+        raise ValueError(f"cell_size must be positive, got {cell_size}")
+    minx, miny, maxx, maxy = bounds_3857
+    if maxx < minx or maxy < miny:
+        raise ValueError(f"degenerate bounds: {bounds_3857}")
+
+    left = math.floor(minx / cell_size) * cell_size
+    right = math.ceil(maxx / cell_size) * cell_size
+    bottom = math.floor(miny / cell_size) * cell_size
+    top = math.ceil(maxy / cell_size) * cell_size
+
+    width = max(1, int(round((right - left) / cell_size)))
+    height = max(1, int(round((top - bottom) / cell_size)))
+    transform = Affine(cell_size, 0.0, left, 0.0, -cell_size, top)
+    return GridSpec(crs=crs, transform=transform, width=width, height=height)
+
+
+def spec_for_bounds_wgs84(bounds_wgs84: Tuple[float, float, float, float],
+                          resolution_m: float) -> GridSpec:
+    """Build a lattice-snapped EPSG:3857 GridSpec covering a WGS84 bbox.
+
+    ``resolution_m`` is the desired *true ground* cell size; it is converted to
+    3857 units at the bbox mid-latitude (``cell = resolution_m / cos(mid_lat)``)
+    so cells are ~``resolution_m`` on the ground. Backs the spec's
+    ``sample_grid(bounds, resolution_m)`` convenience signature.
+    """
+    min_lon, min_lat, max_lon, max_lat = bounds_wgs84
+    mid_lat = (min_lat + max_lat) / 2.0
+    cell_size = resolution_m * mercator_units_per_meter(mid_lat)
+    minx, miny = lonlat_to_mercator(min_lon, min_lat)
+    maxx, maxy = lonlat_to_mercator(max_lon, max_lat)
+    return make_lattice_spec((minx, miny, maxx, maxy), cell_size)
+
+
+def integer_offset(child: GridSpec, parent: GridSpec,
+                   tol: float = 1e-6) -> Tuple[int, int]:
+    """(row_off, col_off) of ``child``'s top-left cell within ``parent``.
+
+    Raises ``ValueError`` if the cell sizes differ or the offset is not an
+    integer number of cells within ``tol`` (a fraction of a cell).
+    """
+    cell = parent.transform.a
+    if abs(child.transform.a - cell) > tol * cell:
+        raise ValueError(
+            f"cell size mismatch: child={child.transform.a} parent={cell}"
+        )
+    col_off = (child.transform.c - parent.transform.c) / cell
+    # transform.f is the top (maxy); rows increase downward, so use parent - child.
+    row_off = (parent.transform.f - child.transform.f) / cell
+    col_r = round(col_off)
+    row_r = round(row_off)
+    if abs(col_off - col_r) > tol or abs(row_off - row_r) > tol:
+        raise ValueError(
+            f"non-integer lattice offset: row={row_off}, col={col_off}"
+        )
+    return int(row_r), int(col_r)

--- a/app/core/services/terrain/grid.py
+++ b/app/core/services/terrain/grid.py
@@ -203,6 +203,37 @@ def spec_for_bounds_wgs84(bounds_wgs84: Tuple[float, float, float, float],
     return make_lattice_spec((minx, miny, maxx, maxy), cell_size)
 
 
+def read_window(ds, spec: GridSpec, nodata=None, pad_px: int = 4):
+    """Read only the ``spec`` footprint from an open rasterio dataset (band 1).
+
+    Returns (array, window_transform), or (None, None) if the footprint does not
+    intersect the tile. Reading a bounded window keeps huge (Cloud-Optimized)
+    tiles from ever loading in full -- e.g. the ~65536x65536 (16 GB) Meta/WRI
+    canopy COGs, or large USGS 3DEP tiles.
+    """
+    from rasterio.windows import from_bounds, Window
+    from rasterio.warp import transform_bounds
+
+    left, bottom, right, top = spec.bounds
+    src_bounds = transform_bounds(spec.crs, ds.crs, left, bottom, right, top)
+    try:
+        win = from_bounds(*src_bounds, transform=ds.transform)
+    except Exception:
+        return None, None
+    win = win.round_offsets().round_lengths()
+    win = Window(win.col_off - pad_px, win.row_off - pad_px,
+                 win.width + 2 * pad_px, win.height + 2 * pad_px)
+    if (win.col_off + win.width <= 0 or win.row_off + win.height <= 0
+            or win.col_off >= ds.width or win.row_off >= ds.height
+            or win.width <= 0 or win.height <= 0):
+        return None, None
+    fill = float(nodata) if nodata is not None else -9999.0
+    raw = ds.read(1, window=win, boundless=True, fill_value=fill)
+    if raw.size == 0:
+        return None, None
+    return raw, ds.window_transform(win)
+
+
 def integer_offset(child: GridSpec, parent: GridSpec,
                    tol: float = 1e-6) -> Tuple[int, int]:
     """(row_off, col_off) of ``child``'s top-left cell within ``parent``.

--- a/app/core/views/images/viewer/dialogs/GPSMapDialog.py
+++ b/app/core/views/images/viewer/dialogs/GPSMapDialog.py
@@ -137,6 +137,7 @@ class GPSMapDialog(TranslationMixin, QDialog):
         self.pod_mode_combo = QComboBox()
         self.pod_mode_combo.addItem(self.tr("POD"), "pod")          # itemData = stable key
         self.pod_mode_combo.addItem(self.tr("Look count"), "looks")
+        self.pod_mode_combo.addItem(self.tr("Canopy height"), "canopy")
         self.pod_mode_combo.setEnabled(False)
         self.pod_mode_combo.currentIndexChanged.connect(self._emit_pod_display_changed)
         controls_layout.addWidget(self.pod_mode_combo)
@@ -162,10 +163,36 @@ class GPSMapDialog(TranslationMixin, QDialog):
 
     def set_pod_available(self, available):
         """Enable/disable the POD overlay controls based on a cached result."""
-        self.pod_toggle_btn.setEnabled(bool(available))
-        self.pod_mode_combo.setEnabled(bool(available) and self.pod_toggle_btn.isChecked())
-        self.pod_opacity_slider.setEnabled(bool(available) and self.pod_toggle_btn.isChecked())
-        if not available and self.pod_toggle_btn.isChecked():
+        self.set_overlay_availability(available, getattr(self, '_canopy_available', False))
+
+    def set_overlay_availability(self, pod_available, canopy_available):
+        """Gate the overlay controls: the POD/look-count modes need a cached POD
+        result, while the canopy mode only needs a configured canopy source."""
+        self._pod_available = bool(pod_available)
+        self._canopy_available = bool(canopy_available)
+        any_available = self._pod_available or self._canopy_available
+
+        model = self.pod_mode_combo.model()
+        for i in range(self.pod_mode_combo.count()):
+            item = model.item(i)
+            if item is not None:
+                key = self.pod_mode_combo.itemData(i)
+                item.setEnabled(self._canopy_available if key == 'canopy'
+                                else self._pod_available)
+
+        # If the current mode just became unavailable, hop to the first enabled one.
+        cur = model.item(self.pod_mode_combo.currentIndex())
+        if cur is None or not cur.isEnabled():
+            for i in range(self.pod_mode_combo.count()):
+                item = model.item(i)
+                if item is not None and item.isEnabled():
+                    self.pod_mode_combo.setCurrentIndex(i)
+                    break
+
+        self.pod_toggle_btn.setEnabled(any_available)
+        self.pod_mode_combo.setEnabled(any_available and self.pod_toggle_btn.isChecked())
+        self.pod_opacity_slider.setEnabled(any_available and self.pod_toggle_btn.isChecked())
+        if not any_available and self.pod_toggle_btn.isChecked():
             self.pod_toggle_btn.setChecked(False)
 
     def _emit_pod_display_changed(self):

--- a/app/core/views/images/viewer/dialogs/GPSMapDialog.py
+++ b/app/core/views/images/viewer/dialogs/GPSMapDialog.py
@@ -4,7 +4,10 @@ GPSMapDialog - Dialog window for displaying GPS map visualization.
 This dialog shows all image GPS locations as connected points on an interactive map.
 """
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QMessageBox
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QMessageBox,
+    QComboBox, QSlider
+)
 from PySide6.QtCore import Qt, Signal, QPointF, QTimer
 from helpers.TranslationMixin import TranslationMixin
 from PySide6.QtGui import QKeySequence, QShortcut, QColor
@@ -24,6 +27,9 @@ class GPSMapDialog(TranslationMixin, QDialog):
 
     # Signal emitted when user right-clicks on the map (lat, lon)
     gps_right_clicked = Signal(float, float)
+
+    # Signal emitted when the POD overlay display changes (enabled, mode, opacity 0-100)
+    pod_display_changed = Signal(bool, str, int)
 
     def __init__(self, parent, gps_data, current_image_index, offline_only=False):
         """
@@ -118,6 +124,32 @@ class GPSMapDialog(TranslationMixin, QDialog):
         self.toggle_view_btn.toggled.connect(self.on_toggle_view)
         controls_layout.addWidget(self.toggle_view_btn)
 
+        # POD coverage overlay controls (enabled once a POD result is cached).
+        controls_layout.addSpacing(20)
+        self.pod_toggle_btn = QPushButton(self.tr("POD Overlay"))
+        self.pod_toggle_btn.setCheckable(True)
+        self.pod_toggle_btn.setEnabled(False)
+        self.pod_toggle_btn.setToolTip(self.tr(
+            "Run a map export with the POD option to generate this overlay"))
+        self.pod_toggle_btn.toggled.connect(self._emit_pod_display_changed)
+        controls_layout.addWidget(self.pod_toggle_btn)
+
+        self.pod_mode_combo = QComboBox()
+        self.pod_mode_combo.addItem(self.tr("POD"), "pod")          # itemData = stable key
+        self.pod_mode_combo.addItem(self.tr("Look count"), "looks")
+        self.pod_mode_combo.setEnabled(False)
+        self.pod_mode_combo.currentIndexChanged.connect(self._emit_pod_display_changed)
+        controls_layout.addWidget(self.pod_mode_combo)
+
+        self.pod_opacity_slider = QSlider(Qt.Horizontal)
+        self.pod_opacity_slider.setRange(0, 100)
+        self.pod_opacity_slider.setValue(70)
+        self.pod_opacity_slider.setFixedWidth(110)
+        self.pod_opacity_slider.setEnabled(False)
+        self.pod_opacity_slider.setToolTip(self.tr("POD overlay opacity"))
+        self.pod_opacity_slider.valueChanged.connect(self._on_pod_opacity_changed)
+        controls_layout.addWidget(self.pod_opacity_slider)
+
         controls_layout.addStretch()
 
         # Help text
@@ -127,6 +159,25 @@ class GPSMapDialog(TranslationMixin, QDialog):
 
         layout.addLayout(controls_layout)
         self.setLayout(layout)
+
+    def set_pod_available(self, available):
+        """Enable/disable the POD overlay controls based on a cached result."""
+        self.pod_toggle_btn.setEnabled(bool(available))
+        self.pod_mode_combo.setEnabled(bool(available) and self.pod_toggle_btn.isChecked())
+        self.pod_opacity_slider.setEnabled(bool(available) and self.pod_toggle_btn.isChecked())
+        if not available and self.pod_toggle_btn.isChecked():
+            self.pod_toggle_btn.setChecked(False)
+
+    def _emit_pod_display_changed(self):
+        enabled = self.pod_toggle_btn.isChecked()
+        self.pod_mode_combo.setEnabled(enabled and self.pod_toggle_btn.isEnabled())
+        self.pod_opacity_slider.setEnabled(enabled and self.pod_toggle_btn.isEnabled())
+        self.pod_display_changed.emit(enabled, self.pod_mode_combo.currentData(),
+                                      self.pod_opacity_slider.value())
+
+    def _on_pod_opacity_changed(self, value):
+        # Opacity is pure view state -> update the view directly (no recompute).
+        self.map_view.set_pod_overlay_opacity(value / 100.0)
 
     def setup_shortcuts(self):
         """Set up keyboard shortcuts."""

--- a/app/core/views/images/viewer/dialogs/MapExportDialog.py
+++ b/app/core/views/images/viewer/dialogs/MapExportDialog.py
@@ -97,6 +97,28 @@ class MapExportDialog(TranslationMixin, QDialog):
         data_group.setLayout(data_layout)
         layout.addWidget(data_group)
 
+        # Probability-of-Detection (POD) coverage
+        self.pod_group = QGroupBox(self.tr("Probability of Detection (POD)"))
+        pod_layout = QVBoxLayout()
+
+        self.include_pod = QCheckBox(self.tr("POD coverage heatmap (terrain-aware)"))
+        self.include_pod.setChecked(False)  # heavy compute -> opt-in
+        self.include_pod.setToolTip(self.tr(
+            "Compute a terrain and canopy aware probability-of-detection raster for the whole "
+            "mission (all non-hidden images, independent of the selections above). Writes "
+            "coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson and stats.json. The "
+            "GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes."))
+
+        self.show_pod_on_map = QCheckBox(self.tr("Show on map when complete"))
+        self.show_pod_on_map.setChecked(True)  # spec 4.1: default on
+        self.show_pod_on_map.setEnabled(False)
+        self.include_pod.toggled.connect(self.show_pod_on_map.setEnabled)
+
+        pod_layout.addWidget(self.include_pod)
+        pod_layout.addWidget(self.show_pod_on_map)
+        self.pod_group.setLayout(pod_layout)
+        layout.addWidget(self.pod_group)
+
         # CalTopo-specific options
         self.caltopo_options_group = QGroupBox(self.tr("CalTopo Options"))
         caltopo_options_layout = QVBoxLayout()
@@ -187,6 +209,24 @@ class MapExportDialog(TranslationMixin, QDialog):
             bool: True if images without flagged AOIs should be included
         """
         return self.include_images_without_flagged_aois.isChecked()
+
+    def should_include_pod(self):
+        """
+        Check if the POD coverage heatmap should be computed.
+
+        Returns:
+            bool: True if the POD pass should run and write outputs
+        """
+        return self.include_pod.isChecked()
+
+    def should_show_pod_on_map(self):
+        """
+        Check if the POD result should be shown on the viewer map when complete.
+
+        Returns:
+            bool: True if POD is enabled and the show-on-map option is set
+        """
+        return self.include_pod.isChecked() and self.show_pod_on_map.isChecked()
 
     def _on_export_type_changed(self):
         """Handle export type radio button changes."""

--- a/app/core/views/images/viewer/dialogs/TileFetchDialog.py
+++ b/app/core/views/images/viewer/dialogs/TileFetchDialog.py
@@ -14,18 +14,38 @@ from helpers.TranslationMixin import TranslationMixin
 
 
 class TileFetchDialog(TranslationMixin, QDialog):
-    def __init__(self, parent=None, default_bounds=None):
-        """default_bounds: optional (min_lon, min_lat, max_lon, max_lat) to prefill."""
+    def __init__(self, parent=None, default_bounds=None, has_mission=False):
+        """
+        Args:
+            default_bounds: optional (min_lon, min_lat, max_lon, max_lat) to prefill.
+            has_mission: whether a mission is loaded (enables the auto-fill button).
+        """
         super().__init__(parent)
         self.setWindowTitle(self.tr("Download Coverage Data"))
-        self.setMinimumWidth(420)
-        self._setup_ui(default_bounds)
+        self.setMinimumWidth(460)
+        self._setup_ui(default_bounds, has_mission)
         self._apply_translations()
 
-    def _setup_ui(self, default_bounds):
+    def _setup_ui(self, default_bounds, has_mission):
         layout = QVBoxLayout(self)
 
         aoi_group = QGroupBox(self.tr("Area of Interest (WGS84)"))
+        aoi_layout = QVBoxLayout()
+
+        # Auto-fill row: derive the AOI from the loaded mission or an image folder.
+        fill_row = QHBoxLayout()
+        self.use_mission_btn = QPushButton(self.tr("Use loaded mission extent"))
+        self.use_mission_btn.setEnabled(bool(has_mission))
+        self.use_mission_btn.setToolTip(self.tr(
+            "Fill the AOI from the GPS positions of the currently loaded mission's images."))
+        self.load_folder_btn = QPushButton(self.tr("Load extent from image folder..."))
+        self.load_folder_btn.setToolTip(self.tr(
+            "Read image GPS from a folder to fill the AOI (use when no mission is loaded)."))
+        fill_row.addWidget(self.use_mission_btn)
+        fill_row.addWidget(self.load_folder_btn)
+        fill_row.addStretch()
+        aoi_layout.addLayout(fill_row)
+
         grid = QGridLayout()
         self.min_lon_edit = QLineEdit()
         self.min_lat_edit = QLineEdit()
@@ -34,10 +54,7 @@ class TileFetchDialog(TranslationMixin, QDialog):
         for e in (self.min_lon_edit, self.min_lat_edit, self.max_lon_edit, self.max_lat_edit):
             e.setValidator(QDoubleValidator())
         if default_bounds:
-            self.min_lon_edit.setText(str(default_bounds[0]))
-            self.min_lat_edit.setText(str(default_bounds[1]))
-            self.max_lon_edit.setText(str(default_bounds[2]))
-            self.max_lat_edit.setText(str(default_bounds[3]))
+            self.set_aoi(default_bounds)
         grid.addWidget(QLabel(self.tr("Min longitude:")), 0, 0)
         grid.addWidget(self.min_lon_edit, 0, 1)
         grid.addWidget(QLabel(self.tr("Min latitude:")), 0, 2)
@@ -46,7 +63,21 @@ class TileFetchDialog(TranslationMixin, QDialog):
         grid.addWidget(self.max_lon_edit, 1, 1)
         grid.addWidget(QLabel(self.tr("Max latitude:")), 1, 2)
         grid.addWidget(self.max_lat_edit, 1, 3)
-        aoi_group.setLayout(grid)
+        aoi_layout.addLayout(grid)
+
+        buffer_row = QHBoxLayout()
+        buffer_row.addWidget(QLabel(self.tr("Footprint buffer (m):")))
+        self.buffer_edit = QLineEdit()
+        self.buffer_edit.setValidator(QDoubleValidator(0.0, 100000.0, 1))
+        self.buffer_edit.setFixedWidth(90)
+        self.buffer_edit.setToolTip(self.tr(
+            "Padding added around the camera positions so downloaded tiles cover the "
+            "image footprints. Auto-sized from the mission; edit and re-fill to change."))
+        buffer_row.addWidget(self.buffer_edit)
+        buffer_row.addStretch()
+        aoi_layout.addLayout(buffer_row)
+
+        aoi_group.setLayout(aoi_layout)
         layout.addWidget(aoi_group)
 
         data_group = QGroupBox(self.tr("Datasets"))
@@ -88,6 +119,24 @@ class TileFetchDialog(TranslationMixin, QDialog):
         directory = QFileDialog.getExistingDirectory(self, self.tr("Select output folder"))
         if directory:
             self.output_edit.setText(directory)
+
+    def set_aoi(self, bounds):
+        """Fill the four AOI fields from (min_lon, min_lat, max_lon, max_lat)."""
+        self.min_lon_edit.setText(f"{bounds[0]:.6f}")
+        self.min_lat_edit.setText(f"{bounds[1]:.6f}")
+        self.max_lon_edit.setText(f"{bounds[2]:.6f}")
+        self.max_lat_edit.setText(f"{bounds[3]:.6f}")
+
+    def set_buffer(self, buffer_m):
+        self.buffer_edit.setText(f"{buffer_m:.0f}")
+
+    def get_buffer(self):
+        """Buffer in meters, or None if empty/invalid."""
+        try:
+            v = float(self.buffer_edit.text())
+            return v if v > 0 else None
+        except ValueError:
+            return None
 
     def get_bounds(self):
         """(min_lon, min_lat, max_lon, max_lat) or None if incomplete/invalid."""

--- a/app/core/views/images/viewer/dialogs/TileFetchDialog.py
+++ b/app/core/views/images/viewer/dialogs/TileFetchDialog.py
@@ -1,0 +1,113 @@
+"""
+TileFetchDialog - options for downloading DEM / canopy tiles for an AOI.
+
+Code-built (matching the MapExportDialog family) so no generated UI changes are
+needed. Collects an AOI bounding box, product selection, and an output folder.
+"""
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel, QLineEdit,
+    QCheckBox, QPushButton, QGroupBox, QFileDialog
+)
+from PySide6.QtGui import QDoubleValidator
+from helpers.TranslationMixin import TranslationMixin
+
+
+class TileFetchDialog(TranslationMixin, QDialog):
+    def __init__(self, parent=None, default_bounds=None):
+        """default_bounds: optional (min_lon, min_lat, max_lon, max_lat) to prefill."""
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Download Coverage Data"))
+        self.setMinimumWidth(420)
+        self._setup_ui(default_bounds)
+        self._apply_translations()
+
+    def _setup_ui(self, default_bounds):
+        layout = QVBoxLayout(self)
+
+        aoi_group = QGroupBox(self.tr("Area of Interest (WGS84)"))
+        grid = QGridLayout()
+        self.min_lon_edit = QLineEdit()
+        self.min_lat_edit = QLineEdit()
+        self.max_lon_edit = QLineEdit()
+        self.max_lat_edit = QLineEdit()
+        for e in (self.min_lon_edit, self.min_lat_edit, self.max_lon_edit, self.max_lat_edit):
+            e.setValidator(QDoubleValidator())
+        if default_bounds:
+            self.min_lon_edit.setText(str(default_bounds[0]))
+            self.min_lat_edit.setText(str(default_bounds[1]))
+            self.max_lon_edit.setText(str(default_bounds[2]))
+            self.max_lat_edit.setText(str(default_bounds[3]))
+        grid.addWidget(QLabel(self.tr("Min longitude:")), 0, 0)
+        grid.addWidget(self.min_lon_edit, 0, 1)
+        grid.addWidget(QLabel(self.tr("Min latitude:")), 0, 2)
+        grid.addWidget(self.min_lat_edit, 0, 3)
+        grid.addWidget(QLabel(self.tr("Max longitude:")), 1, 0)
+        grid.addWidget(self.max_lon_edit, 1, 1)
+        grid.addWidget(QLabel(self.tr("Max latitude:")), 1, 2)
+        grid.addWidget(self.max_lat_edit, 1, 3)
+        aoi_group.setLayout(grid)
+        layout.addWidget(aoi_group)
+
+        data_group = QGroupBox(self.tr("Datasets"))
+        data_layout = QVBoxLayout()
+        self.dem_checkbox = QCheckBox(self.tr("USGS 3DEP DEM"))
+        self.dem_checkbox.setChecked(True)
+        self.canopy_checkbox = QCheckBox(self.tr("Meta/WRI Canopy Height"))
+        self.canopy_checkbox.setChecked(True)
+        data_layout.addWidget(self.dem_checkbox)
+        data_layout.addWidget(self.canopy_checkbox)
+        data_group.setLayout(data_layout)
+        layout.addWidget(data_group)
+
+        out_row = QHBoxLayout()
+        out_row.addWidget(QLabel(self.tr("Output folder:")))
+        self.output_edit = QLineEdit()
+        self.output_button = QPushButton(self.tr("Browse..."))
+        self.output_button.clicked.connect(self._browse_output)
+        out_row.addWidget(self.output_edit, 1)
+        out_row.addWidget(self.output_button)
+        layout.addLayout(out_row)
+
+        self.register_checkbox = QCheckBox(self.tr("Register in Preferences when complete"))
+        self.register_checkbox.setChecked(True)
+        layout.addWidget(self.register_checkbox)
+
+        buttons = QHBoxLayout()
+        buttons.addStretch()
+        self.download_button = QPushButton(self.tr("Download"))
+        self.download_button.setDefault(True)
+        self.download_button.clicked.connect(self.accept)
+        self.cancel_button = QPushButton(self.tr("Cancel"))
+        self.cancel_button.clicked.connect(self.reject)
+        buttons.addWidget(self.download_button)
+        buttons.addWidget(self.cancel_button)
+        layout.addLayout(buttons)
+
+    def _browse_output(self):
+        directory = QFileDialog.getExistingDirectory(self, self.tr("Select output folder"))
+        if directory:
+            self.output_edit.setText(directory)
+
+    def get_bounds(self):
+        """(min_lon, min_lat, max_lon, max_lat) or None if incomplete/invalid."""
+        try:
+            b = (float(self.min_lon_edit.text()), float(self.min_lat_edit.text()),
+                 float(self.max_lon_edit.text()), float(self.max_lat_edit.text()))
+        except ValueError:
+            return None
+        if b[0] >= b[2] or b[1] >= b[3]:
+            return None
+        return b
+
+    def want_dem(self):
+        return self.dem_checkbox.isChecked()
+
+    def want_canopy(self):
+        return self.canopy_checkbox.isChecked()
+
+    def get_output_dir(self):
+        return self.output_edit.text().strip()
+
+    def should_register(self):
+        return self.register_checkbox.isChecked()

--- a/app/core/views/images/viewer/widgets/GPSMapView.py
+++ b/app/core/views/images/viewer/widgets/GPSMapView.py
@@ -11,7 +11,13 @@ from PySide6.QtWidgets import (
     QLabel, QMenu, QApplication
 )
 from PySide6.QtCore import Qt, Signal, QPointF, QRectF, QTimer, QEvent
-from PySide6.QtGui import QPen, QBrush, QColor, QPainterPath, QWheelEvent, QMouseEvent, QPainter, QPixmap, QFont, QPalette, QPolygonF
+from PySide6.QtGui import QPen, QBrush, QColor, QPainterPath, QWheelEvent, QMouseEvent, QPainter, QPixmap, QFont, QPalette, QPolygonF, QTransform
+
+# Half the Web Mercator world extent in meters (pi * 6378137); the scene is a
+# slippy-map plane, so an EPSG:3857 raster maps onto it with a pure scale+shift.
+WEB_MERCATOR_ORIGIN_SHIFT = 20037508.342789244
+# z-value for the POD overlay: above basemap tiles (-100), below flight path (5).
+POD_OVERLAY_Z = -50
 from core.views.images.viewer.widgets.MapTileLoader import MapTileLoader
 from core.services.image.ImageService import ImageService
 from core.services.image.AOIService import AOIService, _get_terrain_service
@@ -80,6 +86,13 @@ class GPSMapView(TranslationMixin, QGraphicsView):
         self.zoom_fov_box = None
         self._fov_cache = None  # Cached FOV params: gsd_m, width, height, bearing, lat, lon
         self._last_visible_rect = None  # Last visible rect for map zoom redraws
+
+        # POD coverage overlay (a georeferenced EPSG:3857 raster as a pixmap item)
+        self.pod_overlay_item = None
+        self._pod_pixmap = None
+        self._pod_transform6 = None   # (a, b, c, d, e, f) affine of the pixmap in EPSG:3857
+        self._pod_opacity = 0.7
+        self._pod_visible = False
 
         # Map bounds
         self.min_lat = None
@@ -422,6 +435,74 @@ class GPSMapView(TranslationMixin, QGraphicsView):
 
         return lat, lon
 
+    # ---------------- POD coverage overlay ----------------
+
+    def set_pod_overlay(self, pixmap, transform6):
+        """Show a georeferenced POD raster on the map.
+
+        Args:
+            pixmap: a ready QPixmap (RGBA) built from the POD/look-count LUT.
+            transform6: (a, b, c, d, e, f) affine coefficients of ``pixmap`` in
+                EPSG:3857 (north-up, square pixels: b == d == 0, e < 0).
+        """
+        self._pod_pixmap = pixmap
+        self._pod_transform6 = tuple(float(v) for v in transform6)
+        self._pod_visible = True
+        self._add_pod_overlay_item()
+
+    def clear_pod_overlay(self):
+        """Remove the POD overlay and forget its raster."""
+        self._pod_visible = False
+        self._pod_pixmap = None
+        self._pod_transform6 = None
+        self._remove_pod_overlay_item()
+
+    def set_pod_overlay_visible(self, visible):
+        self._pod_visible = bool(visible)
+        if self._pod_visible:
+            self._add_pod_overlay_item()
+        else:
+            self._remove_pod_overlay_item()
+
+    def set_pod_overlay_opacity(self, opacity):
+        self._pod_opacity = max(0.0, min(1.0, float(opacity)))
+        if self.pod_overlay_item is not None:
+            self.pod_overlay_item.setOpacity(self._pod_opacity)
+
+    def _remove_pod_overlay_item(self):
+        if self.pod_overlay_item is not None:
+            try:
+                if self.pod_overlay_item.scene() == self.scene:
+                    self.scene.removeItem(self.pod_overlay_item)
+            except RuntimeError:
+                pass
+            self.pod_overlay_item = None
+
+    def _add_pod_overlay_item(self):
+        if not self._pod_visible or self._pod_pixmap is None:
+            return
+        self._remove_pod_overlay_item()
+        item = QGraphicsPixmapItem(self._pod_pixmap)
+        item.setZValue(POD_OVERLAY_Z)
+        item.setOpacity(self._pod_opacity)
+        item.setTransformationMode(Qt.TransformationMode.SmoothTransformation)
+        self.scene.addItem(item)
+        self.pod_overlay_item = item
+        self._position_pod_overlay()
+
+    def _position_pod_overlay(self):
+        """Place the overlay so its EPSG:3857 affine lines up with the scene."""
+        if self.pod_overlay_item is None or self._pod_transform6 is None:
+            return
+        a, b, c, d, e, f = self._pod_transform6
+        world = 256 * (2 ** self.current_zoom)
+        k = world / (2 * WEB_MERCATOR_ORIGIN_SHIFT)     # scene units per 3857 meter
+        self.pod_overlay_item.setPos((c + WEB_MERCATOR_ORIGIN_SHIFT) * k,
+                                     (WEB_MERCATOR_ORIGIN_SHIFT - f) * k)
+        t = QTransform()
+        t.scale(a * k, -e * k)                          # e < 0 for north-up -> positive y scale
+        self.pod_overlay_item.setTransform(t)
+
     def render_map(self):
         """Render map tiles and GPS points."""
         # Store AOI data temporarily if present
@@ -455,6 +536,9 @@ class GPSMapView(TranslationMixin, QGraphicsView):
         # Load tiles and draw points
         self.load_visible_tiles()
         self.draw_gps_points()
+
+        # Re-add the POD overlay (scene.clear() dropped the item; state survives).
+        self._add_pod_overlay_item()
 
         # Restore AOI marker if it was present
         if temp_aoi_data and temp_aoi_color:
@@ -988,6 +1072,9 @@ class GPSMapView(TranslationMixin, QGraphicsView):
         # Update scene rect
         world_size = 256 * (2 ** self.current_zoom)
         self.scene.setSceneRect(-world_size / 2, -world_size / 2, world_size * 2, world_size * 2)
+
+        # Re-anchor the POD overlay to the new zoom scale.
+        self._position_pod_overlay()
 
         # Update GPS point positions
         for i, point_item in enumerate(self.point_items):

--- a/app/helpers/MetaDataHelper.py
+++ b/app/helpers/MetaDataHelper.py
@@ -317,7 +317,18 @@ class MetaDataHelper:
             # If ExifTool fails, fall back to direct parsing
             pass
 
-        # Fallback to original direct parsing method
+        # Fallback to direct byte-parsing (no ExifTool subprocess).
+        return MetaDataHelper.get_xmp_data_direct(file_path)
+
+    @staticmethod
+    def get_xmp_data_direct(file_path: str) -> dict:
+        """Parse XMP (incl. extended XMP) straight from the file bytes.
+
+        No ExifTool subprocess, so this is far cheaper than
+        :meth:`get_xmp_data_merged` when reading many files (e.g. the POD pass,
+        which launches ~one ExifTool process per image otherwise). Returns the
+        merged XMP dict, or {} if none is found.
+        """
         _XMP_EXT_HDR = b"http://ns.adobe.com/xmp/extension/\x00"
 
         def parse_base(data: bytes):
@@ -361,8 +372,11 @@ class MetaDataHelper:
                 buf[off:off + len(ch)] = ch
             return bytes(buf)
 
-        with open(file_path, 'rb') as f:
-            data = f.read()
+        try:
+            with open(file_path, 'rb') as f:
+                data = f.read()
+        except OSError:
+            return {}
 
         guid, base = parse_base(data)
         if not guid:

--- a/app/tests/core/controllers/images/viewer/exports/test_tile_fetch_controller.py
+++ b/app/tests/core/controllers/images/viewer/exports/test_tile_fetch_controller.py
@@ -79,3 +79,49 @@ def test_register_disabled_writes_nothing(app):
     ctrl._register = False
     ctrl._register_results({'dem': FetchResult('usgs_3dep_dem', "d", "m.csv")})
     settings.set_setting.assert_not_called()
+
+
+def test_fill_aoi_fills_dialog_from_mission(app):
+    from unittest.mock import patch
+    from core.views.images.viewer.dialogs.TileFetchDialog import TileFetchDialog
+
+    ctrl = TileFetchController(MagicMock(), MagicMock())
+    dialog = TileFetchDialog(has_mission=True)
+    images = [{"path": "a.jpg"}, {"path": "b.jpg"}]
+
+    with patch("core.services.coverage.aoi.compute_mission_gps_bounds",
+               return_value=(-120.50, 38.70, -120.46, 38.72)), \
+         patch("core.services.coverage.aoi.suggest_buffer_m", return_value=400.0):
+        ctrl._fill_aoi(dialog, images, "loaded mission")
+
+    assert dialog.get_buffer() == 400.0
+    b = dialog.get_bounds()
+    # Padded outward from the raw camera-position box.
+    assert b is not None and b[0] < -120.50 and b[2] > -120.46
+
+
+def test_fill_aoi_warns_when_no_gps(app):
+    from unittest.mock import patch
+    from core.views.images.viewer.dialogs.TileFetchDialog import TileFetchDialog
+
+    ctrl = TileFetchController(MagicMock(), MagicMock())
+    dialog = TileFetchDialog(has_mission=True)
+    with patch("core.services.coverage.aoi.compute_mission_gps_bounds", return_value=None), \
+         patch("core.controllers.images.viewer.exports.TileFetchController.QMessageBox") as mock_mb:
+        ctrl._fill_aoi(dialog, [{"path": "a.jpg"}], "loaded mission")
+    mock_mb.warning.assert_called_once()
+
+
+def test_fill_aoi_respects_existing_buffer(app):
+    from unittest.mock import patch
+    from core.views.images.viewer.dialogs.TileFetchDialog import TileFetchDialog
+
+    ctrl = TileFetchController(MagicMock(), MagicMock())
+    dialog = TileFetchDialog(has_mission=True)
+    dialog.set_buffer(900.0)   # user-set buffer must be kept
+    with patch("core.services.coverage.aoi.compute_mission_gps_bounds",
+               return_value=(-120.50, 38.70, -120.46, 38.72)), \
+         patch("core.services.coverage.aoi.suggest_buffer_m", return_value=100.0) as mock_suggest:
+        ctrl._fill_aoi(dialog, [{"path": "a.jpg"}], "loaded mission")
+    mock_suggest.assert_not_called()
+    assert dialog.get_buffer() == 900.0

--- a/app/tests/core/controllers/images/viewer/exports/test_tile_fetch_controller.py
+++ b/app/tests/core/controllers/images/viewer/exports/test_tile_fetch_controller.py
@@ -1,0 +1,81 @@
+"""Tests for TileFetchThread + TileFetchController wiring."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from core.controllers.images.viewer.exports.TileFetchController import (
+    TileFetchThread,
+    TileFetchController,
+)
+from core.services.terrain.TileFetchService import FetchResult
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def test_thread_runs_both_products(app, tmp_path):
+    service = MagicMock()
+    service.fetch_3dep_dem.return_value = FetchResult('usgs_3dep_dem', str(tmp_path / "dem"), None)
+    service.fetch_meta_canopy.return_value = FetchResult('meta_chm', str(tmp_path / "chm"), None)
+    thread = TileFetchThread(service, (-120.5, 38.7, -120.4, 38.8), str(tmp_path),
+                             want_dem=True, want_canopy=True)
+    results = []
+    thread.finished.connect(lambda r: results.append(r))
+    thread.run()
+    assert service.fetch_3dep_dem.called
+    assert service.fetch_meta_canopy.called
+    assert results and 'dem' in results[0] and 'canopy' in results[0]
+
+
+def test_thread_dem_only(app, tmp_path):
+    service = MagicMock()
+    service.fetch_3dep_dem.return_value = FetchResult('usgs_3dep_dem', str(tmp_path), None)
+    thread = TileFetchThread(service, (-120.5, 38.7, -120.4, 38.8), str(tmp_path),
+                             want_dem=True, want_canopy=False)
+    thread.run()
+    assert service.fetch_3dep_dem.called
+    assert not service.fetch_meta_canopy.called
+
+
+def test_thread_emits_error(app, tmp_path):
+    service = MagicMock()
+    service.fetch_3dep_dem.side_effect = RuntimeError("net down")
+    thread = TileFetchThread(service, (-120.5, 38.7, -120.4, 38.8), str(tmp_path),
+                             want_dem=True, want_canopy=False)
+    errors = []
+    thread.errorOccurred.connect(lambda m: errors.append(m))
+    thread.run()
+    assert errors and "net down" in errors[0]
+
+
+def test_register_results_writes_settings(app, tmp_path):
+    settings = MagicMock()
+    stored = {}
+    settings.set_setting.side_effect = lambda k, v: stored.__setitem__(k, v)
+    ctrl = TileFetchController(MagicMock(), settings)
+    ctrl._register = True
+
+    dem = FetchResult('usgs_3dep_dem', str(tmp_path / "dem"),
+                      str(tmp_path / "dem" / "dem_manifest.csv"))
+    canopy = FetchResult('meta_chm', str(tmp_path / "chm"),
+                         str(tmp_path / "chm" / "chm_manifest.csv"))
+    ctrl._register_results({'dem': dem, 'canopy': canopy})
+
+    assert stored['Terrain3DEPManifestPath'] == dem.manifest_path
+    assert stored['Terrain3DEPTilesDir'] == dem.out_dir
+    assert stored['TerrainProviderId'] == 'usgs_3dep_local'
+    assert stored['CanopyManifestPath'] == canopy.manifest_path
+    assert stored['CanopyTilesDir'] == canopy.out_dir
+    assert stored['CanopyKind'] == 'meta'
+
+
+def test_register_disabled_writes_nothing(app):
+    settings = MagicMock()
+    ctrl = TileFetchController(MagicMock(), settings)
+    ctrl._register = False
+    ctrl._register_results({'dem': FetchResult('usgs_3dep_dem', "d", "m.csv")})
+    settings.set_setting.assert_not_called()

--- a/app/tests/core/controllers/images/viewer/exports/test_unified_map_export_controller.py
+++ b/app/tests/core/controllers/images/viewer/exports/test_unified_map_export_controller.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QDialog
 from core.controllers.images.viewer.exports.UnifiedMapExportController import (
     UnifiedMapExportController,
     UnifiedMapExportThread,
+    CoveragePodExportThread,
 )
 
 
@@ -172,6 +173,8 @@ def test_show_export_dialog_no_data_selected_warns(controller):
         d.should_include_images_without_flagged_aois.return_value = False
         d.should_include_flagged_aois.return_value = False
         d.should_include_coverage.return_value = False
+        d.should_include_pod.return_value = False
+        d.should_show_pod_on_map.return_value = False
         d.should_include_images.return_value = False
 
         controller.show_export_dialog()
@@ -191,6 +194,8 @@ def test_show_export_dialog_kml_export_calls_kml_method(controller):
         d.should_include_images_without_flagged_aois.return_value = False
         d.should_include_flagged_aois.return_value = False
         d.should_include_coverage.return_value = False
+        d.should_include_pod.return_value = False
+        d.should_show_pod_on_map.return_value = False
 
         controller.show_export_dialog()
 
@@ -212,6 +217,8 @@ def test_show_export_dialog_caltopo_method_cancelled(controller):
         d.should_include_images_without_flagged_aois.return_value = False
         d.should_include_flagged_aois.return_value = False
         d.should_include_coverage.return_value = False
+        d.should_include_pod.return_value = False
+        d.should_show_pod_on_map.return_value = False
         d.should_include_images.return_value = True
         MockMethod.return_value.exec.return_value = QDialog.Rejected
 
@@ -235,6 +242,8 @@ def test_show_export_dialog_caltopo_api_path(controller):
         d.should_include_images_without_flagged_aois.return_value = False
         d.should_include_flagged_aois.return_value = False
         d.should_include_coverage.return_value = False
+        d.should_include_pod.return_value = False
+        d.should_show_pod_on_map.return_value = False
         d.should_include_images.return_value = True
         MockMethod.return_value.exec.return_value = QDialog.Accepted
         MockMethod.return_value.get_selected_method.return_value = "api"
@@ -258,6 +267,8 @@ def test_show_export_dialog_caltopo_browser_path(controller):
         d.should_include_images_without_flagged_aois.return_value = False
         d.should_include_flagged_aois.return_value = False
         d.should_include_coverage.return_value = False
+        d.should_include_pod.return_value = False
+        d.should_show_pod_on_map.return_value = False
         d.should_include_images.return_value = True
         MockMethod.return_value.exec.return_value = QDialog.Accepted
         MockMethod.return_value.get_selected_method.return_value = "browser"
@@ -272,4 +283,101 @@ def test_export_to_kml_file_dialog_cancelled(controller):
         "core.controllers.images.viewer.exports.UnifiedMapExportController.QFileDialog"
     ) as MockFile:
         MockFile.getSaveFileName.return_value = ("", "")
-        controller._export_to_kml(True, False, True, False)
+        assert controller._export_to_kml(True, False, True, False) is None
+
+
+# ---------------------------------------------------------------------------
+# POD pass: standalone thread + controller wiring
+# ---------------------------------------------------------------------------
+
+def test_pod_dir_for_kml():
+    import os
+    d = UnifiedMapExportController._pod_dir_for_kml(os.path.join("out", "mission.kml"))
+    assert d == os.path.join("out", "mission_coverage_pod")
+
+
+def _make_result(cancelled=False):
+    r = MagicMock()
+    r.cancelled = cancelled
+    return r
+
+
+def test_pod_thread_completes_and_writes(tmp_path):
+    pod_service = MagicMock()
+    result = _make_result(cancelled=False)
+    pod_service.calculate.return_value = result
+    thread = CoveragePodExportThread(pod_service, [{"path": "a"}], str(tmp_path))
+
+    completed, finished = [], []
+    thread.podCompleted.connect(lambda r: completed.append(r))
+    thread.finished.connect(lambda: finished.append(True))
+    with patch(
+        "core.services.coverage.writers.write_all_outputs"
+    ) as mock_write:
+        thread.run()
+
+    # calculate was driven with progress + cancel plumbing.
+    assert pod_service.calculate.called
+    _, kwargs = pod_service.calculate.call_args
+    assert "progress_callback" in kwargs and "cancel_check" in kwargs
+    mock_write.assert_called_once()
+    assert completed == [result]
+    assert finished == [True]
+
+
+def test_pod_thread_cancelled_result_does_not_write(tmp_path):
+    pod_service = MagicMock()
+    pod_service.calculate.return_value = _make_result(cancelled=True)
+    thread = CoveragePodExportThread(pod_service, [], str(tmp_path))
+
+    canceled, completed = [], []
+    thread.canceled.connect(lambda: canceled.append(True))
+    thread.podCompleted.connect(lambda r: completed.append(r))
+    with patch("core.services.coverage.writers.write_all_outputs") as mock_write:
+        thread.run()
+
+    assert canceled == [True]
+    assert completed == []
+    mock_write.assert_not_called()
+
+
+def test_pod_thread_emits_error(tmp_path):
+    pod_service = MagicMock()
+    pod_service.calculate.side_effect = RuntimeError("kaboom")
+    thread = CoveragePodExportThread(pod_service, [], str(tmp_path))
+    errors = []
+    thread.errorOccurred.connect(lambda m: errors.append(m))
+    thread.run()
+    assert len(errors) == 1 and "kaboom" in errors[0]
+
+
+def test_on_pod_completed_populates_cache(controller):
+    controller.parent.pod_result_cache = MagicMock()
+    result = _make_result()
+    controller._on_pod_completed(result)
+    controller.parent.pod_result_cache.set_result.assert_called_once_with(result)
+
+
+def test_pod_only_export_is_valid(controller):
+    """A POD-only selection must pass validation and trigger the POD pass."""
+    controller._export_to_kml = MagicMock(return_value="C:/tmp/mission.kml")
+    controller._run_pod_export = MagicMock()
+    with patch(
+        "core.controllers.images.viewer.exports.UnifiedMapExportController.MapExportDialog"
+    ) as MockDialog, patch(
+        "core.controllers.images.viewer.exports.UnifiedMapExportController.QMessageBox"
+    ) as MockQMB:
+        d = MockDialog.return_value
+        d.exec.return_value = QDialog.Accepted
+        d.get_export_type.return_value = "kml"
+        d.should_include_locations.return_value = False
+        d.should_include_images_without_flagged_aois.return_value = False
+        d.should_include_flagged_aois.return_value = False
+        d.should_include_coverage.return_value = False
+        d.should_include_pod.return_value = True
+        d.should_show_pod_on_map.return_value = True
+
+        controller.show_export_dialog()
+
+    MockQMB.warning.assert_not_called()
+    controller._run_pod_export.assert_called_once()

--- a/app/tests/core/controllers/images/viewer/test_gps_map_controller_pod.py
+++ b/app/tests/core/controllers/images/viewer/test_gps_map_controller_pod.py
@@ -1,0 +1,107 @@
+"""Tests for the POD overlay orchestration + cell inspect on GPSMapController."""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock
+
+from PySide6.QtWidgets import QApplication
+
+from core.controllers.images.viewer.GPSMapController import GPSMapController
+from core.services.coverage.params import PodParams
+from core.services.coverage.contracts import CoverageResult, LIMIT_CANOPY
+from core.services.terrain.grid import make_lattice_spec, lonlat_to_mercator
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def _controller(app):
+    parent = MagicMock()
+    parent.images = [{"name": "A"}, {"name": "B"}]
+    return GPSMapController(parent)
+
+
+def _real_result(rows=40, cols=30):
+    minx, miny = lonlat_to_mercator(-120.50, 38.70)
+    spec = make_lattice_spec((minx, miny, minx + cols * 3.0, miny + rows * 3.0), 3.0)
+    pod = np.full((spec.height, spec.width), 0.6, dtype=np.float32)
+    look = np.full((spec.height, spec.width), 2, dtype=np.uint16)
+    return CoverageResult(pod=pod, look_count=look, transform=spec.transform,
+                          image_count=2, skipped=[], stats={}, gap_polygons=[],
+                          cancelled=False, params=PodParams())
+
+
+def test_click_with_overlay_shows_inspect_menu(app):
+    ctrl = _controller(app)
+    ctrl._pod_overlay_enabled = True
+    ctrl._show_pod_inspect_menu = MagicMock()
+    ctrl._reverse_locate = MagicMock()
+
+    result = MagicMock()
+    result.sample.return_value = {'pod': 0.6, 'looks': 2, 'limiting_factor': LIMIT_CANOPY, 'frames': [0]}
+    cache = MagicMock()
+    cache.has_result.return_value = True
+    cache.get_result.return_value = result
+    ctrl.parent.pod_result_cache = cache
+
+    ctrl.on_map_gps_clicked(38.71, -120.49)
+    ctrl._show_pod_inspect_menu.assert_called_once()
+    ctrl._reverse_locate.assert_not_called()
+
+
+def test_click_off_coverage_falls_back_to_reverse_locate(app):
+    ctrl = _controller(app)
+    ctrl._pod_overlay_enabled = True
+    ctrl._show_pod_inspect_menu = MagicMock()
+    ctrl._reverse_locate = MagicMock()
+
+    result = MagicMock()
+    result.sample.return_value = None
+    cache = MagicMock()
+    cache.has_result.return_value = True
+    cache.get_result.return_value = result
+    ctrl.parent.pod_result_cache = cache
+
+    ctrl.on_map_gps_clicked(0.0, 0.0)
+    ctrl._show_pod_inspect_menu.assert_not_called()
+    ctrl._reverse_locate.assert_called_once()
+
+
+def test_click_overlay_disabled_uses_reverse_locate(app):
+    ctrl = _controller(app)
+    ctrl._pod_overlay_enabled = False
+    ctrl._reverse_locate = MagicMock()
+    ctrl.on_map_gps_clicked(38.71, -120.49)
+    ctrl._reverse_locate.assert_called_once()
+
+
+def test_build_pod_pixmap_downsamples_and_rescales(app):
+    ctrl = _controller(app)
+    result = _real_result(rows=2100, cols=40)   # > 2048 -> shrinks
+    pixmap, transform6 = ctrl._build_pod_pixmap(result, 'pod')
+    assert pixmap.width() <= 2048 and pixmap.height() <= 2048
+    a0 = tuple(result.transform)[0]
+    # Cell size grows because the raster was downsampled.
+    assert transform6[0] > a0
+
+
+def test_on_pod_display_changed_sets_and_clears_overlay(app):
+    ctrl = _controller(app)
+    ctrl.map_dialog = MagicMock()
+    view = MagicMock()
+    ctrl.map_dialog.map_view = view
+    cache = MagicMock()
+    cache.has_result.return_value = True
+    cache.get_result.return_value = _real_result()
+    ctrl.parent.pod_result_cache = cache
+
+    ctrl.on_pod_display_changed(True, 'pod', 60)
+    assert ctrl._pod_overlay_enabled is True
+    view.set_pod_overlay.assert_called_once()
+    view.set_pod_overlay_opacity.assert_called_with(0.6)
+
+    ctrl.on_pod_display_changed(False, 'pod', 60)
+    assert ctrl._pod_overlay_enabled is False
+    view.clear_pod_overlay.assert_called_once()

--- a/app/tests/core/controllers/images/viewer/test_gps_map_controller_pod.py
+++ b/app/tests/core/controllers/images/viewer/test_gps_map_controller_pod.py
@@ -87,6 +87,86 @@ def test_build_pod_pixmap_downsamples_and_rescales(app):
     assert transform6[0] > a0
 
 
+class _FakeCanopySample:
+    def __init__(self, chm):
+        self.chm = chm
+
+
+def _fake_canopy(chm_value=12.0):
+    svc = MagicMock()
+
+    def sample(spec):
+        chm = np.full((spec.height, spec.width), chm_value, dtype=np.float32)
+        return _FakeCanopySample(chm)
+
+    svc.sample_grid_spec.side_effect = sample
+    return svc
+
+
+def _canopy_controller(app, canopy=None, result=None):
+    ctrl = _controller(app)
+    ctrl.map_dialog = MagicMock()
+    ctrl.map_dialog.map_view = MagicMock()
+    cache = MagicMock()
+    cache.has_result.return_value = result is not None
+    cache.get_result.return_value = result
+    ctrl.parent.pod_result_cache = cache
+    ctrl._canopy_svc = canopy
+    ctrl._canopy_svc_loaded = True
+    return ctrl
+
+
+def test_canopy_mode_sets_overlay_from_canopy_service(app):
+    ctrl = _canopy_controller(app, canopy=_fake_canopy(), result=_real_result())
+    ctrl.on_pod_display_changed(True, 'canopy', 50)
+    assert ctrl._pod_overlay_enabled is True
+    assert ctrl._pod_overlay_mode == 'canopy'
+    ctrl.map_dialog.map_view.set_pod_overlay.assert_called_once()
+    ctrl.map_dialog.map_view.set_pod_overlay_opacity.assert_called_with(0.5)
+
+
+def test_canopy_mode_without_source_clears_and_toasts(app):
+    ctrl = _canopy_controller(app, canopy=None, result=_real_result())
+    ctrl.on_pod_display_changed(True, 'canopy', 50)
+    assert ctrl._pod_overlay_enabled is False
+    ctrl.map_dialog.map_view.clear_pod_overlay.assert_called_once()
+    ctrl.parent.status_controller.show_toast.assert_called_once()
+
+
+def test_canopy_extent_uses_gps_bounds_without_result(app):
+    ctrl = _controller(app)
+    ctrl.parent.pod_result_cache = None
+    ctrl.gps_data = [
+        {'latitude': 38.70, 'longitude': -120.50},
+        {'latitude': 38.71, 'longitude': -120.49},
+    ]
+    spec = ctrl._canopy_extent_spec()
+    assert spec is not None
+    assert spec.crs == "EPSG:3857"
+    min_lon, min_lat, max_lon, max_lat = spec.wgs84_bounds()
+    # Padded outward beyond the raw GPS bounding box.
+    assert min_lon < -120.50 and max_lon > -120.49
+    assert min_lat < 38.70 and max_lat > 38.71
+    assert max(spec.width, spec.height) <= ctrl._max_overlay_dim + 2
+
+
+def test_canopy_extent_matches_pod_grid_when_result_cached(app):
+    result = _real_result()
+    ctrl = _canopy_controller(app, canopy=_fake_canopy(), result=result)
+    spec = ctrl._canopy_extent_spec()
+    assert spec.transform == result.transform
+    assert (spec.height, spec.width) == result.pod.shape
+
+
+def test_canopy_pixmap_cached_per_extent(app):
+    canopy = _fake_canopy()
+    ctrl = _canopy_controller(app, canopy=canopy, result=_real_result())
+    first = ctrl._build_canopy_pixmap()
+    second = ctrl._build_canopy_pixmap()
+    assert first is not None and second is not None
+    assert canopy.sample_grid_spec.call_count == 1
+
+
 def test_on_pod_display_changed_sets_and_clears_overlay(app):
     ctrl = _controller(app)
     ctrl.map_dialog = MagicMock()

--- a/app/tests/core/controllers/test_preferences_canopy.py
+++ b/app/tests/core/controllers/test_preferences_canopy.py
@@ -1,0 +1,65 @@
+"""Smoke tests for the code-built canopy source section in Preferences."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from PySide6.QtWidgets import QApplication
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def prefs(app, monkeypatch):
+    monkeypatch.setattr(
+        "helpers.PickleHelper.PickleHelper.get_drone_sensor_file_version",
+        staticmethod(lambda: {"Version": "1", "Date": "2020-01-01"}),
+    )
+    settings = {
+        "Language": "en", "MaxAOIs": 100, "Theme": "Dark", "AOIRadius": 5,
+        "PositionFormat": "Lat/Long - Decimal Degrees", "TemperatureUnit": "Fahrenheit",
+        "DistanceUnit": "Feet",
+    }
+    parent = MagicMock()
+    parent.settings_service.get_setting.side_effect = lambda k, d=None: settings.get(k, d)
+    parent.settings_service.get_bool_setting.side_effect = lambda k, d=False: settings.get(k, d)
+    parent.settings_service.set_setting.side_effect = lambda k, v: settings.__setitem__(k, v)
+
+    from core.controllers.Preferences import Preferences
+    dialog = Preferences(parent)
+    return dialog, settings
+
+
+def test_canopy_section_built(prefs):
+    dialog, _ = prefs
+    assert dialog.canopyKindComboBox.count() == 3
+    ids = [dialog.canopyKindComboBox.itemData(i) for i in range(3)]
+    assert ids == ["none", "landfire", "meta"]
+
+
+def test_default_kind_none_hides_paths(prefs):
+    dialog, _ = prefs
+    # Default kind is 'none' -> path fields hidden.
+    assert dialog.canopyKindComboBox.currentData() == "none"
+    assert dialog.canopyManifestEdit.isVisible() is False
+
+
+def test_changing_kind_persists_and_shows_paths(prefs):
+    dialog, settings = prefs
+    idx = dialog.canopyKindComboBox.findData("meta")
+    dialog.canopyKindComboBox.setCurrentIndex(idx)
+    assert settings["CanopyKind"] == "meta"
+    # Path fields become relevant (widgets exist; visibility toggles on show).
+    dialog.show()
+    dialog._refresh_canopy_visibility()
+    assert dialog.canopyManifestEdit.isVisibleTo(dialog.canopySourceGroup)
+    dialog.hide()
+
+
+def test_manifest_edit_persists(prefs):
+    dialog, settings = prefs
+    dialog.canopyManifestEdit.setText("C:/data/canopy.csv")
+    dialog._update_canopy_manifest()
+    assert settings["CanopyManifestPath"] == "C:/data/canopy.csv"

--- a/app/tests/core/services/coverage/_kernel_helpers.py
+++ b/app/tests/core/services/coverage/_kernel_helpers.py
@@ -1,0 +1,21 @@
+"""Shared helpers for coverage-kernel tests (metric grids, FrameGeometry literals)."""
+
+from core.services.image.FrameGeometry import FrameGeometry
+from core.services.terrain.grid import make_lattice_spec
+
+
+def make_fg(pitch, yaw=0.0, roll=0.0, agl=120.0, focal=8.8,
+            sensor=(13.2, 8.8), size=(4000, 3000)):
+    """A FrameGeometry with typical DJI intrinsics; lat/lon are unused by the
+    kernel (footprint/mask/ray-march work in the supplied metric grid)."""
+    return FrameGeometry(
+        lat=38.7, lon=-120.5, agl_m=agl, yaw_deg=yaw, pitch_deg=pitch, roll_deg=roll,
+        focal_mm=focal, sensor_mm=sensor, image_size=size, principal_point_mm=None,
+        yaw_source='gimbal', bearing_confidence=1.0, asl_alt_m=None, cam_elev_m=None,
+    )
+
+
+def metric_spec(width_m, height_m, cell):
+    """A north-up EPSG:3857 GridSpec whose units equal true meters (use
+    meters_per_unit=1.0), snapped so the origin sits at (0, 0)."""
+    return make_lattice_spec((0.0, 0.0, float(width_m), float(height_m)), float(cell))

--- a/app/tests/core/services/coverage/test_accumulator.py
+++ b/app/tests/core/services/coverage/test_accumulator.py
@@ -1,0 +1,128 @@
+"""Spec section 8-4: multi-look combination (max within a bin, product across
+bins, common-mode ceiling, per-frame cap, confidence haircut, lazy growth)."""
+
+import numpy as np
+import pytest
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.accumulator import MissionAccumulator
+from core.services.terrain.grid import make_lattice_spec
+
+CELL = 3.0
+C = 0.90  # common_mode_ceiling default
+
+
+def _spec(x0=0.0, y0=0.0, n=30.0):
+    return make_lattice_spec((x0, y0, x0 + n, y0 + n), CELL)
+
+
+def _const_pod(spec, value):
+    return np.full((spec.height, spec.width), value, dtype=np.float32)
+
+
+def _fresh(params=None):
+    params = params or PodParams()
+    return MissionAccumulator(CELL, params), params
+
+
+# Each of these tests fills a single constant-valued frame region on an otherwise
+# zero mission grid, so the grid max equals the accumulated value at that region
+# (independent of where the coarse-snapped mission grid places the frame).
+
+
+def test_two_frames_same_bin_do_not_compound():
+    acc, _ = _fresh()
+    spec = _spec()
+    for _ in range(2):
+        assert acc.add_frame(0, _const_pod(spec, 0.5), spec, yaw_deg=0.0,
+                             pitch_deg=-90.0, bearing_confidence=1.0)
+    pod, look, _, _, _ = acc.finalize()
+    assert float(pod.max()) == pytest.approx(C * 0.5, abs=1e-4)
+
+
+def test_two_frames_different_bins_combine():
+    acc, _ = _fresh()
+    spec = _spec()
+    acc.add_frame(0, _const_pod(spec, 0.5), spec, 0.0, -90.0, 1.0)     # bin 0
+    acc.add_frame(1, _const_pod(spec, 0.5), spec, 180.0, -90.0, 1.0)   # bin 2
+    pod, _, _, _, _ = acc.finalize()
+    assert float(pod.max()) == pytest.approx(C * 0.75, abs=1e-4)
+
+
+def test_eight_bins_at_cap_asymptote_to_ceiling():
+    acc, _ = _fresh()
+    spec = _spec()
+    for i, (yaw, pitch) in enumerate([(y, p) for p in (-90.0, -50.0)
+                                      for y in (0.0, 90.0, 180.0, 270.0)]):
+        acc.add_frame(i, _const_pod(spec, 1.0), spec, yaw, pitch, 1.0)
+    pod, _, _, _, _ = acc.finalize()
+    v = float(pod.max())
+    assert v == pytest.approx(C, abs=1e-3)
+    assert v < 1.0
+
+
+def test_per_frame_cap_applied():
+    acc, _ = _fresh()
+    spec = _spec()
+    acc.add_frame(0, _const_pod(spec, 1.0), spec, 0.0, -90.0, 1.0)
+    pod, _, _, _, _ = acc.finalize()
+    assert float(pod.max()) == pytest.approx(C * 0.85, abs=1e-4)
+
+
+def test_low_confidence_haircut():
+    acc, params = _fresh()
+    spec = _spec()
+    acc.add_frame(0, _const_pod(spec, 0.8), spec, 0.0, -90.0, bearing_confidence=0.4)
+    pod, _, _, _, _ = acc.finalize()
+    expected = C * (0.8 * params.low_confidence_haircut)
+    assert float(pod.max()) == pytest.approx(expected, abs=1e-4)
+
+
+def test_look_count_counts_positive_frames():
+    acc, _ = _fresh()
+    spec = _spec()
+    acc.add_frame(0, _const_pod(spec, 0.5), spec, 0.0, -90.0, 1.0)
+    acc.add_frame(1, _const_pod(spec, 0.5), spec, 90.0, -90.0, 1.0)
+    _, look, _, _, _ = acc.finalize()
+    assert int(look.max()) == 2
+
+
+def test_lazy_growth_preserves_both_frames():
+    acc, _ = _fresh()
+    a = _spec(0.0, 0.0)
+    b = _spec(3000.0, 3000.0)  # far away -> triggers growth
+    assert acc.add_frame(0, _const_pod(a, 0.6), a, 0.0, -90.0, 1.0)
+    assert acc.add_frame(1, _const_pod(b, 0.4), b, 0.0, -90.0, 1.0)
+    pod, look, _, fidx, transform = acc.finalize()
+    from core.services.coverage.contracts import CoverageResult
+    res = CoverageResult(pod=pod, look_count=look, transform=transform,
+                         image_count=2, skipped=[], stats={}, gap_polygons=[],
+                         cancelled=False, frame_index=fidx)
+    # Both frame regions carry their values in the grown grid.
+    from core.services.terrain.grid import mercator_to_lonlat
+    for spec, val, fid in ((a, C * 0.6, 0), (b, C * 0.4, 1)):
+        xs, ys = spec.cell_centers()
+        cx, cy = float(xs[spec.width // 2]), float(ys[spec.height // 2])
+        lon, lat = mercator_to_lonlat(cx, cy)
+        s = res.sample(lat, lon)
+        assert s is not None
+        assert s['pod'] == pytest.approx(val, abs=1e-3)
+        assert fid in s['frames']
+
+
+def test_budget_refusal_returns_false():
+    params = PodParams(mem_budget_mb=1)  # tiny budget
+    acc = MissionAccumulator(CELL, params)
+    a = _spec(0.0, 0.0)
+    b = _spec(3000.0, 3000.0)  # union ~1e6 cells -> exceeds 1 MB
+    assert acc.add_frame(0, _const_pod(a, 0.6), a, 0.0, -90.0, 1.0)
+    assert acc.add_frame(1, _const_pod(b, 0.6), b, 0.0, -90.0, 1.0) is False
+
+
+@pytest.mark.parametrize("yaw,pitch,expected", [
+    (0.0, -90.0, 0), (89.0, -90.0, 1), (91.0, -90.0, 1),
+    (181.0, -90.0, 2), (271.0, -90.0, 3),
+    (0.0, -50.0, 4), (0.0, -10.0, 4), (271.0, -50.0, 7),
+])
+def test_bin_for_frame_table(yaw, pitch, expected):
+    assert MissionAccumulator.bin_for_frame(yaw, pitch, PodParams()) == expected

--- a/app/tests/core/services/coverage/test_aoi.py
+++ b/app/tests/core/services/coverage/test_aoi.py
@@ -1,0 +1,88 @@
+"""Tests for deriving a download AOI from a mission's images."""
+
+import math
+
+import pytest
+from unittest.mock import patch
+
+from core.services.coverage import aoi
+from core.services.coverage.params import PodParams
+
+
+def test_compute_mission_gps_bounds():
+    coords = {
+        "a.jpg": (38.70, -120.50),
+        "b.jpg": (38.72, -120.46),
+        "c.jpg": (38.71, -120.48),
+    }
+    images = [{"path": p} for p in coords]
+    with patch.object(aoi, "image_gps", side_effect=lambda p: coords.get(p)):
+        b = aoi.compute_mission_gps_bounds(images)
+    assert b == pytest.approx((-120.50, 38.70, -120.46, 38.72))
+
+
+def test_compute_bounds_none_without_gps():
+    images = [{"path": "a.jpg"}, {"path": "b.jpg"}]
+    with patch.object(aoi, "image_gps", return_value=None):
+        assert aoi.compute_mission_gps_bounds(images) is None
+
+
+def test_pad_bounds_expands_outward():
+    raw = (-120.50, 38.70, -120.46, 38.72)
+    padded = aoi.pad_bounds(raw, 1000.0)
+    assert padded[0] < raw[0] and padded[1] < raw[1]
+    assert padded[2] > raw[2] and padded[3] > raw[3]
+    # ~1 km in latitude is ~0.009 deg.
+    assert (raw[1] - padded[1]) == pytest.approx(1000.0 / 111320.0, rel=1e-3)
+
+
+def test_suggest_buffer_from_footprint(monkeypatch):
+    # Fake a nadir frame at 120 m AGL -> footprint half-diagonal ~ 108 m.
+    from core.services.image.FrameGeometry import FrameGeometry
+    fg = FrameGeometry(
+        lat=38.7, lon=-120.5, agl_m=120.0, yaw_deg=0.0, pitch_deg=-90.0, roll_deg=0.0,
+        focal_mm=8.8, sensor_mm=(13.2, 8.8), image_size=(4000, 3000),
+        principal_point_mm=None, yaw_source='gimbal', bearing_confidence=1.0)
+    monkeypatch.setattr(aoi, "_frame_geometry", lambda p: fg)
+    images = [{"path": "a.jpg"}, {"path": "b.jpg"}]
+    buf = aoi.suggest_buffer_m(images, params=PodParams())
+    # Reach ~108 m, floored at 100, rounded up to a 50 m step.
+    assert 100.0 <= buf <= 200.0
+    assert buf % 50.0 == 0
+
+
+def test_suggest_buffer_capped_at_max_range(monkeypatch):
+    from core.services.image.FrameGeometry import FrameGeometry
+    # Very oblique frame -> reach clamps to max_range_m.
+    fg = FrameGeometry(
+        lat=38.7, lon=-120.5, agl_m=120.0, yaw_deg=0.0, pitch_deg=-12.0, roll_deg=0.0,
+        focal_mm=8.8, sensor_mm=(13.2, 8.8), image_size=(4000, 3000),
+        principal_point_mm=None, yaw_source='gimbal', bearing_confidence=1.0)
+    monkeypatch.setattr(aoi, "_frame_geometry", lambda p: fg)
+    params = PodParams(max_range_m=800.0)
+    buf = aoi.suggest_buffer_m([{"path": "a.jpg"}], params=params)
+    assert buf <= params.max_range_m
+
+
+def test_suggest_buffer_default_when_no_geometry(monkeypatch):
+    monkeypatch.setattr(aoi, "_frame_geometry", lambda p: None)
+    buf = aoi.suggest_buffer_m([{"path": "a.jpg"}])
+    assert buf == pytest.approx(aoi._DEFAULT_BUFFER_M)
+
+
+def test_estimate_download_aoi(monkeypatch):
+    coords = {"a.jpg": (38.70, -120.50), "b.jpg": (38.72, -120.46)}
+    monkeypatch.setattr(aoi, "image_gps", lambda p: coords.get(p))
+    monkeypatch.setattr(aoi, "suggest_buffer_m", lambda *a, **k: 500.0)
+    images = [{"path": p} for p in coords]
+    est = aoi.estimate_download_aoi(images)
+    assert est is not None
+    padded, raw, buffer_m = est
+    assert buffer_m == 500.0
+    assert raw == pytest.approx((-120.50, 38.70, -120.46, 38.72))
+    assert padded[0] < raw[0] and padded[2] > raw[2]
+
+
+def test_estimate_none_without_gps(monkeypatch):
+    monkeypatch.setattr(aoi, "image_gps", lambda p: None)
+    assert aoi.estimate_download_aoi([{"path": "a.jpg"}]) is None

--- a/app/tests/core/services/coverage/test_colormap.py
+++ b/app/tests/core/services/coverage/test_colormap.py
@@ -7,6 +7,7 @@ from core.services.coverage.colormap import (
     _build_pod_lut,
     pod_to_rgba,
     look_count_to_rgba,
+    chm_to_rgba,
 )
 
 
@@ -33,6 +34,28 @@ def test_pod_to_rgba_transparent_where_no_looks():
     # Looked cells above the floor are opaque.
     assert rgba[0, 1, 3] > 0
     assert rgba[1, 1, 3] > 0
+
+
+def test_chm_rgba_transparent_at_open_ground_and_nodata():
+    chm = np.array([[np.nan, 0.0, 0.3, 5.0]], dtype=np.float32)
+    rgba = chm_to_rgba(chm)
+    assert rgba.shape == (1, 4, 4)
+    # NaN, bare ground, and sub-threshold vegetation are all fully transparent.
+    assert tuple(rgba[0, 0]) == (0, 0, 0, 0)
+    assert tuple(rgba[0, 1]) == (0, 0, 0, 0)
+    assert tuple(rgba[0, 2]) == (0, 0, 0, 0)
+    assert rgba[0, 3, 3] > 0
+
+
+def test_chm_rgba_darker_and_more_opaque_with_height():
+    chm = np.array([[2.0, 15.0, 35.0, 80.0]], dtype=np.float32)
+    rgba = chm_to_rgba(chm, max_height_m=35.0)
+    # Green channel dominates and darkens as canopy gets taller.
+    lum = rgba[0, :, :3].astype(int).sum(axis=1)
+    assert lum[0] > lum[1] > lum[2]
+    # Alpha rises with height, saturating at max_height_m.
+    assert rgba[0, 0, 3] < rgba[0, 1, 3] < rgba[0, 2, 3]
+    assert tuple(rgba[0, 2]) == tuple(rgba[0, 3])
 
 
 def test_look_count_rgba_saturates():

--- a/app/tests/core/services/coverage/test_colormap.py
+++ b/app/tests/core/services/coverage/test_colormap.py
@@ -1,0 +1,44 @@
+"""Tests for the POD / look-count RGBA lookup tables."""
+
+import numpy as np
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.colormap import (
+    _build_pod_lut,
+    pod_to_rgba,
+    look_count_to_rgba,
+)
+
+
+def test_pod_lut_shape_and_alpha_ramp():
+    lut = _build_pod_lut(0.05)
+    assert lut.shape == (256, 4)
+    floor_i = int(round(0.05 * 255))
+    # Fully transparent below the floor, opaque-ish above.
+    assert np.all(lut[:floor_i, 3] == 0)
+    assert lut[floor_i:, 3].max() > 150
+    # Alpha is monotonically non-decreasing above the floor.
+    assert np.all(np.diff(lut[floor_i:, 3].astype(int)) >= 0)
+
+
+def test_pod_to_rgba_transparent_where_no_looks():
+    params = PodParams()
+    pod = np.array([[0.0, 0.5], [0.8, 0.9]], dtype=np.float32)
+    look = np.array([[0, 2], [0, 3]], dtype=np.uint16)
+    rgba = pod_to_rgba(pod, look, params)
+    assert rgba.shape == (2, 2, 4)
+    # Cells with zero looks are fully transparent regardless of POD value.
+    assert tuple(rgba[0, 0]) == (0, 0, 0, 0)
+    assert tuple(rgba[1, 0]) == (0, 0, 0, 0)
+    # Looked cells above the floor are opaque.
+    assert rgba[0, 1, 3] > 0
+    assert rgba[1, 1, 3] > 0
+
+
+def test_look_count_rgba_saturates():
+    look = np.array([[0, 1, 2, 3, 4, 5, 9]], dtype=np.uint16)
+    rgba = look_count_to_rgba(look)
+    assert tuple(rgba[0, 0]) == (0, 0, 0, 0)   # 0 looks transparent
+    assert rgba[0, 1, 3] > 0                    # 1 look visible
+    # 5 and 9 saturate to the same top step.
+    assert tuple(rgba[0, 5]) == tuple(rgba[0, 6])

--- a/app/tests/core/services/coverage/test_contracts.py
+++ b/app/tests/core/services/coverage/test_contracts.py
@@ -1,0 +1,89 @@
+"""Tests for FrameIndex and CoverageResult.sample."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyproj")
+
+from core.services.coverage.contracts import (
+    FrameIndex,
+    CoverageResult,
+    LIMIT_CANOPY,
+)
+from core.services.terrain.grid import make_lattice_spec, lonlat_to_mercator, mercator_to_lonlat
+
+
+def test_frame_index_add_and_query():
+    fi = FrameIndex(block_cells=4, max_per_block=8)
+    mask = np.zeros((8, 8), dtype=bool)
+    mask[0, 0] = True     # block (0,0)
+    mask[5, 6] = True     # block (1,1)
+    fi.add(frame_idx=3, row0=0, col0=0, any_pod_mask=mask)
+    assert fi.frames_at(0, 0) == [3]
+    assert fi.frames_at(5, 6) == [3]
+    # (2,2) shares block (0,0) with cell (0,0), so it reports the same frame.
+    assert fi.frames_at(2, 2) == [3]
+    # A block with no contributing cells is empty.
+    assert fi.frames_at(3, 7) == []  # block (0,1): no True cells there
+
+
+def test_frame_index_cap_and_dedup():
+    fi = FrameIndex(block_cells=4, max_per_block=2)
+    m = np.ones((1, 1), dtype=bool)
+    for f in (1, 1, 2, 3):
+        fi.add(f, 0, 0, m)
+    assert fi.frames_at(0, 0) == [1, 2]  # deduped, capped at 2
+
+
+def test_frame_index_shift_origin():
+    fi = FrameIndex(block_cells=4, max_per_block=8)
+    fi.add(7, 0, 0, np.ones((1, 1), dtype=bool))
+    fi.shift_origin(1, 2)   # blocks move by (+1 row block, +2 col blocks)
+    assert fi.frames_at(0, 0) == []
+    assert fi.frames_at(4, 8) == [7]
+
+
+def test_coverage_result_sample():
+    # Small EPSG:3857 grid near the Sierra foothills.
+    minx, miny = lonlat_to_mercator(-120.50, 38.70)
+    maxx, maxy = lonlat_to_mercator(-120.48, 38.72)
+    spec = make_lattice_spec((minx, miny, maxx, maxy), 30.0)
+    H, W = spec.height, spec.width
+    pod = np.zeros((H, W), dtype=np.float32)
+    look = np.zeros((H, W), dtype=np.uint16)
+    lf = np.zeros((H, W), dtype=np.uint8)
+    # Mark a known interior cell.
+    ri, ci = H // 2, W // 2
+    pod[ri, ci] = 0.63
+    look[ri, ci] = 4
+    lf[ri, ci] = LIMIT_CANOPY
+    fi = FrameIndex(block_cells=4, max_per_block=8)
+    fi.add(11, ri, ci, np.ones((1, 1), dtype=bool))
+
+    result = CoverageResult(
+        pod=pod, look_count=look, transform=spec.transform, image_count=1,
+        skipped=[], stats={}, gap_polygons=[], cancelled=False,
+        limiting_factor=lf, frame_index=fi,
+    )
+
+    xs, ys = spec.cell_centers()
+    lon, lat = mercator_to_lonlat(float(xs[ci]), float(ys[ri]))
+    s = result.sample(lat, lon)
+    assert s is not None
+    assert s['pod'] == pytest.approx(0.63, abs=1e-4)
+    assert s['looks'] == 4
+    assert s['limiting_factor'] == LIMIT_CANOPY
+    assert s['frames'] == [11]
+
+
+def test_coverage_result_sample_out_of_grid():
+    minx, miny = lonlat_to_mercator(-120.50, 38.70)
+    maxx, maxy = lonlat_to_mercator(-120.48, 38.72)
+    spec = make_lattice_spec((minx, miny, maxx, maxy), 30.0)
+    pod = np.zeros((spec.height, spec.width), dtype=np.float32)
+    result = CoverageResult(
+        pod=pod, look_count=np.zeros_like(pod, dtype=np.uint16),
+        transform=spec.transform, image_count=0, skipped=[], stats={},
+        gap_polygons=[], cancelled=False,
+    )
+    assert result.sample(10.0, 10.0) is None

--- a/app/tests/core/services/coverage/test_coverage_pod_service.py
+++ b/app/tests/core/services/coverage/test_coverage_pod_service.py
@@ -1,0 +1,122 @@
+"""Orchestration tests for CoveragePodService with mocked geometry/terrain seams."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+pytest.importorskip("shapely")
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.CoveragePodService import CoveragePodService
+from core.services.coverage.contracts import (
+    SKIP_HIDDEN, SKIP_NO_POSE, SKIP_PITCH_TOO_SHALLOW, SKIP_NO_DEM, SKIP_ERROR,
+)
+from core.services.terrain.grid import GridSample
+from ._kernel_helpers import make_fg
+
+
+class _FakeProvider:
+    def get_datum_info(self):
+        return {"name": "FLAT", "type": "orthometric"}
+
+
+class _FlatTerrain:
+    """Returns a flat (zero-elevation) DEM co-registered to any requested spec."""
+    def __init__(self):
+        self.provider = _FakeProvider()
+
+    def sample_grid_spec(self, spec):
+        data = np.zeros((spec.height, spec.width), dtype=np.float32)
+        return GridSample(data=data, transform=spec.transform, crs=spec.crs,
+                          datum_note="flat")
+
+
+class _NoTerrain:
+    def __init__(self):
+        self.provider = _FakeProvider()
+
+    def sample_grid_spec(self, spec):
+        return None
+
+
+def _service(terrain, params=None):
+    svc = CoveragePodService(terrain=terrain, canopy=None,
+                             params=params or PodParams(grid_res_m=3.0))
+
+    def fake_fg(image):
+        if image.get('_raise'):
+            raise RuntimeError("boom")
+        return image.get('_fg')
+
+    svc._frame_geometry = fake_fg
+    return svc
+
+
+def test_skip_taxonomy_and_processing():
+    images = [
+        {'name': 'hidden', 'hidden': True},
+        {'name': 'nopose', '_fg': None},
+        {'name': 'shallow', '_fg': make_fg(pitch=-5.0)},
+        {'name': 'err', '_raise': True},
+        {'name': 'good', '_fg': make_fg(pitch=-90.0)},
+    ]
+    calls = []
+    svc = _service(_FlatTerrain())
+    result = svc.calculate(images, progress_callback=lambda c, t, m: calls.append((c, t, m)))
+
+    assert result.cancelled is False
+    assert result.image_count == 1
+    reasons = dict(result.skipped)
+    assert reasons['hidden'] == SKIP_HIDDEN
+    assert reasons['nopose'] == SKIP_NO_POSE
+    assert reasons['shallow'] == SKIP_PITCH_TOO_SHALLOW
+    assert reasons['err'] == SKIP_ERROR
+    assert result.stats['skipped_counts'][SKIP_ERROR] == 1
+    # Per-image progress (5) + 2 finalize ticks.
+    assert len(calls) == len(images) + 2
+
+
+def test_no_dem_skips_all():
+    images = [{'name': 'g', '_fg': make_fg(pitch=-90.0)}]
+    svc = _service(_NoTerrain())
+    result = svc.calculate(images)
+    # No frames could be placed (no accumulator) -> empty result.
+    assert result.image_count == 0
+    assert dict(result.skipped)['g'] == SKIP_NO_DEM
+    assert result.pod.size == 0
+
+
+def test_cancel_immediately():
+    images = [{'name': 'g', '_fg': make_fg(pitch=-90.0)}]
+    svc = _service(_FlatTerrain())
+    result = svc.calculate(images, cancel_check=lambda: True)
+    assert result.cancelled is True
+    assert result.image_count == 0
+
+
+def test_cancel_midway():
+    images = [{'name': f'g{i}', '_fg': make_fg(pitch=-90.0)} for i in range(4)]
+    svc = _service(_FlatTerrain())
+    state = {'n': 0}
+
+    def cancel():
+        state['n'] += 1
+        return state['n'] > 2   # allow a couple of frames, then cancel
+
+    result = svc.calculate(images, cancel_check=cancel)
+    assert result.cancelled is True
+
+
+def test_processed_result_has_products():
+    images = [
+        {'name': 'a', '_fg': make_fg(pitch=-90.0, yaw=0.0)},
+        {'name': 'b', '_fg': make_fg(pitch=-90.0, yaw=90.0)},
+    ]
+    svc = _service(_FlatTerrain())
+    result = svc.calculate(images)
+    assert result.image_count == 2
+    assert result.pod.ndim == 2 and result.pod.size > 0
+    assert result.limiting_factor is not None
+    assert result.frame_index is not None
+    assert 'area_sqm' in result.stats
+    assert result.stats['terrain']['name'] == 'FLAT'

--- a/app/tests/core/services/coverage/test_coverage_result_cache.py
+++ b/app/tests/core/services/coverage/test_coverage_result_cache.py
@@ -1,0 +1,18 @@
+"""Tests for the in-session CoverageResultCache lifecycle."""
+
+from core.services.coverage.CoverageResultCache import CoverageResultCache
+
+
+def test_cache_lifecycle():
+    cache = CoverageResultCache()
+    assert cache.has_result() is False
+    assert cache.get_result() is None
+
+    sentinel = object()
+    cache.set_result(sentinel)
+    assert cache.has_result() is True
+    assert cache.get_result() is sentinel
+
+    cache.invalidate()
+    assert cache.has_result() is False
+    assert cache.get_result() is None

--- a/app/tests/core/services/coverage/test_datum_shift.py
+++ b/app/tests/core/services/coverage/test_datum_shift.py
@@ -1,0 +1,42 @@
+"""Spec section 8-5: a constant vertical datum offset must not change POD.
+
+The datum rule sets cam_elev = DEM(nadir) + AGL, so shifting the whole DEM (and
+therefore the camera) by a constant leaves every relative height identical.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.kernel import compute_target_mask_and_gsd, frame_pod_kernel
+from ._kernel_helpers import make_fg, metric_spec
+
+PARAMS = PodParams(ray_samples=96, gsd_full_cm=1.0, gsd_max_cm=500.0)
+
+
+def _pod_for_dem(dem, spec, fg, cam_xy, agl):
+    # Datum rule: camera elevation tracks the DEM under the nadir point.
+    rows, cols = spec.world_to_index(cam_xy[0], cam_xy[1])
+    r, c = int(round(float(rows))), int(round(float(cols)))
+    cam_z = float(dem[r, c]) + agl
+    cam_xyz = (cam_xy[0], cam_xy[1], cam_z)
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, PARAMS, 1.0)
+    return frame_pod_kernel(dem, None, None, spec.transform, cam_xyz, mask, gsd, PARAMS, 1.0)
+
+
+def test_constant_datum_offset_invariant_with_ridge():
+    spec = metric_spec(300.0, 260.0, 1.0)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    ys = spec.cell_centers()[1]
+    wall_rows = np.where((ys >= 100.0) & (ys <= 110.0))[0]
+    dem[wall_rows, :] = 60.0
+    fg = make_fg(pitch=-35.0, yaw=0.0)
+    minx, _, maxx, _ = spec.bounds
+    cam_xy = ((minx + maxx) / 2.0, 20.0)
+    agl = 120.0
+
+    pod1 = _pod_for_dem(dem, spec, fg, cam_xy, agl)
+    pod2 = _pod_for_dem(dem - 30.0, spec, fg, cam_xy, agl)
+    assert np.array_equal(pod1, pod2)

--- a/app/tests/core/services/coverage/test_gsd_grid.py
+++ b/app/tests/core/services/coverage/test_gsd_grid.py
@@ -1,0 +1,80 @@
+"""Vectorized per-cell GSD vs GSDService, and the adequacy piecewise endpoints."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+
+from core.services.GSDService import GSDService
+from core.services.coverage.params import PodParams
+from core.services.coverage.kernel import compute_target_mask_and_gsd, frame_pod_kernel
+from ._kernel_helpers import make_fg, metric_spec
+
+FOCAL = 8.8
+SENSOR = (13.2, 8.8)
+SIZE = (4000, 3000)
+AGL = 120.0
+
+
+def _grid(fg, params):
+    spec = metric_spec(400.0, 320.0, 1.0)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    minx, miny, maxx, maxy = spec.bounds
+    cam_xyz = ((minx + maxx) / 2.0, (miny + maxy) / 2.0, fg.agl_m)
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, params, 1.0)
+    return spec, dem, cam_xyz, mask, gsd
+
+
+def test_nadir_gsd_matches_gsdservice():
+    fg = make_fg(pitch=-90.0, focal=FOCAL, sensor=SENSOR, size=SIZE, agl=AGL)
+    spec, dem, cam_xyz, mask, gsd = _grid(fg, PodParams())
+    rows, cols = spec.world_to_index(cam_xyz[0], cam_xyz[1])
+    r, c = int(round(float(rows))), int(round(float(cols)))
+
+    svc = GSDService(FOCAL, SIZE, AGL, 0.0, SENSOR)
+    center_cm = svc.compute_gsd(SIZE[1] // 2, SIZE[0] // 2)
+    assert gsd[r, c] == pytest.approx(center_cm, rel=1e-3)
+
+    analytic = 100.0 * AGL * (SENSOR[0] / SIZE[0]) * 1e-3 / (FOCAL * 1e-3)
+    assert gsd[r, c] == pytest.approx(analytic, rel=1e-3)
+
+
+def test_oblique_on_axis_gsd_matches_gsdservice():
+    # 30 deg off nadir (pitch -60).
+    fg = make_fg(pitch=-60.0, yaw=0.0, focal=FOCAL, sensor=SENSOR, size=SIZE, agl=AGL)
+    spec = metric_spec(600.0, 500.0, 1.0)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    minx, miny, maxx, maxy = spec.bounds
+    cam_x = (minx + maxx) / 2.0
+    cam_y = miny + 20.0
+    cam_xyz = (cam_x, cam_y, AGL)
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, PodParams(), 1.0)
+    # On-axis ground point at 60 deg depression: north offset = agl / tan(60).
+    import math
+    ty = cam_y + AGL / math.tan(math.radians(60.0))
+    rows, cols = spec.world_to_index(cam_x, ty)
+    r, c = int(round(float(rows))), int(round(float(cols)))
+    assert mask[r, c]
+
+    # The kernel uses a geometric-mean closed form while GSDService does a full
+    # per-pixel ray/ground projection; they agree exactly at nadir and diverge
+    # modestly with obliquity. A ~10% band at 30 deg off-nadir is immaterial to
+    # the coarse adequacy ramp.
+    svc = GSDService(FOCAL, SIZE, AGL, 30.0, SENSOR)
+    center_cm = svc.compute_gsd(SIZE[1] // 2, SIZE[0] // 2)
+    assert gsd[r, c] == pytest.approx(center_cm, rel=0.10)
+
+
+def test_adequacy_endpoints():
+    fg = make_fg(pitch=-90.0, focal=FOCAL, sensor=SENSOR, size=SIZE, agl=AGL)
+    # Sub-nadir GSD ~4.5 cm. Knobs below it -> adequacy 1; knobs above it -> 0.
+    p_full = PodParams(gsd_full_cm=10.0, gsd_max_cm=20.0)
+    spec, dem, cam_xyz, mask, gsd = _grid(fg, p_full)
+    rows, cols = spec.world_to_index(cam_xyz[0], cam_xyz[1])
+    r, c = int(round(float(rows))), int(round(float(cols)))
+    pod = frame_pod_kernel(dem, None, None, spec.transform, cam_xyz, mask, gsd, p_full, 1.0)
+    assert pod[r, c] == pytest.approx(1.0, rel=1e-3)
+
+    p_zero = PodParams(gsd_full_cm=1.0, gsd_max_cm=3.0)
+    pod0 = frame_pod_kernel(dem, None, None, spec.transform, cam_xyz, mask, gsd, p_zero, 1.0)
+    assert pod0[r, c] == 0.0

--- a/app/tests/core/services/coverage/test_kernel_canopy.py
+++ b/app/tests/core/services/coverage/test_kernel_canopy.py
@@ -1,0 +1,93 @@
+"""Spec section 8-3: canopy transmittance matches closed-form Beer-Lambert."""
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.kernel import compute_target_mask_and_gsd, frame_pod_kernel
+from ._kernel_helpers import make_fg, metric_spec
+
+# Generous GSD knobs (gsd_full above every in-frame GSD) so adequacy == 1
+# everywhere and POD isolates transmittance.
+PARAMS = PodParams(gsd_full_cm=50.0, gsd_max_cm=1000.0, extinction_k=0.06)
+
+# The midpoint ray-march carries an O(1/K) integration bias at the sharp canopy
+# boundary (~5% in L at K=48); it is a constant that extinction_k absorbs during
+# field calibration (spec section 8-6), so the closed-form checks use a matching
+# tolerance rather than asserting exactness.
+BEER_TOL = 0.07
+
+
+def _pod_grid(fg, chm_val, cover_val, cell=1.0, width_m=240.0, height_m=200.0,
+              params=PARAMS):
+    spec = metric_spec(width_m, height_m, cell)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    chm = (None if chm_val is None
+           else np.full((spec.height, spec.width), chm_val, dtype=np.float32))
+    cover = (None if cover_val is None
+             else np.full((spec.height, spec.width), cover_val, dtype=np.float32))
+    minx, miny, maxx, maxy = spec.bounds
+    cam_xyz = ((minx + maxx) / 2.0, (miny + maxy) / 2.0, fg.agl_m)
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, params, 1.0)
+    pod = frame_pod_kernel(dem, chm, cover, spec.transform, cam_xyz, mask, gsd, params, 1.0)
+    return spec, mask, pod, cam_xyz
+
+
+def _center_pod(spec, pod, cam_xyz):
+    rows, cols = spec.world_to_index(cam_xyz[0], cam_xyz[1])
+    return float(pod[int(round(float(rows))), int(round(float(cols)))])
+
+
+def test_nadir_uniform_canopy_beer_lambert():
+    fg = make_fg(pitch=-90.0)
+    spec, mask, pod, cam = _pod_grid(fg, chm_val=20.0, cover_val=1.0)
+    expected = math.exp(-PARAMS.extinction_k * 20.0)   # vertical path == chm
+    center = _center_pod(spec, pod, cam)
+    assert center == pytest.approx(expected, rel=BEER_TOL)
+    # The sub-nadir cell is the most vertical LOS, so it has the shortest canopy
+    # path and the highest transmittance of the frame.
+    assert center == pytest.approx(float(pod[mask].max()), rel=1e-3)
+
+
+def test_cover_half_halves_optical_path():
+    fg = make_fg(pitch=-90.0)
+    spec, mask, pod, cam = _pod_grid(fg, chm_val=20.0, cover_val=0.5)
+    expected = math.exp(-PARAMS.extinction_k * 20.0 * 0.5)
+    assert _center_pod(spec, pod, cam) == pytest.approx(expected, rel=BEER_TOL)
+
+
+def test_no_canopy_transmittance_one():
+    fg = make_fg(pitch=-90.0)
+    spec, mask, pod, cam = _pod_grid(fg, chm_val=None, cover_val=None)
+    # adequacy == 1 (generous knobs), no canopy -> POD == 1.
+    assert _center_pod(spec, pod, cam) == pytest.approx(1.0, rel=1e-3)
+    assert np.allclose(pod[mask], 1.0, atol=1e-3)
+
+
+def test_oblique_45_path_is_root2_longer():
+    # Optical axis at 45 deg depression; the cell on the axis sees the 20 m layer
+    # over a slant path of ~20 * sqrt(2).
+    fg = make_fg(pitch=-45.0, yaw=0.0)
+    spec = metric_spec(600.0, 400.0, 1.0)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    chm = np.full((spec.height, spec.width), 20.0, dtype=np.float32)
+    cover = np.ones((spec.height, spec.width), dtype=np.float32)
+    # Camera near the south edge so the -45 deg axis lands inside the grid.
+    minx, miny, maxx, maxy = spec.bounds
+    cam_x = (minx + maxx) / 2.0
+    cam_y = miny + 20.0
+    cam_z = fg.agl_m
+    cam_xyz = (cam_x, cam_y, cam_z)
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, PARAMS, 1.0)
+    pod = frame_pod_kernel(dem, chm, cover, spec.transform, cam_xyz, mask, gsd, PARAMS, 1.0)
+    # On-axis ground point at 45 deg: north offset == agl (since tan(45)=1).
+    tgt_x, tgt_y = cam_x, cam_y + fg.agl_m
+    rows, cols = spec.world_to_index(tgt_x, tgt_y)
+    r, c = int(round(float(rows))), int(round(float(cols)))
+    assert mask[r, c]
+    l_eff = -math.log(pod[r, c]) / PARAMS.extinction_k
+    assert l_eff == pytest.approx(20.0 * math.sqrt(2), rel=0.10)

--- a/app/tests/core/services/coverage/test_kernel_flat_plane.py
+++ b/app/tests/core/services/coverage/test_kernel_flat_plane.py
@@ -1,0 +1,60 @@
+"""Spec section 8-1: flat-plane nadir POD footprint matches the analytic FOV."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.kernel import compute_target_mask_and_gsd, frame_pod_kernel
+from ._kernel_helpers import make_fg, metric_spec
+
+
+def _run(fg, cell=0.5, width_m=240.0, height_m=200.0, params=None):
+    params = params or PodParams(gsd_full_cm=1.0, gsd_max_cm=50.0)
+    spec = metric_spec(width_m, height_m, cell)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    minx, miny, maxx, maxy = spec.bounds
+    cam_xyz = ((minx + maxx) / 2.0, (miny + maxy) / 2.0, fg.agl_m)
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, params, 1.0)
+    pod = frame_pod_kernel(dem, None, None, spec.transform, cam_xyz, mask, gsd, params, 1.0)
+    return spec, mask, gsd, pod, cam_xyz
+
+
+def test_nadir_footprint_area_within_1_percent():
+    fg = make_fg(pitch=-90.0, yaw=0.0)
+    cell = 0.5
+    spec, mask, gsd, pod, _ = _run(fg, cell=cell)
+    # Analytic nadir ground rectangle: (agl * sensor_w / focal) x (agl * sensor_h / focal).
+    exp_w = fg.agl_m * fg.sensor_mm[0] / fg.focal_mm    # 180 m
+    exp_h = fg.agl_m * fg.sensor_mm[1] / fg.focal_mm    # 120 m
+    expected_area = exp_w * exp_h
+    area = int(mask.sum()) * cell * cell
+    assert area == pytest.approx(expected_area, rel=0.01)
+    # POD is nonzero exactly where visible-in-frustum.
+    assert np.count_nonzero(pod) == int(mask.sum())
+
+
+def test_interior_pod_equals_adequacy_at_nadir():
+    params = PodParams()  # default gsd knobs 2..10
+    fg = make_fg(pitch=-90.0)
+    spec, mask, gsd, pod, cam_xyz = _run(fg, params=params)
+    # Cell directly under the camera: r == agl, sin_gamma == 1.
+    cam_x, cam_y, _ = cam_xyz
+    rows, cols = spec.world_to_index(cam_x, cam_y)
+    r, c = int(round(float(rows))), int(round(float(cols)))
+    pel_m = (fg.sensor_mm[0] / fg.image_size[0]) * 1e-3
+    f_m = fg.focal_mm * 1e-3
+    gsd_center_cm = 100.0 * fg.agl_m * pel_m / f_m
+    adequacy = (params.gsd_max_cm - gsd_center_cm) / (params.gsd_max_cm - params.gsd_full_cm)
+    assert pod[r, c] == pytest.approx(adequacy, rel=0.02)
+    assert gsd[r, c] == pytest.approx(gsd_center_cm, rel=1e-3)
+
+
+def test_rotated_yaw_preserves_area():
+    cell = 0.5
+    _, mask0, _, _, _ = _run(make_fg(pitch=-90.0, yaw=0.0), cell=cell)
+    _, mask37, _, _, _ = _run(make_fg(pitch=-90.0, yaw=37.0), cell=cell)
+    a0 = int(mask0.sum()) * cell * cell
+    a37 = int(mask37.sum()) * cell * cell
+    assert a37 == pytest.approx(a0, rel=0.01)

--- a/app/tests/core/services/coverage/test_kernel_ridge.py
+++ b/app/tests/core/services/coverage/test_kernel_ridge.py
@@ -1,0 +1,95 @@
+"""Spec section 8-2: a ridge/wall occludes exactly the cells a brute-force
+line-of-sight check says it should."""
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("scipy")
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.kernel import compute_target_mask_and_gsd, frame_pod_kernel
+from ._kernel_helpers import make_fg, metric_spec
+
+# Dense sampling + generous GSD so POD == terrain visibility (0/adequacy).
+PARAMS = PodParams(ray_samples=96, gsd_full_cm=1.0, gsd_max_cm=500.0)
+
+
+def _brute_blocked(dem, spec, cam, tx, ty, tz, cell_m, n=800, eps=0.5):
+    cam_x, cam_y, cam_z = cam
+    ground_range = math.hypot(tx - cam_x, ty - cam_y)
+    ts = (np.arange(n) + 0.5) / n
+    sxs = cam_x + (tx - cam_x) * ts
+    sys = cam_y + (ty - cam_y) * ts
+    szs = cam_z + (tz - cam_z) * ts
+    for i in range(n):
+        if (1.0 - ts[i]) * ground_range <= cell_m:
+            continue
+        rows, cols = spec.world_to_index(sxs[i], sys[i])
+        ri = int(round(float(rows)))
+        ci = int(round(float(cols)))
+        if 0 <= ri < dem.shape[0] and 0 <= ci < dem.shape[1]:
+            if dem[ri, ci] > szs[i] + eps:
+                return True
+    return False
+
+
+@pytest.fixture
+def ridge_scene():
+    spec = metric_spec(300.0, 260.0, 1.0)
+    dem = np.zeros((spec.height, spec.width), dtype=np.float32)
+    # A full-width E-W wall, 60 m tall, spanning y in [100, 110].
+    ys = spec.cell_centers()[1]
+    wall_rows = np.where((ys >= 100.0) & (ys <= 110.0))[0]
+    dem[wall_rows, :] = 60.0
+    fg = make_fg(pitch=-35.0, yaw=0.0)
+    minx, _, maxx, _ = spec.bounds
+    cam_xyz = ((minx + maxx) / 2.0, 20.0, fg.agl_m)  # south edge, looking north
+    mask, gsd = compute_target_mask_and_gsd(dem, spec, fg, cam_xyz, PARAMS, 1.0)
+    pod = frame_pod_kernel(dem, None, None, spec.transform, cam_xyz, mask, gsd, PARAMS, 1.0)
+    return spec, dem, fg, cam_xyz, mask, gsd, pod
+
+
+def _cell(spec, x, y):
+    rows, cols = spec.world_to_index(x, y)
+    return int(round(float(rows))), int(round(float(cols)))
+
+
+def test_spot_checks_front_shadow_and_clear(ridge_scene):
+    spec, dem, fg, cam_xyz, mask, gsd, pod = ridge_scene
+    cx = cam_xyz[0]
+    # In front of the wall -> visible.
+    r, c = _cell(spec, cx, 95.0)
+    assert mask[r, c] and pod[r, c] > 0
+    # Immediately behind the wall -> shadowed (LOS still below the 60 m top).
+    r, c = _cell(spec, cx, 135.0)
+    assert mask[r, c] and pod[r, c] == 0.0
+    # Far enough north that the LOS clears the wall top -> visible again.
+    r, c = _cell(spec, cx, 205.0)
+    assert mask[r, c] and pod[r, c] > 0
+
+
+def test_matches_brute_force_along_centerline(ridge_scene):
+    spec, dem, fg, cam_xyz, mask, gsd, pod = ridge_scene
+    cx = cam_xyz[0]
+    ys = spec.cell_centers()[1]
+    cell_m = spec.transform.a
+    mismatches = 0
+    checked = 0
+    for y in ys:
+        # Skip the wall itself and a small band around the shadow boundary (~y=190)
+        # where bilinear (kernel) vs nearest (brute) sampling can disagree by a cell.
+        if 98.0 <= y <= 112.0 or 182.0 <= y <= 198.0:
+            continue
+        r, c = _cell(spec, cx, float(y))
+        if not mask[r, c]:
+            continue
+        checked += 1
+        tz = float(dem[r, c])
+        brute = _brute_blocked(dem, spec, cam_xyz, cx, float(y), tz, cell_m)
+        kernel_blocked = (pod[r, c] == 0.0)
+        if brute != kernel_blocked:
+            mismatches += 1
+    assert checked > 30
+    assert mismatches == 0

--- a/app/tests/core/services/coverage/test_pod_params.py
+++ b/app/tests/core/services/coverage/test_pod_params.py
@@ -1,0 +1,68 @@
+"""Tests for PodParams defaults, thermal preset, and settings loading."""
+
+from unittest.mock import MagicMock
+
+from core.services.coverage.params import PodParams
+
+
+def test_spec_defaults():
+    p = PodParams()
+    assert p.grid_res_m == 3.0
+    assert p.ray_samples == 48
+    assert p.extinction_k == 0.06
+    assert p.gsd_full_cm == 2.0
+    assert p.gsd_max_cm == 10.0
+    assert p.max_range_m == 800.0
+    assert p.min_pitch_deg == -10.0
+    assert p.gap_threshold == 0.25
+    assert p.pod_frame_cap == 0.85
+    assert p.common_mode_ceiling == 0.90
+    assert p.angle_bins == 8
+    assert p.pod_display_floor == 0.05
+
+
+def test_to_dict_roundtrips_keys():
+    d = PodParams().to_dict()
+    assert d['grid_res_m'] == 3.0
+    assert 'extinction_k' in d and 'pod_frame_cap' in d
+
+
+def test_thermal_preset_changes_only_gsd_knobs():
+    base = PodParams()
+    t = PodParams.thermal()
+    assert t.gsd_full_cm == 6.0
+    assert t.gsd_max_cm == 25.0
+    # Everything else stays default.
+    assert t.grid_res_m == base.grid_res_m
+    assert t.extinction_k == base.extinction_k
+
+
+def test_from_settings_none_returns_defaults():
+    assert PodParams.from_settings(None) == PodParams()
+
+
+def test_from_settings_reads_exposed_subset():
+    settings = MagicMock()
+    values = {'PodGsdPreset': 'rgb', 'PodGridResM': '1.5', 'PodGapThreshold': '0.4'}
+    settings.get_setting.side_effect = lambda k, d=None: values.get(k, d)
+    p = PodParams.from_settings(settings)
+    assert p.grid_res_m == 1.5
+    assert p.gap_threshold == 0.4
+    # Unexposed knobs stay default.
+    assert p.pod_frame_cap == 0.85
+
+
+def test_from_settings_thermal_preset():
+    settings = MagicMock()
+    settings.get_setting.side_effect = lambda k, d=None: 'thermal' if k == 'PodGsdPreset' else d
+    p = PodParams.from_settings(settings)
+    assert p.gsd_full_cm == 6.0
+    assert p.gsd_max_cm == 25.0
+
+
+def test_from_settings_bad_value_falls_back():
+    settings = MagicMock()
+    values = {'PodGridResM': 'not-a-number'}
+    settings.get_setting.side_effect = lambda k, d=None: values.get(k, d)
+    p = PodParams.from_settings(settings)
+    assert p.grid_res_m == 3.0

--- a/app/tests/core/services/coverage/test_writers.py
+++ b/app/tests/core/services/coverage/test_writers.py
@@ -60,6 +60,25 @@ def test_pod_geotiff_roundtrip(tmp_path, small_result):
         assert ds.tags().get("ADIAT_PRODUCT") == "coverage_pod"
 
 
+def test_pod_values_geotiff_roundtrip(tmp_path, small_result):
+    spec, result = small_result
+    path = str(tmp_path / "coverage_pod_values.tif")
+    writers.write_pod_values_geotiff(path, result.pod, result.look_count,
+                                     result.transform, result.params)
+    with rasterio.open(path) as ds:
+        assert ds.count == 1
+        assert ds.dtypes[0] == "float32"
+        assert ds.crs.to_epsg() == 3857
+        assert np.isnan(ds.nodata)
+        assert tuple(ds.transform)[:6] == pytest.approx(tuple(result.transform)[:6])
+        band = ds.read(1)
+        looked = result.look_count > 0
+        # Actual probabilities are queryable where looked; NaN elsewhere.
+        assert band[looked] == pytest.approx(result.pod[looked], abs=1e-6)
+        assert np.isnan(band[~looked]).all()
+        assert ds.tags()["ADIAT_PRODUCT"] == "coverage_pod_values"
+
+
 def test_looks_geotiff_roundtrip(tmp_path, small_result):
     spec, result = small_result
     path = str(tmp_path / "coverage_looks.tif")
@@ -116,7 +135,7 @@ def test_write_all_outputs(tmp_path, small_result):
     spec, result = small_result
     out = str(tmp_path / "coverage_pod")
     paths = writers.write_all_outputs(result, out)
-    assert set(paths.keys()) == {"pod", "looks", "gaps", "stats"}
+    assert set(paths.keys()) == {"pod", "pod_values", "looks", "gaps", "stats"}
     for p in paths.values():
         import os
         assert os.path.exists(p)

--- a/app/tests/core/services/coverage/test_writers.py
+++ b/app/tests/core/services/coverage/test_writers.py
@@ -1,0 +1,122 @@
+"""Tests for the GeoTIFF / GeoJSON / stats writers (tmp_path + rasterio read-back)."""
+
+import json
+
+import numpy as np
+import pytest
+
+pytest.importorskip("rasterio")
+pytest.importorskip("shapely")
+
+import rasterio
+from rasterio.enums import ColorInterp
+from shapely.geometry import box
+
+from core.services.coverage.params import PodParams
+from core.services.coverage.colormap import pod_to_rgba
+from core.services.coverage.contracts import CoverageResult
+from core.services.coverage import writers
+from core.services.terrain.grid import make_lattice_spec, lonlat_to_mercator
+
+
+@pytest.fixture
+def small_result():
+    minx, miny = lonlat_to_mercator(-120.50, 38.70)
+    spec = make_lattice_spec((minx, miny, minx + 300.0, miny + 240.0), 3.0)
+    H, W = spec.height, spec.width
+    pod = np.zeros((H, W), dtype=np.float32)
+    look = np.zeros((H, W), dtype=np.uint16)
+    # A covered patch with high POD in the middle.
+    pod[H // 4: 3 * H // 4, W // 4: 3 * W // 4] = 0.8
+    look[H // 4: 3 * H // 4, W // 4: 3 * W // 4] = 3
+    params = PodParams()
+    result = CoverageResult(
+        pod=pod, look_count=look, transform=spec.transform, image_count=5,
+        skipped=[("a.jpg", "no_dem"), ("b.jpg", "no_dem")], stats={},
+        gap_polygons=[], cancelled=False, params=params)
+    result.stats = writers.build_stats(
+        pod, look, spec.transform, result.skipped, [], params,
+        canopy_source="none", terrain_info={"name": "NAVD88"})
+    return spec, result
+
+
+def test_pod_geotiff_roundtrip(tmp_path, small_result):
+    spec, result = small_result
+    path = str(tmp_path / "coverage_pod.tif")
+    rgba = pod_to_rgba(result.pod, result.look_count, result.params)
+    writers.write_pod_geotiff(path, rgba, result.transform, result.params)
+
+    with rasterio.open(path) as ds:
+        assert ds.count == 4
+        assert ds.dtypes[0] == "uint8"
+        assert ds.crs.to_epsg() == 3857
+        assert ds.colorinterp[3] == ColorInterp.alpha
+        assert tuple(ds.transform)[:6] == pytest.approx(tuple(result.transform)[:6])
+        alpha = ds.read(4)
+        # Uncovered cells (look 0) are fully transparent.
+        assert alpha[0, 0] == 0
+        # The covered patch is opaque.
+        assert alpha[spec.height // 2, spec.width // 2] > 0
+        assert ds.tags().get("ADIAT_PRODUCT") == "coverage_pod"
+
+
+def test_looks_geotiff_roundtrip(tmp_path, small_result):
+    spec, result = small_result
+    path = str(tmp_path / "coverage_looks.tif")
+    writers.write_looks_geotiff(path, result.look_count, result.transform)
+    with rasterio.open(path) as ds:
+        assert ds.count == 1
+        assert ds.dtypes[0] == "uint16"
+        assert ds.nodata == 0
+        band = ds.read(1)
+        assert band.max() == 3
+
+
+def test_gaps_geojson_is_valid_wgs84(tmp_path, small_result):
+    spec, result = small_result
+    # A gap polygon in EPSG:3857 near the grid.
+    minx, miny, maxx, maxy = spec.bounds
+    gap = box(minx + 10, miny + 10, minx + 40, miny + 40)
+    path = str(tmp_path / "coverage_gaps.geojson")
+    writers.write_gaps_geojson(path, [gap], gap_threshold=0.25)
+    with open(path) as fh:
+        gj = json.load(fh)
+    assert gj["type"] == "FeatureCollection"
+    assert len(gj["features"]) == 1
+    feat = gj["features"][0]
+    assert feat["properties"]["kind"] == "coverage_gap"
+    # Coordinates are lon/lat (WGS84), near -120.5 / 38.7.
+    lon, lat = feat["geometry"]["coordinates"][0][0]
+    assert -121.0 < lon < -120.0
+    assert 38.0 < lat < 39.0
+
+
+def test_build_stats_keys_and_area(small_result):
+    spec, result = small_result
+    stats = result.stats
+    assert set(stats["area_sqm"].keys()) == {
+        "looks_ge_1", "pod_ge_0_25", "pod_ge_0_50", "pod_ge_0_75"}
+    # Covered area = number of looked cells * ~9 m^2 (3 m cells), within Mercator scale.
+    assert stats["area_sqm"]["looks_ge_1"] > 0
+    assert stats["skipped_counts"]["no_dem"] == 2
+    assert stats["canopy"]["source"] == "none"
+
+
+def test_compute_gap_polygons_inside_hull(small_result):
+    spec, result = small_result
+    minx, miny, maxx, maxy = spec.bounds
+    hull = box(minx, miny, maxx, maxy)
+    polys = writers.compute_gap_polygons(
+        result.pod, result.look_count, result.transform, hull, gap_threshold=0.25)
+    # The uncovered border (POD 0 < 0.25) inside the hull yields gap polygon(s).
+    assert len(polys) >= 1
+
+
+def test_write_all_outputs(tmp_path, small_result):
+    spec, result = small_result
+    out = str(tmp_path / "coverage_pod")
+    paths = writers.write_all_outputs(result, out)
+    assert set(paths.keys()) == {"pod", "looks", "gaps", "stats"}
+    for p in paths.values():
+        import os
+        assert os.path.exists(p)

--- a/app/tests/core/services/image/test_frame_geometry.py
+++ b/app/tests/core/services/image/test_frame_geometry.py
@@ -1,0 +1,208 @@
+"""Tests for FrameGeometry + the ImageService yaw-source / projection-context refactor."""
+
+import os
+import tempfile
+
+import cv2
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+from core.services.image.FrameGeometry import (
+    FrameGeometry,
+    BEARING_QUALITY_CONFIDENCE,
+    NO_YAW_CONFIDENCE,
+)
+from core.services.image.ImageService import ImageService
+
+EXIF_IMAGE = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "data", "rgb", "input", "DJI_0082.JPG")
+)
+
+
+def _mock_image_service(**overrides):
+    """A duck-typed ImageService with the getters FrameGeometry consumes."""
+    svc = MagicMock()
+    svc.img_array = np.zeros((3000, 4000, 3), dtype=np.uint8)
+    svc.exif_data = {"GPS": {}}  # LocationInfo.get_gps is patched by callers
+    svc.get_camera_intrinsics.return_value = {
+        'focal_length_mm': 8.8,
+        'sensor_width_mm': 13.2,
+        'sensor_height_mm': 8.8,
+    }
+    svc.get_camera_yaw_with_source.return_value = (137.0, 'gimbal')
+    svc.get_camera_pitch.return_value = -90.0
+    svc.get_gimbal_roll.return_value = 0.0
+    svc.get_relative_altitude.return_value = 120.0
+    svc.get_asl_altitude.return_value = 1500.0
+    for k, v in overrides.items():
+        setattr(svc, k, v)
+    return svc
+
+
+def _patch_gps(lat=38.7, lon=-120.5):
+    return patch(
+        "core.services.image.FrameGeometry.LocationInfo.get_gps",
+        return_value={'latitude': lat, 'longitude': lon},
+    )
+
+
+def test_from_image_service_populates_all_fields():
+    svc = _mock_image_service()
+    with _patch_gps():
+        fg = FrameGeometry.from_image_service(svc)
+    assert fg is not None
+    assert fg.lat == pytest.approx(38.7)
+    assert fg.lon == pytest.approx(-120.5)
+    assert fg.agl_m == pytest.approx(120.0)
+    assert fg.yaw_deg == pytest.approx(137.0)
+    assert fg.yaw_source == 'gimbal'
+    assert fg.bearing_confidence == 1.0
+    assert fg.pitch_deg == pytest.approx(-90.0)
+    assert fg.focal_mm == pytest.approx(8.8)
+    assert fg.sensor_mm == (13.2, 8.8)
+    assert fg.image_size == (4000, 3000)   # (width, height)
+    assert fg.principal_point_mm is None
+    assert fg.cam_elev_m is None           # no terrain access
+    assert fg.asl_alt_m == pytest.approx(1500.0)
+
+
+def test_no_gps_returns_none():
+    svc = _mock_image_service()
+    with patch("core.services.image.FrameGeometry.LocationInfo.get_gps", return_value={}):
+        assert FrameGeometry.from_image_service(svc) is None
+
+
+def test_missing_intrinsics_returns_none():
+    svc = _mock_image_service()
+    svc.get_camera_intrinsics.return_value = None
+    with _patch_gps():
+        assert FrameGeometry.from_image_service(svc) is None
+
+
+def test_nonpositive_agl_returns_none():
+    svc = _mock_image_service()
+    svc.get_relative_altitude.return_value = 0.0
+    with _patch_gps():
+        assert FrameGeometry.from_image_service(svc) is None
+
+
+def test_agl_override_and_custom_priority():
+    svc = _mock_image_service()
+    # agl_override_ft (e.g. wingtra) wins over custom and XMP.
+    with _patch_gps():
+        fg = FrameGeometry.from_image_service(svc, custom_altitude_ft=400.0,
+                                              agl_override_ft=328.084)
+    assert fg.agl_m == pytest.approx(100.0, abs=1e-3)   # 328.084 ft
+    with _patch_gps():
+        fg2 = FrameGeometry.from_image_service(svc, custom_altitude_ft=328.084)
+    assert fg2.agl_m == pytest.approx(100.0, abs=1e-3)
+
+
+def test_roll_over_90_is_zeroed():
+    svc = _mock_image_service()
+    svc.get_gimbal_roll.return_value = 178.0
+    with _patch_gps():
+        fg = FrameGeometry.from_image_service(svc)
+    assert fg.roll_deg == 0.0
+
+
+def test_yaw_fallback_confidence_mapping():
+    svc = _mock_image_service()
+    svc.get_camera_yaw_with_source.return_value = (200.0, 'calculated')
+    with _patch_gps():
+        fg = FrameGeometry.from_image_service(svc, bearing_quality='turn_inferred')
+    assert fg.yaw_source == 'calculated'
+    assert fg.bearing_confidence == BEARING_QUALITY_CONFIDENCE['turn_inferred']
+
+
+def test_no_yaw_defaults_to_zero_low_confidence():
+    svc = _mock_image_service()
+    svc.get_camera_yaw_with_source.return_value = (None, None)
+    with _patch_gps():
+        fg = FrameGeometry.from_image_service(svc)
+    assert fg.yaw_deg == 0.0
+    assert fg.yaw_source == 'default'
+    assert fg.bearing_confidence == NO_YAW_CONFIDENCE
+
+
+def test_image_size_from_exif_when_no_array():
+    import piexif
+    svc = _mock_image_service()
+    svc.img_array = None
+    svc.exif_data = {
+        "GPS": {},
+        "Exif": {piexif.ExifIFD.PixelXDimension: 5472, piexif.ExifIFD.PixelYDimension: 3648},
+    }
+    with _patch_gps():
+        fg = FrameGeometry.from_image_service(svc)
+    assert fg.image_size == (5472, 3648)
+
+
+# --- ImageService integration: yaw parity + projection-context golden keys ---
+
+@pytest.fixture
+def synthetic_service():
+    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp:
+        cv2.imwrite(tmp.name, np.zeros((60, 80, 3), dtype=np.uint8))
+        path = tmp.name
+    svc = ImageService(path, img_array=np.zeros((60, 80, 3), dtype=np.uint8))
+    yield svc
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+PROJ_CTX_KEYS = {
+    'drone_lat', 'drone_lon', 'img_w', 'img_h', 'cx', 'cy', 'focal_mm',
+    'sensor_w_mm', 'sensor_h_mm', 'pitch', 'yaw', 'roll', 'reported_agl',
+    'drone_terrain_elev_m', 'drone_absolute_elev_m', 'terrain_service',
+}
+
+
+def test_projection_context_golden_keys(synthetic_service):
+    svc = synthetic_service
+    # Stub the pose/intrinsics getters on the instance.
+    svc.get_camera_intrinsics = lambda: {
+        'focal_length_mm': 8.8, 'sensor_width_mm': 13.2, 'sensor_height_mm': 8.8}
+    svc.get_camera_yaw_with_source = lambda: (45.0, 'gimbal')
+    svc.get_camera_pitch = lambda: -90.0
+    svc.get_gimbal_roll = lambda: 0.0
+    svc.get_relative_altitude = lambda unit='m': 120.0
+    svc.get_asl_altitude = lambda unit: 1500.0
+
+    disabled_terrain = MagicMock()
+    disabled_terrain.enabled = False
+    with patch("core.services.image.FrameGeometry.LocationInfo.get_gps",
+               return_value={'latitude': 38.7, 'longitude': -120.5}), \
+         patch("core.services.terrain.TerrainService", return_value=disabled_terrain):
+        ctx = svc._get_projection_context()
+
+    assert ctx is not None
+    assert set(ctx.keys()) == PROJ_CTX_KEYS
+    assert ctx['drone_lat'] == pytest.approx(38.7)
+    assert ctx['img_w'] == 80 and ctx['img_h'] == 60
+    assert ctx['cx'] == pytest.approx(40.0) and ctx['cy'] == pytest.approx(30.0)
+    assert ctx['yaw'] == pytest.approx(45.0)
+    assert ctx['pitch'] == pytest.approx(-90.0)
+    assert ctx['reported_agl'] == pytest.approx(120.0)
+    # Terrain disabled -> reconciliation fields stay None.
+    assert ctx['drone_terrain_elev_m'] is None
+    assert ctx['drone_absolute_elev_m'] is None
+
+
+def test_projection_context_none_without_img_array(synthetic_service):
+    synthetic_service.img_array = None
+    assert synthetic_service._get_projection_context() is None
+
+
+@pytest.mark.skipif(not os.path.exists(EXIF_IMAGE),
+                    reason="test data DJI_0082.JPG not present in this checkout")
+def test_real_image_frame_geometry_and_yaw_parity():
+    svc = ImageService(EXIF_IMAGE)
+    assert svc.get_camera_yaw() == svc.get_camera_yaw_with_source()[0]
+    fg = svc.get_frame_geometry()
+    assert fg is not None
+    assert fg.yaw_source in ('gimbal', 'flight')
+    assert fg.bearing_confidence == 1.0
+    assert -180.0 <= fg.pitch_deg <= 180.0
+    assert fg.agl_m > 0

--- a/app/tests/core/services/terrain/test_canopy_service.py
+++ b/app/tests/core/services/terrain/test_canopy_service.py
@@ -1,0 +1,151 @@
+"""Tests for CanopyService: EVH/EVC LUTs, sample_grid_spec, cover derivation."""
+
+import csv
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely")
+rasterio = pytest.importorskip("rasterio")
+
+from rasterio.transform import from_bounds
+
+from core.services.terrain.CanopyService import (
+    CanopyService,
+    evh_code_to_meters,
+    evc_code_to_fraction,
+    KIND_META,
+)
+from core.services.terrain.grid import (
+    lonlat_to_mercator,
+    mercator_to_lonlat,
+    spec_for_bounds_wgs84,
+)
+
+# A small 3857 region near the Sierra foothills.
+_MINX, _MINY = lonlat_to_mercator(-120.50, 38.70)
+_MAXX, _MAXY = lonlat_to_mercator(-120.48, 38.72)
+
+
+def _write_tile(path, value, dtype, nodata=None):
+    cols = rows = 24
+    transform = from_bounds(_MINX, _MINY, _MAXX, _MAXY, cols, rows)
+    data = np.full((rows, cols), value, dtype=dtype)
+    with rasterio.open(path, "w", driver="GTiff", height=rows, width=cols, count=1,
+                       dtype=dtype, crs="EPSG:3857", transform=transform,
+                       nodata=nodata) as dst:
+        dst.write(data, 1)
+
+
+def _wgs84_bbox():
+    lo, la = mercator_to_lonlat(_MINX, _MINY)
+    hi, ha = mercator_to_lonlat(_MAXX, _MAXY)
+    return lo, la, hi, ha
+
+
+def _manifest(tmp_path, entries, has_product=True):
+    path = tmp_path / "canopy_manifest.csv"
+    lo, la, hi, ha = _wgs84_bbox()
+    fields = ['filename'] + (['product'] if has_product else []) + ['minX', 'minY', 'maxX', 'maxY']
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields)
+        w.writeheader()
+        for e in entries:
+            row = {'filename': e['filename'], 'minX': lo, 'minY': la, 'maxX': hi, 'maxY': ha}
+            if has_product:
+                row['product'] = e['product']
+            w.writerow(row)
+    return str(path)
+
+
+def _spec():
+    return spec_for_bounds_wgs84(_wgs84_bbox(), 10.0)
+
+
+# --- LUTs ---
+
+def test_evh_lut():
+    codes = np.array([101, 150, 199, 205, 230, 305, 11, 99, -9999])
+    m = evh_code_to_meters(codes)
+    assert m[0] == pytest.approx(1.0)
+    assert m[1] == pytest.approx(50.0)
+    assert m[2] == pytest.approx(99.0)
+    assert m[3] == pytest.approx(0.5)
+    assert m[4] == pytest.approx(3.0)
+    assert m[5] == pytest.approx(0.5)
+    assert m[6] == 0.0        # water -> 0
+    assert np.isnan(m[7])     # 99 fill
+    assert np.isnan(m[8])     # -9999 nodata
+
+
+def test_evc_lut():
+    codes = np.array([110, 155, 199, 250, 355, 100, 99, -9999])
+    f = evc_code_to_fraction(codes)
+    assert f[0] == pytest.approx(0.10)
+    assert f[1] == pytest.approx(0.55)
+    assert f[2] == pytest.approx(0.99)
+    assert f[3] == pytest.approx(0.50)
+    assert f[4] == pytest.approx(0.55)
+    assert f[5] == 0.0        # sparse -> 0
+    assert np.isnan(f[6])
+    assert np.isnan(f[7])
+
+
+# --- sample_grid_spec ---
+
+def test_landfire_evh_evc_coregistered(tmp_path):
+    _write_tile(tmp_path / "evh.tif", 150, "int16")   # 50 m tree
+    _write_tile(tmp_path / "evc.tif", 155, "int16")   # 0.55 cover
+    manifest = _manifest(tmp_path, [
+        {'filename': 'evh.tif', 'product': 'landfire_evh'},
+        {'filename': 'evc.tif', 'product': 'landfire_evc'},
+    ])
+    svc = CanopyService(manifest, str(tmp_path), kind='landfire')
+    spec = _spec()
+    sample = svc.sample_grid_spec(spec)
+    assert sample is not None
+    assert sample.chm.shape == (spec.height, spec.width)
+    assert sample.cover.shape == (spec.height, spec.width)
+    # Interior cells decode to the tile constants.
+    ch, cw = spec.height // 2, spec.width // 2
+    assert sample.chm[ch, cw] == pytest.approx(50.0, abs=0.5)
+    assert sample.cover[ch, cw] == pytest.approx(0.55, abs=0.02)
+    assert sample.cover_derived is False
+    svc.close()
+
+
+def test_meta_chm_derives_cover(tmp_path):
+    _write_tile(tmp_path / "chm.tif", 30.0, "float32", nodata=-9999.0)
+    manifest = _manifest(tmp_path, [{'filename': 'chm.tif', 'product': 'meta_chm'}])
+    svc = CanopyService(manifest, str(tmp_path), kind=KIND_META)
+    spec = _spec()
+    sample = svc.sample_grid_spec(spec)
+    assert sample is not None
+    ch, cw = spec.height // 2, spec.width // 2
+    assert sample.chm[ch, cw] == pytest.approx(30.0, abs=0.5)
+    # cover = clip(30/20,0,1)*0.9 = 0.9
+    assert sample.cover[ch, cw] == pytest.approx(0.9, abs=0.02)
+    assert sample.cover_derived is True
+    svc.close()
+
+
+def test_empty_aoi_returns_none(tmp_path):
+    _write_tile(tmp_path / "chm.tif", 30.0, "float32")
+    manifest = _manifest(tmp_path, [{'filename': 'chm.tif', 'product': 'meta_chm'}])
+    svc = CanopyService(manifest, str(tmp_path), kind=KIND_META)
+    far = spec_for_bounds_wgs84((-100.0, 20.0, -99.99, 20.01), 10.0)
+    assert svc.sample_grid_spec(far) is None
+    svc.close()
+
+
+def test_missing_manifest_does_not_raise(tmp_path):
+    svc = CanopyService(str(tmp_path / "nope.csv"), str(tmp_path), kind=KIND_META)
+    assert svc.sample_grid_spec(_spec()) is None
+
+
+def test_landfire_without_product_column_refuses(tmp_path):
+    _write_tile(tmp_path / "evh.tif", 150, "int16")
+    manifest = _manifest(tmp_path, [{'filename': 'evh.tif'}], has_product=False)
+    svc = CanopyService(manifest, str(tmp_path), kind='landfire')
+    # EVH/EVC indistinguishable without 'product' -> manifest refused -> no tiles.
+    assert svc.sample_grid_spec(_spec()) is None

--- a/app/tests/core/services/terrain/test_canopy_service_factory.py
+++ b/app/tests/core/services/terrain/test_canopy_service_factory.py
@@ -1,0 +1,52 @@
+"""Tests for CanopyServiceFactory.create_from_settings and the create_canopy_service alias."""
+
+from unittest.mock import MagicMock
+
+from core.services.terrain.CanopyServiceFactory import (
+    CanopyServiceFactory,
+    create_canopy_service,
+    CANOPY_KIND_NONE,
+)
+
+
+def _settings(values):
+    s = MagicMock()
+    s.get_setting.side_effect = lambda k, d=None: values.get(k, d)
+    return s
+
+
+def test_none_settings_returns_none():
+    assert CanopyServiceFactory.create_from_settings(None) is None
+
+
+def test_kind_none_returns_none():
+    s = _settings({'CanopyKind': CANOPY_KIND_NONE})
+    assert CanopyServiceFactory.create_from_settings(s) is None
+
+
+def test_landfire_missing_paths_returns_none():
+    s = _settings({'CanopyKind': 'landfire'})
+    assert CanopyServiceFactory.create_from_settings(s) is None
+
+
+def test_meta_with_paths_builds_service(tmp_path):
+    manifest = tmp_path / "m.csv"
+    manifest.write_text("filename,product,minX,minY,maxX,maxY\n")
+    s = _settings({'CanopyKind': 'meta',
+                   'CanopyManifestPath': str(manifest),
+                   'CanopyTilesDir': str(tmp_path)})
+    svc = CanopyServiceFactory.create_from_settings(s)
+    assert svc is not None
+    assert svc.kind == 'meta'
+
+
+def test_alias_matches_classmethod():
+    s = _settings({'CanopyKind': CANOPY_KIND_NONE})
+    assert create_canopy_service(s) is None
+
+
+def test_available_kinds_shape():
+    kinds = CanopyServiceFactory.available_kinds()
+    ids = [k['id'] for k in kinds]
+    assert ids == ['none', 'landfire', 'meta']
+    assert all('label' in k and 'requires_paths' in k for k in kinds)

--- a/app/tests/core/services/terrain/test_elevation_provider_sample_grid.py
+++ b/app/tests/core/services/terrain/test_elevation_provider_sample_grid.py
@@ -1,0 +1,80 @@
+"""Tests for the ElevationProvider.sample_grid ABC default (per-point slow path)."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("affine")
+
+from core.services.terrain.ElevationProvider import ElevationProvider, TerrariumProvider  # noqa: E402
+from core.services.terrain.grid import (  # noqa: E402
+    make_lattice_spec,
+    spec_for_bounds_wgs84,
+    mercator_to_lonlat,
+)
+
+
+class _PlaneProvider(ElevationProvider):
+    """Analytic provider: elevation is a plane in lat/lon, so the slow-path grid
+    can be checked against a closed form at every cell center."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get_provider_name(self):
+        return "plane"
+
+    def get_datum_info(self):
+        return {'name': 'TEST', 'type': 'orthometric', 'geoid_model': 'none'}
+
+    def get_provider_kind(self):
+        return 'local_geotiff'
+
+    def sample_elevation(self, lat, lon):
+        self.calls += 1
+        return 2.0 * lat + 3.0 * lon
+
+
+def test_slow_path_matches_plane_at_cell_centers():
+    provider = _PlaneProvider()
+    spec = spec_for_bounds_wgs84((-120.50, 38.70, -120.48, 38.72), 30.0)
+    sample = provider.sample_grid_spec(spec)
+    assert sample is not None
+    assert sample.data.shape == (spec.height, spec.width)
+    assert sample.crs == spec.crs
+    assert "orthometric" in sample.datum_note
+
+    xs, ys = spec.cell_centers()
+    for i in (0, spec.height // 2, spec.height - 1):
+        for j in (0, spec.width // 2, spec.width - 1):
+            lon, lat = mercator_to_lonlat(float(xs[j]), float(ys[i]))
+            expected = 2.0 * lat + 3.0 * lon
+            assert sample.data[i, j] == pytest.approx(expected, abs=1e-3)
+
+
+def test_none_values_become_nan():
+    class _Sparse(_PlaneProvider):
+        def sample_elevation(self, lat, lon):
+            return None if lon < -120.49 else 100.0
+
+    provider = _Sparse()
+    spec = spec_for_bounds_wgs84((-120.50, 38.70, -120.48, 38.71), 30.0)
+    sample = provider.sample_grid_spec(spec)
+    assert sample is not None
+    assert np.isnan(sample.data).any()
+    assert np.nanmax(sample.data) == pytest.approx(100.0)
+
+
+def test_unimplemented_sample_elevation_returns_none():
+    # Terrarium raises NotImplementedError for sample_elevation -> grid slow path None.
+    provider = TerrariumProvider()
+    spec = spec_for_bounds_wgs84((-120.50, 38.70, -120.49, 38.71), 30.0)
+    assert provider.sample_grid_spec(spec) is None
+
+
+def test_cell_limit_guard_returns_none():
+    provider = _PlaneProvider()
+    # A grid far exceeding SLOW_GRID_CELL_LIMIT.
+    big = make_lattice_spec((0.0, 0.0, 3000.0, 3000.0), 3.0)  # 1_000_000 cells
+    assert big.width * big.height > ElevationProvider.SLOW_GRID_CELL_LIMIT
+    assert provider.sample_grid_spec(big) is None
+    assert provider.calls == 0

--- a/app/tests/core/services/terrain/test_grid_spec.py
+++ b/app/tests/core/services/terrain/test_grid_spec.py
@@ -1,0 +1,140 @@
+"""Tests for the Web Mercator grid contracts and lattice helpers (grid.py)."""
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("affine")
+
+from core.services.terrain.grid import (  # noqa: E402
+    GridSpec,
+    GridSample,
+    make_lattice_spec,
+    spec_for_bounds_wgs84,
+    integer_offset,
+    lonlat_to_mercator,
+    mercator_to_lonlat,
+    mercator_units_per_meter,
+    WEB_MERCATOR_CRS,
+)
+from affine import Affine  # noqa: E402
+
+
+def test_mercator_roundtrip():
+    for lon, lat in [(-120.5, 38.7), (0.0, 0.0), (11.25, 43.77), (-150.0, 61.2)]:
+        x, y = lonlat_to_mercator(lon, lat)
+        lon2, lat2 = mercator_to_lonlat(x, y)
+        assert lon2 == pytest.approx(lon, abs=1e-7)
+        assert lat2 == pytest.approx(lat, abs=1e-7)
+
+
+def test_units_per_meter_equator_is_one():
+    assert mercator_units_per_meter(0.0) == pytest.approx(1.0)
+    # At 60N the inflation factor is 1/cos(60) = 2.
+    assert mercator_units_per_meter(60.0) == pytest.approx(2.0, rel=1e-6)
+
+
+def test_make_lattice_spec_snaps_outward_and_aligns():
+    cell = 3.0
+    # Bounds not aligned to the lattice.
+    spec = make_lattice_spec((10.4, 20.1, 40.9, 55.2), cell)
+    minx, miny, maxx, maxy = spec.bounds
+    # Edges are integer multiples of the cell size from origin.
+    for edge in (minx, maxx, miny, maxy):
+        assert edge / cell == pytest.approx(round(edge / cell), abs=1e-9)
+    # Snapped outward: contains the original bounds.
+    assert minx <= 10.4 and miny <= 20.1
+    assert maxx >= 40.9 and maxy >= 55.2
+    assert spec.cell_size == pytest.approx(cell)
+    assert spec.transform.e == pytest.approx(-cell)
+
+
+def test_cell_centers_and_world_to_index_are_inverse():
+    spec = make_lattice_spec((0.0, 0.0, 30.0, 30.0), 3.0)
+    xs, ys = spec.cell_centers()
+    assert xs.shape == (spec.width,)
+    assert ys.shape == (spec.height,)
+    # The center of cell (i, j) must map back to fractional index (i, j).
+    rows, cols = spec.world_to_index(xs[2], ys[4])
+    assert float(cols) == pytest.approx(2.0, abs=1e-9)
+    assert float(rows) == pytest.approx(4.0, abs=1e-9)
+
+
+def test_integer_offset_roundtrip():
+    parent = make_lattice_spec((0.0, 0.0, 300.0, 300.0), 3.0)
+    # A child snapped from a sub-window shares the lattice.
+    child = make_lattice_spec((30.0, 60.0, 90.0, 120.0), 3.0)
+    row_off, col_off = integer_offset(child, parent)
+    assert isinstance(row_off, int) and isinstance(col_off, int)
+    # child minx=30 -> col 10; child top(maxy) vs parent top -> row offset.
+    assert col_off == 10
+    # parent top = 300, child top = 120 -> (300-120)/3 = 60
+    assert row_off == 60
+
+
+def test_integer_offset_rejects_cell_mismatch():
+    parent = make_lattice_spec((0.0, 0.0, 300.0, 300.0), 3.0)
+    child = make_lattice_spec((0.0, 0.0, 300.0, 300.0), 1.0)
+    with pytest.raises(ValueError):
+        integer_offset(child, parent)
+
+
+def test_two_specs_same_cell_are_coregistered():
+    a = spec_for_bounds_wgs84((-120.60, 38.60, -120.40, 38.75), 3.0)
+    # A different but overlapping bbox at the same target resolution -> same cell,
+    # so integer_offset must succeed (this is the accumulation invariant).
+    b_cell = a.cell_size
+    minx, miny, maxx, maxy = a.bounds
+    child = make_lattice_spec((minx + 30 * b_cell, miny + 15 * b_cell,
+                               minx + 60 * b_cell, miny + 45 * b_cell), b_cell)
+    row_off, col_off = integer_offset(child, a)
+    assert col_off == 30
+    assert row_off == a.height - 45  # top-anchored
+
+
+def test_spec_for_bounds_wgs84_is_3857_and_ground_scaled():
+    spec = spec_for_bounds_wgs84((-120.5, 38.7, -120.4, 38.75), 3.0)
+    assert spec.crs == WEB_MERCATOR_CRS
+    mid_lat = (38.7 + 38.75) / 2
+    # cell in 3857 units ~= resolution_m / cos(lat)
+    assert spec.cell_size == pytest.approx(3.0 * mercator_units_per_meter(mid_lat), rel=1e-6)
+    # wgs84_bounds round-trips to contain the request.
+    lo, la, hi, ha = spec.wgs84_bounds()
+    assert lo <= -120.5 and hi >= -120.4
+    assert la <= 38.7 and ha >= 38.75
+
+
+def test_grid_sample_bilinear():
+    spec = make_lattice_spec((0.0, 0.0, 30.0, 30.0), 3.0)
+    # A ramp increasing to the east; value == x-index.
+    data = np.tile(np.arange(spec.width, dtype=np.float32), (spec.height, 1))
+    sample = GridSample(data=data, transform=spec.transform, crs=spec.crs,
+                        datum_note="test")
+    xs, ys = spec.cell_centers()
+    # At cell-center of column 3 the value is exactly 3.
+    v = sample.sample_bilinear(float(xs[3]), float(ys[2]))
+    assert v == pytest.approx(3.0, abs=1e-6)
+    # Halfway between column 3 and 4 centers -> 3.5.
+    v2 = sample.sample_bilinear(float((xs[3] + xs[4]) / 2), float(ys[2]))
+    assert v2 == pytest.approx(3.5, abs=1e-6)
+
+
+def test_grid_sample_bilinear_out_of_bounds_and_nan():
+    spec = make_lattice_spec((0.0, 0.0, 30.0, 30.0), 3.0)
+    data = np.zeros((spec.height, spec.width), dtype=np.float32)
+    data[0, 0] = np.nan
+    sample = GridSample(data=data, transform=spec.transform, crs=spec.crs,
+                        datum_note="test")
+    # Far outside the grid.
+    assert sample.sample_bilinear(10_000.0, 10_000.0) is None
+    xs, ys = spec.cell_centers()
+    # A cell touching the NaN corner returns None.
+    assert sample.sample_bilinear(float(xs[0]), float(ys[0])) is None
+
+
+def test_wgs84_bounds_rejects_non_3857():
+    spec = GridSpec(crs="EPSG:4326", transform=Affine(1, 0, 0, 0, -1, 1),
+                    width=1, height=1)
+    with pytest.raises(ValueError):
+        spec.wgs84_bounds()

--- a/app/tests/core/services/terrain/test_terrain_service.py
+++ b/app/tests/core/services/terrain/test_terrain_service.py
@@ -7,9 +7,22 @@ import tempfile
 from PIL import Image
 import io
 
-from core.services.terrain.TerrainService import TerrainService, ElevationResult
+from core.services.terrain.TerrainService import TerrainService as _TerrainService, ElevationResult
+from core.services.terrain.TerrainProviderFactory import PROVIDER_TERRARIUM
 from core.services.terrain.TerrainCacheService import TerrainCacheService
 from core.services.terrain.GeoidService import GeoidService
+
+
+def TerrainService(**kwargs):
+    """Construct a TerrainService pinned to the Terrarium provider.
+
+    Without an explicit provider_id, TerrainService reads TerrainProviderId
+    from the machine's real settings, so a developer who has configured the
+    3DEP local provider would silently flip these tests onto a different
+    backend. Pinning keeps them hermetic.
+    """
+    kwargs.setdefault('provider_id', PROVIDER_TERRARIUM)
+    return _TerrainService(**kwargs)
 
 
 class TestElevationResult:

--- a/app/tests/core/services/terrain/test_terrain_service_sample_grid.py
+++ b/app/tests/core/services/terrain/test_terrain_service_sample_grid.py
@@ -1,0 +1,88 @@
+"""Tests for TerrainService.sample_grid_spec dispatch + the Terrarium mosaic path."""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("affine")
+pytest.importorskip("scipy")
+from PIL import Image  # noqa: E402
+
+from core.services.terrain.TerrainService import TerrainService  # noqa: E402
+from core.services.terrain.grid import (  # noqa: E402
+    spec_for_bounds_wgs84,
+    make_lattice_spec,
+    GridSample,
+)
+
+
+def _terrarium_tile(elevation_m: float) -> Image.Image:
+    """Build a 256x256 PIL tile whose every pixel decodes to ``elevation_m``."""
+    total = elevation_m + 32768.0
+    r = int(total // 256)
+    rem = total - r * 256
+    g = int(rem)
+    b = int(round((rem - g) * 256)) % 256
+    arr = np.zeros((256, 256, 3), dtype=np.uint8)
+    arr[..., 0] = r
+    arr[..., 1] = g
+    arr[..., 2] = b
+    return Image.fromarray(arr, mode="RGB")
+
+
+class _FakeTileCache:
+    def __init__(self, elevation_m):
+        self._tile = _terrarium_tile(elevation_m)
+
+    def get_tile(self, z, x, y):
+        return self._tile
+
+    def get_tile_if_cached(self, z, x, y):
+        return self._tile
+
+
+@pytest.fixture
+def terrarium_service(tmp_path):
+    svc = TerrainService(cache_dir=str(tmp_path), enable_geoid=False,
+                         provider_id="terrarium")
+    return svc
+
+
+def test_disabled_service_returns_none(terrarium_service):
+    terrarium_service.enabled = False
+    spec = spec_for_bounds_wgs84((-120.50, 38.70, -120.495, 38.705), 30.0)
+    assert terrarium_service.sample_grid_spec(spec) is None
+
+
+def test_tiled_web_mosaic_returns_constant(terrarium_service):
+    terrarium_service.cache = _FakeTileCache(1234.0)
+    spec = spec_for_bounds_wgs84((-120.50, 38.70, -120.495, 38.705), 40.0)
+    sample = terrarium_service.sample_grid_spec(spec)
+    assert sample is not None
+    assert sample.data.shape == (spec.height, spec.width)
+    # Every decoded cell should recover the encoded constant (within 1/256 m).
+    assert np.nanmax(np.abs(sample.data - 1234.0)) < 0.02
+
+
+def test_local_geotiff_dispatch(terrarium_service, monkeypatch):
+    spec = make_lattice_spec((0.0, 0.0, 30.0, 30.0), 3.0)
+    sentinel = GridSample(
+        data=np.zeros((spec.height, spec.width), dtype=np.float32),
+        transform=spec.transform, crs=spec.crs, datum_note="stub",
+    )
+
+    class _Stub:
+        def get_provider_kind(self):
+            return "local_geotiff"
+
+        def sample_grid_spec(self, s):
+            return sentinel
+
+    terrarium_service.provider = _Stub()
+    assert terrarium_service.sample_grid_spec(spec) is sentinel
+
+
+def test_sample_grid_convenience_wrapper(terrarium_service):
+    terrarium_service.cache = _FakeTileCache(500.0)
+    sample = terrarium_service.sample_grid((-120.50, 38.70, -120.495, 38.705), 40.0)
+    assert sample is not None
+    assert np.nanmax(np.abs(sample.data - 500.0)) < 0.02

--- a/app/tests/core/services/terrain/test_tile_fetch_service.py
+++ b/app/tests/core/services/terrain/test_tile_fetch_service.py
@@ -1,0 +1,122 @@
+"""Tests for TileFetchService (quadkey math + mocked 3DEP / Meta downloads)."""
+
+import csv
+import os
+
+import pytest
+
+from core.services.terrain.TileFetchService import TileFetchService
+
+
+class _Resp:
+    def __init__(self, status, content=b"TILE"):
+        self.status_code = status
+        self.content = content
+
+
+class _Session:
+    def __init__(self, handler):
+        self._handler = handler
+        self.calls = []
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append((url, params))
+        return self._handler(url, params, len(self.calls))
+
+
+def _svc(handler):
+    return TileFetchService(session=_Session(handler), backoff_ms=0)
+
+
+# --- quadkey / tiling math ---
+
+def test_quadkey_known_value():
+    # Bing docs example: tile (3, 5) at z=3 -> "213".
+    assert TileFetchService.tile_xy_to_quadkey(3, 5, 3) == "213"
+    assert len(TileFetchService.tile_xy_to_quadkey(10, 20, 9)) == 9
+
+
+def test_tiles_covering_bbox_count():
+    tiles = TileFetchService.tiles_covering_bbox((-120.5, 38.7, -120.48, 38.72), 9)
+    assert len(tiles) >= 1
+    # A tiny AOI at z9 sits in one or two tiles.
+    assert len(tiles) <= 4
+
+
+def test_tile_bounds_roundtrip():
+    x, y, z = 84, 202, 9
+    lon0, lat0, lon1, lat1 = TileFetchService.tile_xy_to_bounds(x, y, z)
+    assert lon0 < lon1 and lat0 < lat1
+    xx, yy = TileFetchService.lnglat_to_tile_xy((lon0 + lon1) / 2, (lat0 + lat1) / 2, z)
+    assert (xx, yy) == (x, y)
+
+
+# --- 3DEP DEM ---
+
+def test_fetch_3dep_params_and_manifest(tmp_path):
+    svc = _svc(lambda url, params, n: _Resp(200))
+    result = svc.fetch_3dep_dem((-120.50, 38.70, -120.49, 38.71), str(tmp_path),
+                                tile_px=2048, native_res_m=1.0)
+    assert result.tiles_written >= 1
+    assert result.manifest_path and os.path.exists(result.manifest_path)
+    # exportImage params carry the required fields.
+    _, params = svc.session.calls[0]
+    assert params['bboxSR'] == 4326
+    assert params['pixelType'] == 'F32'
+    assert params['format'] == 'tiff'
+    assert 'size' in params and 'bbox' in params
+    # Manifest has the USGS3DEPProvider schema (no product column).
+    with open(result.manifest_path, newline="") as fh:
+        header = next(csv.reader(fh))
+    assert header == ['filename', 'minX', 'minY', 'maxX', 'maxY']
+
+
+def test_fetch_3dep_tiles_large_aoi(tmp_path):
+    svc = _svc(lambda url, params, n: _Resp(200))
+    # Small tile_px + coarse res forces multiple sub-tiles.
+    result = svc.fetch_3dep_dem((-120.60, 38.60, -120.50, 38.70), str(tmp_path),
+                                tile_px=256, native_res_m=10.0)
+    assert result.tiles_written > 1
+    assert len(svc.session.calls) > 1
+
+
+# --- Meta canopy ---
+
+def test_fetch_meta_url_and_manifest(tmp_path):
+    svc = _svc(lambda url, params, n: _Resp(200))
+    result = svc.fetch_meta_canopy((-120.50, 38.70, -120.49, 38.71), str(tmp_path))
+    assert result.tiles_written >= 1
+    url, _ = svc.session.calls[0]
+    assert "dataforgood-fb-data.s3.amazonaws.com" in url
+    assert url.endswith(".tif") and "/chm/" in url
+    with open(result.manifest_path, newline="") as fh:
+        header = next(csv.reader(fh))
+    assert header == ['filename', 'product', 'minX', 'minY', 'maxX', 'maxY']
+
+
+def test_fetch_meta_retry_then_success(tmp_path):
+    state = {'n': 0}
+
+    def handler(url, params, n):
+        state['n'] += 1
+        return _Resp(500) if state['n'] == 1 else _Resp(200)
+
+    svc = _svc(handler)
+    result = svc.fetch_meta_canopy((-120.50, 38.70, -120.499, 38.701), str(tmp_path))
+    assert result.tiles_written >= 1
+    assert len(svc.session.calls) >= 2   # retried after the 500
+
+
+def test_fetch_meta_404_is_skipped(tmp_path):
+    svc = _svc(lambda url, params, n: _Resp(404))
+    result = svc.fetch_meta_canopy((-120.50, 38.70, -120.49, 38.71), str(tmp_path))
+    assert result.tiles_written == 0
+    assert result.tiles_skipped >= 1
+    assert result.manifest_path is None   # nothing written
+
+
+def test_fetch_cancel(tmp_path):
+    svc = _svc(lambda url, params, n: _Resp(200))
+    result = svc.fetch_meta_canopy((-120.50, 38.70, -120.40, 38.80), str(tmp_path),
+                                   cancel_check=lambda: True)
+    assert result.cancelled is True

--- a/app/tests/core/services/terrain/test_usgs_3dep_sample_grid.py
+++ b/app/tests/core/services/terrain/test_usgs_3dep_sample_grid.py
@@ -1,0 +1,125 @@
+"""Tests for USGS3DEPProvider.sample_grid_spec (windowed reproject fast path).
+
+Writes tiny real GeoTIFFs (EPSG:26910 UTM) into tmp_path so the reproject +
+mosaic + nodata handling is exercised against actual rasterio datasets.
+"""
+
+import csv
+
+import numpy as np
+import pytest
+
+pytest.importorskip("shapely")
+rasterio = pytest.importorskip("rasterio")
+
+from rasterio.transform import from_origin  # noqa: E402
+from pyproj import Transformer  # noqa: E402
+
+from core.services.terrain.USGS3DEPProvider import USGS3DEPProvider  # noqa: E402
+from core.services.terrain.grid import spec_for_bounds_wgs84  # noqa: E402
+
+UTM10 = "EPSG:26910"
+NODATA = -9999.0
+_to_wgs84 = Transformer.from_crs(UTM10, "EPSG:4326", always_xy=True).transform
+
+
+def _utm_bbox_to_wgs84(west, south, east, north):
+    lons, lats = [], []
+    for x, y in [(west, south), (west, north), (east, south), (east, north)]:
+        lon, lat = _to_wgs84(x, y)
+        lons.append(lon)
+        lats.append(lat)
+    return min(lons), min(lats), max(lons), max(lats)
+
+
+def _write_tile(path, west, north, data, res=10.0):
+    rows, cols = data.shape
+    transform = from_origin(west, north, res, res)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=rows, width=cols, count=1,
+        dtype="float32", crs=UTM10, transform=transform, nodata=NODATA,
+    ) as dst:
+        dst.write(data.astype("float32"), 1)
+    east = west + cols * res
+    south = north - rows * res
+    return _utm_bbox_to_wgs84(west, south, east, north)
+
+
+@pytest.fixture
+def two_tile_provider(tmp_path):
+    tiles_dir = tmp_path / "tiles"
+    tiles_dir.mkdir()
+
+    west0, north0 = 350000.0, 4286000.0  # Sierra-ish UTM 10N
+    # Tile A: constant 500 m.
+    a = np.full((100, 100), 500.0, dtype=np.float32)
+    bbox_a = _write_tile(tiles_dir / "a.tif", west0, north0, a)
+
+    # Tile B: adjacent east, eastward gradient + a nodata stripe in columns 40:60.
+    b = np.tile(np.arange(100, dtype=np.float32) + 600.0, (100, 1))
+    b[:, 40:60] = NODATA
+    bbox_b = _write_tile(tiles_dir / "b.tif", west0 + 1000.0, north0, b)
+
+    manifest = tmp_path / "dem_manifest.csv"
+    with open(manifest, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["filename", "minX", "minY", "maxX", "maxY"])
+        w.writeheader()
+        for name, bbox in (("a.tif", bbox_a), ("b.tif", bbox_b)):
+            w.writerow({"filename": name, "minX": bbox[0], "minY": bbox[1],
+                        "maxX": bbox[2], "maxY": bbox[3]})
+
+    provider = USGS3DEPProvider(str(manifest), str(tiles_dir))
+    yield provider, bbox_a, bbox_b
+    provider.close()
+
+
+def test_lookup_tiles_bbox_returns_both(two_tile_provider):
+    provider, bbox_a, bbox_b = two_tile_provider
+    union = (min(bbox_a[0], bbox_b[0]), min(bbox_a[1], bbox_b[1]),
+             max(bbox_a[2], bbox_b[2]), max(bbox_a[3], bbox_b[3]))
+    tiles = provider.lookup_tiles_bbox(*union)
+    names = sorted(t["filename"] for t in tiles)
+    assert names == ["a.tif", "b.tif"]
+
+
+def test_sample_grid_mosaics_both_tiles_no_seam(two_tile_provider):
+    provider, bbox_a, bbox_b = two_tile_provider
+    union = (min(bbox_a[0], bbox_b[0]), min(bbox_a[1], bbox_b[1]),
+             max(bbox_a[2], bbox_b[2]), max(bbox_a[3], bbox_b[3]))
+    # Shrink slightly to avoid edge cells that only partially overlap.
+    pad_lon = (union[2] - union[0]) * 0.05
+    pad_lat = (union[3] - union[1]) * 0.05
+    spec = spec_for_bounds_wgs84(
+        (union[0] + pad_lon, union[1] + pad_lat, union[2] - pad_lon, union[3] - pad_lat),
+        15.0,
+    )
+    sample = provider.sample_grid_spec(spec)
+    assert sample is not None
+    assert sample.data.shape == (spec.height, spec.width)
+
+    # Constant tile A: its western portion should sit at ~500 with no NaN.
+    west_quarter = sample.data[:, : spec.width // 4]
+    assert np.nanmedian(west_quarter) == pytest.approx(500.0, abs=2.0)
+
+    # There must be finite coverage spanning the A/B seam (middle columns).
+    mid = sample.data[:, spec.width // 2 - 2: spec.width // 2 + 2]
+    assert np.isfinite(mid).any()
+
+
+def test_nodata_stripe_becomes_nan(two_tile_provider):
+    provider, bbox_a, bbox_b = two_tile_provider
+    # Grid over just tile B's nodata stripe region (its central columns).
+    spec = spec_for_bounds_wgs84(bbox_b, 12.0)
+    sample = provider.sample_grid_spec(spec)
+    assert sample is not None
+    # The nodata stripe (columns 40:60 of a 100-wide tile) must surface as NaN,
+    # and it must NOT have bled a -9999 sentinel into finite values.
+    assert np.isnan(sample.data).any()
+    finite = sample.data[np.isfinite(sample.data)]
+    assert finite.min() > -1000.0  # no sentinel bleed
+
+
+def test_bbox_outside_coverage_returns_none(two_tile_provider):
+    provider, _, _ = two_tile_provider
+    spec = spec_for_bounds_wgs84((-100.0, 20.0, -99.99, 20.01), 15.0)
+    assert provider.sample_grid_spec(spec) is None

--- a/app/tests/core/views/images/viewer/dialogs/test_gps_map_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_gps_map_dialog.py
@@ -1,0 +1,68 @@
+"""Tests for GPSMapDialog overlay-control gating."""
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from core.views.images.viewer.dialogs.GPSMapDialog import GPSMapDialog
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def dialog(app):
+    dlg = GPSMapDialog(None, [], None, offline_only=True)
+    yield dlg
+    dlg.close()
+    dlg.deleteLater()
+
+
+def _mode_keys(dlg):
+    return [dlg.pod_mode_combo.itemData(i) for i in range(dlg.pod_mode_combo.count())]
+
+
+def test_mode_combo_offers_canopy(dialog):
+    assert _mode_keys(dialog) == ["pod", "looks", "canopy"]
+
+
+def test_canopy_only_enables_toggle_and_hops_selection(dialog):
+    model = dialog.pod_mode_combo.model()
+    keys = _mode_keys(dialog)
+
+    dialog.set_overlay_availability(False, True)
+    assert dialog.pod_toggle_btn.isEnabled()
+    assert model.item(keys.index("canopy")).isEnabled()
+    assert not model.item(keys.index("pod")).isEnabled()
+    assert not model.item(keys.index("looks")).isEnabled()
+    # The unavailable default ('pod') hops to the only enabled mode.
+    assert dialog.pod_mode_combo.currentData() == "canopy"
+
+
+def test_pod_only_disables_canopy_and_hops_back(dialog):
+    model = dialog.pod_mode_combo.model()
+    keys = _mode_keys(dialog)
+
+    dialog.set_overlay_availability(False, True)   # selection lands on canopy
+    dialog.set_overlay_availability(True, False)
+    assert model.item(keys.index("pod")).isEnabled()
+    assert not model.item(keys.index("canopy")).isEnabled()
+    assert dialog.pod_mode_combo.currentData() == "pod"
+
+
+def test_nothing_available_disables_and_unchecks(dialog):
+    dialog.set_overlay_availability(True, True)
+    dialog.pod_toggle_btn.setChecked(True)
+    dialog.set_overlay_availability(False, False)
+    assert not dialog.pod_toggle_btn.isEnabled()
+    assert not dialog.pod_toggle_btn.isChecked()
+
+
+def test_set_pod_available_keeps_canopy_state(dialog):
+    dialog.set_overlay_availability(False, True)
+    dialog.set_pod_available(True)  # legacy entry point must not drop canopy
+    model = dialog.pod_mode_combo.model()
+    keys = _mode_keys(dialog)
+    assert model.item(keys.index("pod")).isEnabled()
+    assert model.item(keys.index("canopy")).isEnabled()

--- a/app/tests/core/views/images/viewer/dialogs/test_map_export_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_map_export_dialog.py
@@ -74,3 +74,28 @@ def test_should_include_images_default(app):
     dialog = MapExportDialog()
     dialog.caltopo_radio.setChecked(True)  # Enable the option
     assert dialog.should_include_images() is True
+
+
+def test_should_include_pod_default_off(app):
+    """POD is heavy compute, so it is opt-in (off by default)."""
+    dialog = MapExportDialog()
+    assert dialog.should_include_pod() is False
+
+
+def test_show_pod_on_map_gated_on_include(app):
+    """Show-on-map is enabled only when POD is enabled; default on."""
+    dialog = MapExportDialog()
+    assert dialog.show_pod_on_map.isEnabled() is False
+    assert dialog.should_show_pod_on_map() is False
+    dialog.include_pod.setChecked(True)
+    assert dialog.show_pod_on_map.isEnabled() is True
+    assert dialog.show_pod_on_map.isChecked() is True
+    assert dialog.should_show_pod_on_map() is True
+
+
+def test_show_pod_on_map_requires_include(app):
+    """show_pod_on_map returns False when POD itself is disabled."""
+    dialog = MapExportDialog()
+    dialog.show_pod_on_map.setChecked(True)
+    dialog.include_pod.setChecked(False)
+    assert dialog.should_show_pod_on_map() is False

--- a/app/tests/core/views/images/viewer/dialogs/test_tile_fetch_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_tile_fetch_dialog.py
@@ -32,3 +32,21 @@ def test_invalid_bounds_return_none(app):
     d.max_lon_edit.setText("-120.5")         # max < min
     d.max_lat_edit.setText("38.8")
     assert d.get_bounds() is None
+
+
+def test_use_mission_button_gated_on_has_mission(app):
+    assert TileFetchDialog(has_mission=False).use_mission_btn.isEnabled() is False
+    assert TileFetchDialog(has_mission=True).use_mission_btn.isEnabled() is True
+
+
+def test_set_aoi_and_buffer(app):
+    d = TileFetchDialog()
+    d.set_aoi((-120.51, 38.69, -120.45, 38.73))
+    assert d.get_bounds() == pytest.approx((-120.51, 38.69, -120.45, 38.73))
+    d.set_buffer(650.0)
+    assert d.get_buffer() == pytest.approx(650.0)
+
+
+def test_get_buffer_empty_is_none(app):
+    d = TileFetchDialog()
+    assert d.get_buffer() is None

--- a/app/tests/core/views/images/viewer/dialogs/test_tile_fetch_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_tile_fetch_dialog.py
@@ -1,0 +1,34 @@
+"""Tests for the TileFetchDialog getters."""
+
+import pytest
+from PySide6.QtWidgets import QApplication
+
+from core.views.images.viewer.dialogs.TileFetchDialog import TileFetchDialog
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def test_defaults(app):
+    d = TileFetchDialog()
+    assert d.want_dem() is True
+    assert d.want_canopy() is True
+    assert d.should_register() is True
+    assert d.get_output_dir() == ""
+
+
+def test_prefill_and_bounds(app):
+    d = TileFetchDialog(default_bounds=(-120.5, 38.7, -120.4, 38.8))
+    assert d.get_bounds() == pytest.approx((-120.5, 38.7, -120.4, 38.8))
+
+
+def test_invalid_bounds_return_none(app):
+    d = TileFetchDialog()
+    assert d.get_bounds() is None            # empty fields
+    d.min_lon_edit.setText("-120.4")
+    d.min_lat_edit.setText("38.7")
+    d.max_lon_edit.setText("-120.5")         # max < min
+    d.max_lat_edit.setText("38.8")
+    assert d.get_bounds() is None

--- a/app/tests/core/views/images/viewer/widgets/test_gps_map_view_pod_overlay.py
+++ b/app/tests/core/views/images/viewer/widgets/test_gps_map_view_pod_overlay.py
@@ -1,0 +1,75 @@
+"""Tests for the POD coverage overlay on GPSMapView."""
+
+import pytest
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QPixmap
+
+from core.views.images.viewer.widgets.GPSMapView import (
+    GPSMapView,
+    POD_OVERLAY_Z,
+    WEB_MERCATOR_ORIGIN_SHIFT,
+)
+
+
+@pytest.fixture(scope="session")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def _transform6(cell=3.0, c=0.0, f=0.0):
+    # (a, b, c, d, e, f): north-up, square cells (b=d=0, e=-a).
+    return (cell, 0.0, c, 0.0, -cell, f)
+
+
+def test_set_overlay_adds_item_at_correct_z(app):
+    view = GPSMapView()
+    view.current_zoom = 15
+    view.set_pod_overlay(QPixmap(4, 4), _transform6())
+    assert view.pod_overlay_item is not None
+    assert view.pod_overlay_item.zValue() == POD_OVERLAY_Z
+    assert view.pod_overlay_item.opacity() == pytest.approx(0.7)
+    assert view.pod_overlay_item.scene() is view.scene
+
+
+def test_opacity_setter(app):
+    view = GPSMapView()
+    view.set_pod_overlay(QPixmap(4, 4), _transform6())
+    view.set_pod_overlay_opacity(0.35)
+    assert view.pod_overlay_item.opacity() == pytest.approx(0.35)
+
+
+def test_clear_removes_item(app):
+    view = GPSMapView()
+    view.set_pod_overlay(QPixmap(4, 4), _transform6())
+    view.clear_pod_overlay()
+    assert view.pod_overlay_item is None
+    assert view._pod_pixmap is None
+
+
+def test_placement_at_origin_is_world_center(app):
+    view = GPSMapView()
+    view.current_zoom = 15
+    view.set_pod_overlay(QPixmap(4, 4), _transform6(c=0.0, f=0.0))
+    world = 256 * (2 ** 15)
+    pos = view.pod_overlay_item.pos()
+    # c == 0 (lon 0) maps to the horizontal middle of the world.
+    assert pos.x() == pytest.approx(world / 2, rel=1e-6)
+    assert pos.y() == pytest.approx(world / 2, rel=1e-6)
+
+
+def test_reanchor_on_zoom_doubles_position_and_scale(app):
+    view = GPSMapView()
+    view.current_zoom = 15
+    c = WEB_MERCATOR_ORIGIN_SHIFT / 2
+    view.set_pod_overlay(QPixmap(4, 4), _transform6(cell=3.0, c=c, f=c))
+    pos15 = view.pod_overlay_item.pos()
+    sx15 = view.pod_overlay_item.transform().m11()
+
+    view.current_zoom = 16
+    view._position_pod_overlay()
+    pos16 = view.pod_overlay_item.pos()
+    sx16 = view.pod_overlay_item.transform().m11()
+
+    assert pos16.x() == pytest.approx(pos15.x() * 2, rel=1e-6)
+    assert pos16.y() == pytest.approx(pos15.y() * 2, rel=1e-6)
+    assert sx16 == pytest.approx(sx15 * 2, rel=1e-6)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ spectral
 piexif
 simplekml
 scikit-image
-pyqtdarktheme==2.1.0
+pyqtdarktheme-fork==2.3.6
 pillow
 pandas
 pyarrow==20.0.0

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -2142,39 +2142,6 @@ The items should now be visible on your map.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>Select CalTopo Map</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Select a CalTopo map to export flagged AOIs:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Search:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Filter maps by name...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Select Map</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Cancel</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3333,55 +3300,44 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Select Color from List</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Search:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filter by name or uses…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Uses</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Use Color</translation>
@@ -3390,13 +3346,11 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Select Color from Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Use Color</translation>
@@ -3405,29 +3359,22 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Load Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Color Selector</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Select Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3435,37 +3382,31 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>Could not load image: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Error loading image: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Error setting image: {error}</translation>
@@ -5133,12 +5074,67 @@ Do you want to continue?</translation>
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="56"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
         <source>No GPS data found in images</source>
         <translation>No GPS data found in images</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="366"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <source>Not covered — no looks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <source>Terrain occlusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <source>Canopy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <source>Image resolution (GSD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <source>None</source>
+        <translation type="unfinished">None</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <source>POD: {pod}%   Looks: {looks}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <source>Limiting factor: {factor}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <source>Image {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <source>View {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <source>Find location in images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
         <source>GPS coordinate not in any images</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5146,58 +5142,83 @@ Do you want to continue?</translation>
 <context>
     <name>GPSMapDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="42"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="48"/>
         <source>GPS Map View</source>
         <translation>GPS Map View</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="102"/>
         <source>Zoom In (+)</source>
         <translation>Zoom In (+)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="106"/>
         <source>Zoom Out (-)</source>
         <translation>Zoom Out (-)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="110"/>
         <source>Fit All (F)</source>
         <translation>Fit All (F)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="108"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="114"/>
         <source>Rotate (R)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="116"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="202"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
         <source>Satellite View</source>
         <translation>Satellite View</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="124"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="129"/>
+        <source>POD Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="133"/>
+        <source>Run a map export with the POD option to generate this overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="138"/>
+        <source>POD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="139"/>
+        <source>Look count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <source>POD overlay opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Click point to select • Drag to pan • Scroll to zoom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="199"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
         <source>Map View</source>
         <translation>Map View</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="236"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="246"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
         <source>Map Tile Loading Issue</source>
         <translation>Map Tile Loading Issue</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5209,13 +5230,13 @@ The map will continue to work with cached tiles where available.</translation>
 <context>
     <name>GPSMapView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1129"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1216"/>
         <source>Copy Data</source>
         <translation>Copy Data</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1669"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1756"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1857"/>
         <source>Zoom FOV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8647,26 +8668,46 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="101"/>
+        <source>Probability of Detection (POD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <source>POD coverage heatmap (terrain-aware)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
+        <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). Writes coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson and stats.json. The GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <source>Show on map when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="123"/>
         <source>CalTopo Options</source>
         <translation>CalTopo Options</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
         <source>Include Images</source>
         <translation>Include Images</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="128"/>
         <source>Upload photos to CalTopo markers (CalTopo only)</source>
         <translation>Upload photos to CalTopo markers (CalTopo only)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="148"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="130"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="152"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -8967,89 +9008,6 @@ then click again to place the second point.</translation>
         <location filename="../app/core/views/flight/MissionGalleryDock.py" line="151"/>
         <source>{n} detections</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Detection Mode</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Mode:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Auto</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Static Camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Moving Camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algorithm</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algorithm:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Frame Difference</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>MOG2 Background</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>KNN Background</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Optical Flow</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Feature Matching</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Detection Parameters</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Sensitivity: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Min Area:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Max Area:</translation>
     </message>
 </context>
 <context>
@@ -9809,96 +9767,148 @@ All changes are saved automatically when modified.</source>
 All changes are saved automatically when modified.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="60"/>
+        <location filename="../app/core/controllers/Preferences.py" line="66"/>
         <source>Language:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="79"/>
+        <location filename="../app/core/controllers/Preferences.py" line="85"/>
         <source>Terrain Elevation Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="83"/>
+        <location filename="../app/core/controllers/Preferences.py" line="89"/>
         <source>Provider:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="93"/>
+        <location filename="../app/core/controllers/Preferences.py" line="99"/>
+        <location filename="../app/core/controllers/Preferences.py" line="141"/>
         <source>Manifest CSV:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="95"/>
+        <location filename="../app/core/controllers/Preferences.py" line="101"/>
         <source>Path to dem_manifest.csv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="96"/>
-        <location filename="../app/core/controllers/Preferences.py" line="107"/>
+        <location filename="../app/core/controllers/Preferences.py" line="102"/>
+        <location filename="../app/core/controllers/Preferences.py" line="113"/>
+        <location filename="../app/core/controllers/Preferences.py" line="144"/>
+        <location filename="../app/core/controllers/Preferences.py" line="154"/>
         <source>Browse...</source>
         <translation type="unfinished">Browse...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="104"/>
+        <location filename="../app/core/controllers/Preferences.py" line="110"/>
+        <location filename="../app/core/controllers/Preferences.py" line="151"/>
         <source>Tiles directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="106"/>
+        <location filename="../app/core/controllers/Preferences.py" line="112"/>
+        <location filename="../app/core/controllers/Preferences.py" line="153"/>
         <source>Folder containing the GeoTIFF tiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="160"/>
-        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <location filename="../app/core/controllers/Preferences.py" line="128"/>
+        <source>Canopy Data Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="132"/>
+        <source>Source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="143"/>
+        <source>Path to the canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="162"/>
+        <source>Download tiles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="164"/>
+        <source>Download DEM and/or canopy tiles for an area of interest and register them here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="223"/>
+        <location filename="../app/core/controllers/Preferences.py" line="496"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="251"/>
+        <location filename="../app/core/controllers/Preferences.py" line="320"/>
         <source>Select 3DEP manifest CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="253"/>
+        <location filename="../app/core/controllers/Preferences.py" line="322"/>
+        <location filename="../app/core/controllers/Preferences.py" line="367"/>
         <source>CSV files (*.csv);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="263"/>
+        <location filename="../app/core/controllers/Preferences.py" line="332"/>
         <source>Select 3DEP tiles directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="301"/>
+        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <source>Select canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="375"/>
+        <source>Select canopy tiles directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="386"/>
+        <source>Download Tiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="387"/>
+        <source>The tile downloader is unavailable:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="431"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} tiles ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="307"/>
+        <location filename="../app/core/controllers/Preferences.py" line="437"/>
         <source>Not available</source>
         <translation>Not available</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="309"/>
-        <location filename="../app/core/controllers/Preferences.py" line="317"/>
-        <location filename="../app/core/controllers/Preferences.py" line="345"/>
+        <location filename="../app/core/controllers/Preferences.py" line="439"/>
+        <location filename="../app/core/controllers/Preferences.py" line="447"/>
+        <location filename="../app/core/controllers/Preferences.py" line="475"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="318"/>
+        <location filename="../app/core/controllers/Preferences.py" line="448"/>
         <source>Terrain service not available.</source>
         <translation>Terrain service not available.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="324"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
         <source>Clear Terrain Cache</source>
         <translation>Clear Terrain Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="326"/>
+        <location filename="../app/core/controllers/Preferences.py" line="456"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -9907,37 +9917,37 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 This will require re-downloading tiles when terrain elevation is used.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="339"/>
+        <location filename="../app/core/controllers/Preferences.py" line="469"/>
         <source>Cache Cleared</source>
         <translation>Cache Cleared</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="340"/>
+        <location filename="../app/core/controllers/Preferences.py" line="470"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>Cleared {count} cached terrain tiles.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="346"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Failed to clear cache: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="353"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Select a Drone Sensor File</source>
         <translation>Select a Drone Sensor File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="355"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="381"/>
+        <location filename="../app/core/controllers/Preferences.py" line="511"/>
         <source>Restart Required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="382"/>
+        <location filename="../app/core/controllers/Preferences.py" line="512"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10155,42 +10165,42 @@ Aggressive</source>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</translation>
     </message>
@@ -10198,22 +10208,22 @@ Aggressive</source>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Recent Colors</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Select a recently used color:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>No recent colors found</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
@@ -11280,14 +11290,6 @@ Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Select Recording Folder</translation>
     </message>
 </context>
 <context>
@@ -13051,6 +13053,138 @@ Aggressive</source>
     </message>
 </context>
 <context>
+    <name>TileFetchController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <source>Invalid Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <source>Please enter a valid bounding box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <source>No Output Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <source>Please choose an output folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <source>No Dataset</source>
+        <translation type="unfinished">No Dataset</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <source>Please select at least one dataset.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <source>Download Complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <source>Downloaded {count} tiles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <source>Download Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <source>Tile download failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TileFetchDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <source>Download Coverage Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <source>Area of Interest (WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Min latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <source>Max longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <source>Max latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <source>Datasets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <source>USGS 3DEP DEM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <source>Meta/WRI Canopy Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <source>Output folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <source>Browse...</source>
+        <translation type="unfinished">Browse...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <source>Register in Preferences when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <source>Select output folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TrackGalleryWidget</name>
     <message>
         <location filename="../app/core/views/streaming/components/TrackGalleryWidget.py" line="41"/>
@@ -13076,68 +13210,101 @@ Aggressive</source>
 <context>
     <name>UnifiedMapExportController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="382"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="432"/>
         <source>No Data Selected</source>
         <translation>No Data Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="433"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Please select at least one type of data to export.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="408"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="509"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="543"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="577"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="622"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="458"/>
+        <source>Select folder for POD coverage files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="466"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="569"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="792"/>
         <source>Export Error</source>
         <translation>Export Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="467"/>
         <source>An error occurred during export:
 {error}</source>
         <translation>An error occurred during export:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="426"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="484"/>
         <source>Save Map Export</source>
         <translation>Save Map Export</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="486"/>
         <source>KML files (*.kml)</source>
         <translation>KML files (*.kml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="510"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="570"/>
         <source>Failed to export to KML:
 {error}</source>
         <translation>Failed to export to KML:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="544"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="680"/>
+        <source>POD Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="613"/>
+        <source>Could not start the POD calculation:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="653"/>
+        <source>POD coverage complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="673"/>
+        <source>POD calculation cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="681"/>
+        <source>POD calculation failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
         <source>Failed to export to CalTopo:
 {error}</source>
         <translation>Failed to export to CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="594"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="764"/>
         <source>Map export completed successfully!</source>
         <translation>Map export completed successfully!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="609"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="779"/>
         <source>Map export cancelled</source>
         <translation>Map export cancelled</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="623"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="793"/>
         <source>Map export failed:
 {error}</source>
         <translation>Map export failed:
@@ -13699,29 +13866,6 @@ Shows total frames extracted when complete.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -13824,7 +13968,7 @@ Shows all AOIs from all images in a grid view</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14056,7 +14200,7 @@ The viewer will now close.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1357"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Skip Hidden ({count}) </translation>
     </message>
@@ -14211,41 +14355,41 @@ Would you like to read dimensions from the image files and update the results fi
         <translation>Toggle AOI Circles</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1532"/>
         <source>Missing Dependency</source>
         <translation>Missing Dependency</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1534"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1543"/>
         <source>Upscale Error</source>
         <translation>Upscale Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1545"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>An error occurred while opening the upscale dialog:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1871"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1968"/>
         <source>Unknown Reviewer</source>
         <translation>Unknown Reviewer</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2031"/>
         <source>Loading gallery...</source>
         <translation>Loading gallery...</translation>
     </message>

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -5074,67 +5074,72 @@ Do you want to continue?</translation>
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="65"/>
         <source>No GPS data found in images</source>
         <translation>No GPS data found in images</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
         <source>Not covered — no looks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="305"/>
         <source>Terrain occlusion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="306"/>
         <source>Canopy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="307"/>
         <source>Image resolution (GSD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="308"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="310"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="436"/>
+        <source>No canopy data covers this area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="460"/>
         <source>POD: {pod}%   Looks: {looks}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="463"/>
         <source>Limiting factor: {factor}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="471"/>
         <source>Image {n}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="472"/>
         <source>View {name}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="475"/>
         <source>Find location in images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="589"/>
         <source>GPS coordinate not in any images</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5168,7 +5173,7 @@ Do you want to continue?</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="280"/>
         <source>Satellite View</source>
         <translation>Satellite View</translation>
     </message>
@@ -5193,32 +5198,37 @@ Do you want to continue?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="140"/>
+        <source>Canopy height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="150"/>
         <source>POD overlay opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="157"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Click point to select • Drag to pan • Scroll to zoom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="277"/>
         <source>Map View</source>
         <translation>Map View</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="314"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="324"/>
         <source>Map Tile Loading Issue</source>
         <translation>Map Tile Loading Issue</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="326"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -9839,7 +9839,7 @@ All changes are saved automatically when modified.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/Preferences.py" line="223"/>
-        <location filename="../app/core/controllers/Preferences.py" line="496"/>
+        <location filename="../app/core/controllers/Preferences.py" line="503"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
@@ -9881,34 +9881,34 @@ All changes are saved automatically when modified.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="431"/>
+        <location filename="../app/core/controllers/Preferences.py" line="438"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} tiles ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="437"/>
+        <location filename="../app/core/controllers/Preferences.py" line="444"/>
         <source>Not available</source>
         <translation>Not available</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="439"/>
-        <location filename="../app/core/controllers/Preferences.py" line="447"/>
-        <location filename="../app/core/controllers/Preferences.py" line="475"/>
+        <location filename="../app/core/controllers/Preferences.py" line="446"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="482"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="448"/>
+        <location filename="../app/core/controllers/Preferences.py" line="455"/>
         <source>Terrain service not available.</source>
         <translation>Terrain service not available.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="461"/>
         <source>Clear Terrain Cache</source>
         <translation>Clear Terrain Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="456"/>
+        <location filename="../app/core/controllers/Preferences.py" line="463"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -9917,37 +9917,37 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 This will require re-downloading tiles when terrain elevation is used.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="469"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Cache Cleared</source>
         <translation>Cache Cleared</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="470"/>
+        <location filename="../app/core/controllers/Preferences.py" line="477"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>Cleared {count} cached terrain tiles.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="476"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Failed to clear cache: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="483"/>
+        <location filename="../app/core/controllers/Preferences.py" line="490"/>
         <source>Select a Drone Sensor File</source>
         <translation>Select a Drone Sensor File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="485"/>
+        <location filename="../app/core/controllers/Preferences.py" line="492"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="511"/>
+        <location filename="../app/core/controllers/Preferences.py" line="518"/>
         <source>Restart Required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="512"/>
+        <location filename="../app/core/controllers/Preferences.py" line="519"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13055,52 +13055,77 @@ Aggressive</source>
 <context>
     <name>TileFetchController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
         <source>Invalid Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="98"/>
         <source>Please enter a valid bounding box.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="101"/>
         <source>No Output Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="102"/>
         <source>Please choose an output folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="105"/>
         <source>No Dataset</source>
         <translation type="unfinished">No Dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="106"/>
         <source>Please select at least one dataset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="144"/>
+        <source>No GPS Found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="145"/>
+        <source>No GPS positions were found in the {source} images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="158"/>
+        <source>Select image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="167"/>
+        <source>No Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="168"/>
+        <source>No images were found in the selected folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="199"/>
         <source>Download Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="200"/>
         <source>Downloaded {count} tiles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="214"/>
         <source>Download Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="215"/>
         <source>Tile download failed:
 {error}</source>
         <translation type="unfinished"></translation>
@@ -13109,77 +13134,107 @@ Aggressive</source>
 <context>
     <name>TileFetchDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="24"/>
         <source>Download Coverage Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="32"/>
         <source>Area of Interest (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="37"/>
+        <source>Use loaded mission extent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="40"/>
+        <source>Fill the AOI from the GPS positions of the currently loaded mission&apos;s images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
-        <source>Min longitude:</source>
+        <source>Load extent from image folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Read image GPS from a folder to fill the AOI (use when no mission is loaded).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="58"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="60"/>
         <source>Min latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="62"/>
         <source>Max longitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
         <source>Max latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="69"/>
+        <source>Footprint buffer (m):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="74"/>
+        <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="83"/>
         <source>Datasets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="85"/>
         <source>USGS 3DEP DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="87"/>
         <source>Meta/WRI Canopy Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="95"/>
         <source>Output folder:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="97"/>
         <source>Browse...</source>
         <translation type="unfinished">Browse...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="103"/>
         <source>Register in Preferences when complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="119"/>
         <source>Select output folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -9894,7 +9894,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/Preferences.py" line="223"/>
-        <location filename="../app/core/controllers/Preferences.py" line="496"/>
+        <location filename="../app/core/controllers/Preferences.py" line="503"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
@@ -9936,34 +9936,34 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="431"/>
+        <location filename="../app/core/controllers/Preferences.py" line="438"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} mosaicos ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="437"/>
+        <location filename="../app/core/controllers/Preferences.py" line="444"/>
         <source>Not available</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="439"/>
-        <location filename="../app/core/controllers/Preferences.py" line="447"/>
-        <location filename="../app/core/controllers/Preferences.py" line="475"/>
+        <location filename="../app/core/controllers/Preferences.py" line="446"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="482"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="448"/>
+        <location filename="../app/core/controllers/Preferences.py" line="455"/>
         <source>Terrain service not available.</source>
         <translation>Servicio de terreno no disponible.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="461"/>
         <source>Clear Terrain Cache</source>
         <translation>Borrar caché de terreno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="456"/>
+        <location filename="../app/core/controllers/Preferences.py" line="463"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -9972,37 +9972,37 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 Esto requerirá volver a descargar los mosaicos cuando se use la elevación del terreno.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="469"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Cache Cleared</source>
         <translation>Caché borrada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="470"/>
+        <location filename="../app/core/controllers/Preferences.py" line="477"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>Se borraron {count} mosaicos de terreno en caché.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="476"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Error al borrar la caché: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="483"/>
+        <location filename="../app/core/controllers/Preferences.py" line="490"/>
         <source>Select a Drone Sensor File</source>
         <translation>Seleccionar un archivo de sensor de dron</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="485"/>
+        <location filename="../app/core/controllers/Preferences.py" line="492"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="511"/>
+        <location filename="../app/core/controllers/Preferences.py" line="518"/>
         <source>Restart Required</source>
         <translation>Reinicio necesario</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="512"/>
+        <location filename="../app/core/controllers/Preferences.py" line="519"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Reinicie la aplicación para que los cambios de idioma surtan efecto.</translation>
     </message>
@@ -13129,52 +13129,77 @@ agresivo</translation>
 <context>
     <name>TileFetchController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
         <source>Invalid Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="98"/>
         <source>Please enter a valid bounding box.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="101"/>
         <source>No Output Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="102"/>
         <source>Please choose an output folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="105"/>
         <source>No Dataset</source>
         <translation type="unfinished">Sin conjunto de datos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="106"/>
         <source>Please select at least one dataset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="144"/>
+        <source>No GPS Found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="145"/>
+        <source>No GPS positions were found in the {source} images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="158"/>
+        <source>Select image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="167"/>
+        <source>No Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="168"/>
+        <source>No images were found in the selected folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="199"/>
         <source>Download Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="200"/>
         <source>Downloaded {count} tiles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="214"/>
         <source>Download Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="215"/>
         <source>Tile download failed:
 {error}</source>
         <translation type="unfinished"></translation>
@@ -13183,77 +13208,107 @@ agresivo</translation>
 <context>
     <name>TileFetchDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="24"/>
         <source>Download Coverage Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="32"/>
         <source>Area of Interest (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="37"/>
+        <source>Use loaded mission extent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="40"/>
+        <source>Fill the AOI from the GPS positions of the currently loaded mission&apos;s images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
-        <source>Min longitude:</source>
+        <source>Load extent from image folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Read image GPS from a folder to fill the AOI (use when no mission is loaded).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="58"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="60"/>
         <source>Min latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="62"/>
         <source>Max longitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
         <source>Max latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="69"/>
+        <source>Footprint buffer (m):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="74"/>
+        <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="83"/>
         <source>Datasets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="85"/>
         <source>USGS 3DEP DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="87"/>
         <source>Meta/WRI Canopy Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="95"/>
         <source>Output folder:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="97"/>
         <source>Browse...</source>
         <translation type="unfinished">Examinar...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="103"/>
         <source>Register in Preferences when complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="119"/>
         <source>Select output folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -5078,67 +5078,72 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="65"/>
         <source>No GPS data found in images</source>
         <translation>No se encontraron datos GPS en las imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
         <source>Not covered — no looks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="305"/>
         <source>Terrain occlusion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="306"/>
         <source>Canopy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="307"/>
         <source>Image resolution (GSD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="308"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="310"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="436"/>
+        <source>No canopy data covers this area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="460"/>
         <source>POD: {pod}%   Looks: {looks}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="463"/>
         <source>Limiting factor: {factor}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="471"/>
         <source>Image {n}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="472"/>
         <source>View {name}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="475"/>
         <source>Find location in images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="589"/>
         <source>GPS coordinate not in any images</source>
         <translation>La coordenada GPS no está en ninguna imagen</translation>
     </message>
@@ -5172,7 +5177,7 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="280"/>
         <source>Satellite View</source>
         <translation>Vista satélite</translation>
     </message>
@@ -5197,32 +5202,37 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="140"/>
+        <source>Canopy height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="150"/>
         <source>POD overlay opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="157"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Haga clic en un punto para seleccionar • Arrastre para desplazar • Rueda para acercar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="277"/>
         <source>Map View</source>
         <translation>Vista de mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="314"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="324"/>
         <source>Map Tile Loading Issue</source>
         <translation>Problema al cargar los mosaicos del mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="326"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -2144,39 +2144,6 @@ Los elementos deberían estar ahora visibles en su mapa.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>Seleccionar mapa de CalTopo</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Seleccione un mapa de CalTopo para exportar los AOI marcados:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Búsqueda:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Filtrar mapas por nombre...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Seleccionar mapa</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3337,55 +3304,44 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Seleccionar color desde lista</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Búsqueda:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filtrar por nombre o usos…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Usos</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Usar color</translation>
@@ -3394,13 +3350,11 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Seleccionar color desde imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Usar color</translation>
@@ -3409,29 +3363,22 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Cargar imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Selector de color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3439,37 +3386,31 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>No se pudo cargar la imagen: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Error al cargar la imagen: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (cursor)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Error al establecer la imagen: {error}</translation>
@@ -5137,12 +5078,67 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="56"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
         <source>No GPS data found in images</source>
         <translation>No se encontraron datos GPS en las imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="366"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <source>Not covered — no looks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <source>Terrain occlusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <source>Canopy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <source>Image resolution (GSD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <source>None</source>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <source>POD: {pod}%   Looks: {looks}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <source>Limiting factor: {factor}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <source>Image {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <source>View {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <source>Find location in images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
         <source>GPS coordinate not in any images</source>
         <translation>La coordenada GPS no está en ninguna imagen</translation>
     </message>
@@ -5150,58 +5146,83 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
 <context>
     <name>GPSMapDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="42"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="48"/>
         <source>GPS Map View</source>
         <translation>Vista de mapa GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="102"/>
         <source>Zoom In (+)</source>
         <translation>Acercar (+)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="106"/>
         <source>Zoom Out (-)</source>
         <translation>Alejar (-)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="110"/>
         <source>Fit All (F)</source>
         <translation>Ajustar todo (F)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="108"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="114"/>
         <source>Rotate (R)</source>
         <translation>Rotar (R)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="116"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="202"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
         <source>Satellite View</source>
         <translation>Vista satélite</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="124"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="129"/>
+        <source>POD Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="133"/>
+        <source>Run a map export with the POD option to generate this overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="138"/>
+        <source>POD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="139"/>
+        <source>Look count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <source>POD overlay opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Haga clic en un punto para seleccionar • Arrastre para desplazar • Rueda para acercar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="199"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
         <source>Map View</source>
         <translation>Vista de mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="236"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="246"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
         <source>Map Tile Loading Issue</source>
         <translation>Problema al cargar los mosaicos del mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5213,13 +5234,13 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
 <context>
     <name>GPSMapView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1129"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1216"/>
         <source>Copy Data</source>
         <translation>Copiar datos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1669"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1756"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1857"/>
         <source>Zoom FOV</source>
         <translation>FOV de zoom</translation>
     </message>
@@ -8702,26 +8723,46 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="101"/>
+        <source>Probability of Detection (POD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <source>POD coverage heatmap (terrain-aware)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
+        <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). Writes coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson and stats.json. The GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <source>Show on map when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="123"/>
         <source>CalTopo Options</source>
         <translation>Opciones de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
         <source>Include Images</source>
         <translation>Incluir imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="128"/>
         <source>Upload photos to CalTopo markers (CalTopo only)</source>
         <translation>Subir fotos a los marcadores de CalTopo (solo CalTopo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="148"/>
         <source>Export</source>
         <translation>Exportar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="130"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="152"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -9022,89 +9063,6 @@ y luego vuelva a hacer clic para colocar el segundo punto.</translation>
         <location filename="../app/core/views/flight/MissionGalleryDock.py" line="151"/>
         <source>{n} detections</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Modo de detección</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Modo:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Automático</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Cámara estática</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Cámara en movimiento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algoritmo</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algoritmo:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Diferencia de fotograma</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>Fondo MOG2</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>Fondo KNN</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Flujo óptico</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Coincidencia de características</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Parámetros de detección</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Sensibilidad: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Área mín.:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Área máx.:</translation>
     </message>
 </context>
 <context>
@@ -9864,96 +9822,148 @@ All changes are saved automatically when modified.</source>
 Todos los cambios se guardan automáticamente al modificarse.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="60"/>
+        <location filename="../app/core/controllers/Preferences.py" line="66"/>
         <source>Language:</source>
         <translation>Idioma:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="79"/>
+        <location filename="../app/core/controllers/Preferences.py" line="85"/>
         <source>Terrain Elevation Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="83"/>
+        <location filename="../app/core/controllers/Preferences.py" line="89"/>
         <source>Provider:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="93"/>
+        <location filename="../app/core/controllers/Preferences.py" line="99"/>
+        <location filename="../app/core/controllers/Preferences.py" line="141"/>
         <source>Manifest CSV:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="95"/>
+        <location filename="../app/core/controllers/Preferences.py" line="101"/>
         <source>Path to dem_manifest.csv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="96"/>
-        <location filename="../app/core/controllers/Preferences.py" line="107"/>
+        <location filename="../app/core/controllers/Preferences.py" line="102"/>
+        <location filename="../app/core/controllers/Preferences.py" line="113"/>
+        <location filename="../app/core/controllers/Preferences.py" line="144"/>
+        <location filename="../app/core/controllers/Preferences.py" line="154"/>
         <source>Browse...</source>
         <translation type="unfinished">Examinar...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="104"/>
+        <location filename="../app/core/controllers/Preferences.py" line="110"/>
+        <location filename="../app/core/controllers/Preferences.py" line="151"/>
         <source>Tiles directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="106"/>
+        <location filename="../app/core/controllers/Preferences.py" line="112"/>
+        <location filename="../app/core/controllers/Preferences.py" line="153"/>
         <source>Folder containing the GeoTIFF tiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="160"/>
-        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <location filename="../app/core/controllers/Preferences.py" line="128"/>
+        <source>Canopy Data Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="132"/>
+        <source>Source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="143"/>
+        <source>Path to the canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="162"/>
+        <source>Download tiles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="164"/>
+        <source>Download DEM and/or canopy tiles for an area of interest and register them here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="223"/>
+        <location filename="../app/core/controllers/Preferences.py" line="496"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="251"/>
+        <location filename="../app/core/controllers/Preferences.py" line="320"/>
         <source>Select 3DEP manifest CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="253"/>
+        <location filename="../app/core/controllers/Preferences.py" line="322"/>
+        <location filename="../app/core/controllers/Preferences.py" line="367"/>
         <source>CSV files (*.csv);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="263"/>
+        <location filename="../app/core/controllers/Preferences.py" line="332"/>
         <source>Select 3DEP tiles directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="301"/>
+        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <source>Select canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="375"/>
+        <source>Select canopy tiles directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="386"/>
+        <source>Download Tiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="387"/>
+        <source>The tile downloader is unavailable:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="431"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} mosaicos ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="307"/>
+        <location filename="../app/core/controllers/Preferences.py" line="437"/>
         <source>Not available</source>
         <translation>No disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="309"/>
-        <location filename="../app/core/controllers/Preferences.py" line="317"/>
-        <location filename="../app/core/controllers/Preferences.py" line="345"/>
+        <location filename="../app/core/controllers/Preferences.py" line="439"/>
+        <location filename="../app/core/controllers/Preferences.py" line="447"/>
+        <location filename="../app/core/controllers/Preferences.py" line="475"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="318"/>
+        <location filename="../app/core/controllers/Preferences.py" line="448"/>
         <source>Terrain service not available.</source>
         <translation>Servicio de terreno no disponible.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="324"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
         <source>Clear Terrain Cache</source>
         <translation>Borrar caché de terreno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="326"/>
+        <location filename="../app/core/controllers/Preferences.py" line="456"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -9962,37 +9972,37 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 Esto requerirá volver a descargar los mosaicos cuando se use la elevación del terreno.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="339"/>
+        <location filename="../app/core/controllers/Preferences.py" line="469"/>
         <source>Cache Cleared</source>
         <translation>Caché borrada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="340"/>
+        <location filename="../app/core/controllers/Preferences.py" line="470"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>Se borraron {count} mosaicos de terreno en caché.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="346"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Error al borrar la caché: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="353"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Select a Drone Sensor File</source>
         <translation>Seleccionar un archivo de sensor de dron</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="355"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="381"/>
+        <location filename="../app/core/controllers/Preferences.py" line="511"/>
         <source>Restart Required</source>
         <translation>Reinicio necesario</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="382"/>
+        <location filename="../app/core/controllers/Preferences.py" line="512"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Reinicie la aplicación para que los cambios de idioma surtan efecto.</translation>
     </message>
@@ -10212,42 +10222,42 @@ agresivo</translation>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Umbral:&lt;/b&gt; {value}</translation>
     </message>
@@ -10255,22 +10265,22 @@ agresivo</translation>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Colores recientes</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Seleccione un color usado recientemente:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>No se encontraron colores recientes</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
@@ -11338,14 +11348,6 @@ Formatos compatibles: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Archivos de vídeo (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Todos los archivos (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Seleccionar carpeta de grabación</translation>
     </message>
 </context>
 <context>
@@ -13125,6 +13127,138 @@ agresivo</translation>
     </message>
 </context>
 <context>
+    <name>TileFetchController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <source>Invalid Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <source>Please enter a valid bounding box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <source>No Output Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <source>Please choose an output folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <source>No Dataset</source>
+        <translation type="unfinished">Sin conjunto de datos</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <source>Please select at least one dataset.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <source>Download Complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <source>Downloaded {count} tiles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <source>Download Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <source>Tile download failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TileFetchDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <source>Download Coverage Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <source>Area of Interest (WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Min latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <source>Max longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <source>Max latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <source>Datasets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <source>USGS 3DEP DEM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <source>Meta/WRI Canopy Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <source>Output folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <source>Browse...</source>
+        <translation type="unfinished">Examinar...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <source>Register in Preferences when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <source>Select output folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TrackGalleryWidget</name>
     <message>
         <location filename="../app/core/views/streaming/components/TrackGalleryWidget.py" line="41"/>
@@ -13150,68 +13284,101 @@ agresivo</translation>
 <context>
     <name>UnifiedMapExportController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="382"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="432"/>
         <source>No Data Selected</source>
         <translation>Ningún dato seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="433"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Seleccione al menos un tipo de datos para exportar.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="408"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="509"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="543"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="577"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="622"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="458"/>
+        <source>Select folder for POD coverage files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="466"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="569"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="792"/>
         <source>Export Error</source>
         <translation>Error de exportación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="467"/>
         <source>An error occurred during export:
 {error}</source>
         <translation>Se produjo un error durante la exportación:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="426"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="484"/>
         <source>Save Map Export</source>
         <translation>Guardar exportación de mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="486"/>
         <source>KML files (*.kml)</source>
         <translation>Archivos KML (*.kml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="510"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="570"/>
         <source>Failed to export to KML:
 {error}</source>
         <translation>Error al exportar a KML:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="544"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="680"/>
+        <source>POD Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="613"/>
+        <source>Could not start the POD calculation:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="653"/>
+        <source>POD coverage complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="673"/>
+        <source>POD calculation cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="681"/>
+        <source>POD calculation failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
         <source>Failed to export to CalTopo:
 {error}</source>
         <translation>Error al exportar a CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="594"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="764"/>
         <source>Map export completed successfully!</source>
         <translation>¡Exportación de mapa completada correctamente!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="609"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="779"/>
         <source>Map export cancelled</source>
         <translation>Exportación de mapa cancelada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="623"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="793"/>
         <source>Map export failed:
 {error}</source>
         <translation>Error en la exportación de mapa:
@@ -13787,29 +13954,6 @@ Muestra el total de fotogramas extraídos al completarse.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -13912,7 +14056,7 @@ Muestra todos los AOI de todas las imágenes en una vista de cuadrícula</transl
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14144,7 +14288,7 @@ El visor se cerrará ahora.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1357"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Omitir ocultas ({count}) </translation>
     </message>
@@ -14301,41 +14445,41 @@ Would you like to read dimensions from the image files and update the results fi
         <translation>Alternar círculos de AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1532"/>
         <source>Missing Dependency</source>
         <translation>Dependencia faltante</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1534"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>El módulo qimage2ndarray es necesario para la función de escalado.
 Instálelo usando: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1543"/>
         <source>Upscale Error</source>
         <translation>Error de escalado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1545"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Se produjo un error al abrir el diálogo de escalado:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1871"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1968"/>
         <source>Unknown Reviewer</source>
         <translation>Revisor desconocido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2031"/>
         <source>Loading gallery...</source>
         <translation>Cargando galería...</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -2144,39 +2144,6 @@ Gli elementi dovrebbero ora essere visibili sulla tua mappa.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>Seleziona Mappa CalTopo</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Seleziona una mappa CalTopo per esportare le AOI contrassegnate:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Cerca:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Filtra mappe per nome...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Seleziona Mappa</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Annulla</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3489,55 +3456,44 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Seleziona Colore dall&apos;Elenco</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Cerca:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filtra per nome o utilizzi…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Utilizzi</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Usa Colore</translation>
@@ -3546,13 +3502,11 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Seleziona Colore dall&apos;Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Usa Colore</translation>
@@ -3561,29 +3515,22 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Carica Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Selettore Colore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Seleziona Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3591,37 +3538,31 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>Impossibile caricare l&apos;immagine: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Errore durante il caricamento dell&apos;immagine: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (passaggio mouse)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Errore durante l&apos;impostazione dell&apos;immagine: {error}</translation>
@@ -5313,12 +5254,67 @@ Vuoi continuare?</translation>
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="56"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
         <source>No GPS data found in images</source>
         <translation>Nessun dato GPS trovato nelle immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="366"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <source>Not covered — no looks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <source>Terrain occlusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <source>Canopy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <source>Image resolution (GSD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <source>None</source>
+        <translation type="unfinished">Nessuno</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <source>POD: {pod}%   Looks: {looks}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <source>Limiting factor: {factor}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <source>Image {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <source>View {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <source>Find location in images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
         <source>GPS coordinate not in any images</source>
         <translation>Coordinata GPS non presente in nessuna immagine</translation>
     </message>
@@ -5326,58 +5322,83 @@ Vuoi continuare?</translation>
 <context>
     <name>GPSMapDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="42"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="48"/>
         <source>GPS Map View</source>
         <translation>Vista Mappa GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="102"/>
         <source>Zoom In (+)</source>
         <translation>Ingrandisci (+)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="106"/>
         <source>Zoom Out (-)</source>
         <translation>Rimpicciolisci (-)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="110"/>
         <source>Fit All (F)</source>
         <translation>Adatta Tutto (F)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="108"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="114"/>
         <source>Rotate (R)</source>
         <translation>Ruota (R)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="116"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="202"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
         <source>Satellite View</source>
         <translation>Vista Satellitare</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="124"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="129"/>
+        <source>POD Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="133"/>
+        <source>Run a map export with the POD option to generate this overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="138"/>
+        <source>POD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="139"/>
+        <source>Look count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <source>POD overlay opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Clicca su un punto per selezionare • Trascina per scorrere • Scorri per lo zoom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="199"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
         <source>Map View</source>
         <translation>Vista Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="236"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="246"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
         <source>Map Tile Loading Issue</source>
         <translation>Problema di Caricamento Tasselli Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5389,13 +5410,13 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
 <context>
     <name>GPSMapView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1129"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1216"/>
         <source>Copy Data</source>
         <translation>Copia Dati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1669"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1756"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1857"/>
         <source>Zoom FOV</source>
         <translation>Zoom FOV</translation>
     </message>
@@ -9098,26 +9119,46 @@ Fai domande, segnala problemi e suggerisci nuove funzionalità.</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="101"/>
+        <source>Probability of Detection (POD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <source>POD coverage heatmap (terrain-aware)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
+        <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). Writes coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson and stats.json. The GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <source>Show on map when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="123"/>
         <source>CalTopo Options</source>
         <translation>Opzioni CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
         <source>Include Images</source>
         <translation>Includi Immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="128"/>
         <source>Upload photos to CalTopo markers (CalTopo only)</source>
         <translation>Carica foto sui marker CalTopo (solo CalTopo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="148"/>
         <source>Export</source>
         <translation>Esporta</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="130"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="152"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -9418,89 +9459,6 @@ poi clicca di nuovo per posizionare il secondo punto.</translation>
         <location filename="../app/core/views/flight/MissionGalleryDock.py" line="151"/>
         <source>{n} detections</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Modalità Rilevamento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Modalità:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Auto</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Telecamera Statica</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Telecamera in Movimento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algoritmo</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algoritmo:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Differenza Frame</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>Sfondo MOG2</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>Sfondo KNN</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Flusso Ottico</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Corrispondenza Caratteristiche</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Parametri Rilevamento</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Sensibilità: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Area Min:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Area Max:</translation>
     </message>
 </context>
 <context>
@@ -9946,55 +9904,56 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation>Scuro</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="160"/>
-        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <location filename="../app/core/controllers/Preferences.py" line="223"/>
+        <location filename="../app/core/controllers/Preferences.py" line="496"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="251"/>
+        <location filename="../app/core/controllers/Preferences.py" line="320"/>
         <source>Select 3DEP manifest CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="253"/>
+        <location filename="../app/core/controllers/Preferences.py" line="322"/>
+        <location filename="../app/core/controllers/Preferences.py" line="367"/>
         <source>CSV files (*.csv);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="263"/>
+        <location filename="../app/core/controllers/Preferences.py" line="332"/>
         <source>Select 3DEP tiles directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="301"/>
+        <location filename="../app/core/controllers/Preferences.py" line="431"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} tasselli ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="307"/>
+        <location filename="../app/core/controllers/Preferences.py" line="437"/>
         <source>Not available</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="309"/>
-        <location filename="../app/core/controllers/Preferences.py" line="317"/>
-        <location filename="../app/core/controllers/Preferences.py" line="345"/>
+        <location filename="../app/core/controllers/Preferences.py" line="439"/>
+        <location filename="../app/core/controllers/Preferences.py" line="447"/>
+        <location filename="../app/core/controllers/Preferences.py" line="475"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="318"/>
+        <location filename="../app/core/controllers/Preferences.py" line="448"/>
         <source>Terrain service not available.</source>
         <translation>Servizio terreno non disponibile.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="324"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
         <source>Clear Terrain Cache</source>
         <translation>Cancella Cache Terreno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="326"/>
+        <location filename="../app/core/controllers/Preferences.py" line="456"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -10003,78 +9962,129 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;elevazione del terreno.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="339"/>
+        <location filename="../app/core/controllers/Preferences.py" line="469"/>
         <source>Cache Cleared</source>
         <translation>Cache Cancellata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="340"/>
+        <location filename="../app/core/controllers/Preferences.py" line="470"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>Cancellati {count} tasselli di terreno dalla cache.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="346"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Impossibile cancellare la cache: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="353"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Select a Drone Sensor File</source>
         <translation>Seleziona un File Sensore Drone</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="60"/>
+        <location filename="../app/core/controllers/Preferences.py" line="66"/>
         <source>Language:</source>
         <translation>Lingua:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="79"/>
+        <location filename="../app/core/controllers/Preferences.py" line="85"/>
         <source>Terrain Elevation Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="83"/>
+        <location filename="../app/core/controllers/Preferences.py" line="89"/>
         <source>Provider:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="93"/>
+        <location filename="../app/core/controllers/Preferences.py" line="99"/>
+        <location filename="../app/core/controllers/Preferences.py" line="141"/>
         <source>Manifest CSV:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="95"/>
+        <location filename="../app/core/controllers/Preferences.py" line="101"/>
         <source>Path to dem_manifest.csv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="96"/>
-        <location filename="../app/core/controllers/Preferences.py" line="107"/>
+        <location filename="../app/core/controllers/Preferences.py" line="102"/>
+        <location filename="../app/core/controllers/Preferences.py" line="113"/>
+        <location filename="../app/core/controllers/Preferences.py" line="144"/>
+        <location filename="../app/core/controllers/Preferences.py" line="154"/>
         <source>Browse...</source>
         <translation type="unfinished">Sfoglia...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="104"/>
+        <location filename="../app/core/controllers/Preferences.py" line="110"/>
+        <location filename="../app/core/controllers/Preferences.py" line="151"/>
         <source>Tiles directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="106"/>
+        <location filename="../app/core/controllers/Preferences.py" line="112"/>
+        <location filename="../app/core/controllers/Preferences.py" line="153"/>
         <source>Folder containing the GeoTIFF tiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="355"/>
+        <location filename="../app/core/controllers/Preferences.py" line="128"/>
+        <source>Canopy Data Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="132"/>
+        <source>Source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="143"/>
+        <source>Path to the canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="162"/>
+        <source>Download tiles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="164"/>
+        <source>Download DEM and/or canopy tiles for an area of interest and register them here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <source>Select canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="375"/>
+        <source>Select canopy tiles directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="386"/>
+        <source>Download Tiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="387"/>
+        <source>The tile downloader is unavailable:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="381"/>
+        <location filename="../app/core/controllers/Preferences.py" line="511"/>
         <source>Restart Required</source>
         <translation>Riavvio Richiesto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="382"/>
+        <location filename="../app/core/controllers/Preferences.py" line="512"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Riavvia l&apos;applicazione affinché le modifiche alla lingua abbiano effetto.</translation>
     </message>
@@ -10608,42 +10618,42 @@ Aggressivo</translation>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Soglia:&lt;/b&gt; {value}</translation>
     </message>
@@ -10651,22 +10661,22 @@ Aggressivo</translation>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Colori Recenti</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Seleziona un colore usato di recente:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>Nessun colore recente trovato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -11782,14 +11792,6 @@ Formati supportati: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>File Video (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Tutti i File (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Seleziona Cartella Registrazioni</translation>
     </message>
 </context>
 <context>
@@ -13569,6 +13571,138 @@ Aggressivo</translation>
     </message>
 </context>
 <context>
+    <name>TileFetchController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <source>Invalid Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <source>Please enter a valid bounding box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <source>No Output Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <source>Please choose an output folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <source>No Dataset</source>
+        <translation type="unfinished">Nessun Dataset</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <source>Please select at least one dataset.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <source>Download Complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <source>Downloaded {count} tiles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <source>Download Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <source>Tile download failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TileFetchDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <source>Download Coverage Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <source>Area of Interest (WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Min latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <source>Max longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <source>Max latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <source>Datasets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <source>USGS 3DEP DEM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <source>Meta/WRI Canopy Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <source>Output folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <source>Browse...</source>
+        <translation type="unfinished">Sfoglia...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <source>Register in Preferences when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annulla</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <source>Select output folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TrackGalleryWidget</name>
     <message>
         <location filename="../app/core/views/streaming/components/TrackGalleryWidget.py" line="41"/>
@@ -13594,68 +13728,101 @@ Aggressivo</translation>
 <context>
     <name>UnifiedMapExportController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="382"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="432"/>
         <source>No Data Selected</source>
         <translation>Nessun Dato Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="433"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Seleziona almeno un tipo di dato da esportare.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="408"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="509"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="543"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="577"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="622"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="458"/>
+        <source>Select folder for POD coverage files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="466"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="569"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="792"/>
         <source>Export Error</source>
         <translation>Errore di Esportazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="467"/>
         <source>An error occurred during export:
 {error}</source>
         <translation>Si è verificato un errore durante l&apos;esportazione:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="426"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="484"/>
         <source>Save Map Export</source>
         <translation>Salva Esportazione Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="486"/>
         <source>KML files (*.kml)</source>
         <translation>File KML (*.kml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="510"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="570"/>
         <source>Failed to export to KML:
 {error}</source>
         <translation>Impossibile esportare in KML:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="544"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="680"/>
+        <source>POD Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="613"/>
+        <source>Could not start the POD calculation:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="653"/>
+        <source>POD coverage complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="673"/>
+        <source>POD calculation cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="681"/>
+        <source>POD calculation failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
         <source>Failed to export to CalTopo:
 {error}</source>
         <translation>Impossibile esportare su CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="594"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="764"/>
         <source>Map export completed successfully!</source>
         <translation>Esportazione mappa completata con successo!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="609"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="779"/>
         <source>Map export cancelled</source>
         <translation>Esportazione mappa annullata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="623"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="793"/>
         <source>Map export failed:
 {error}</source>
         <translation>Esportazione mappa non riuscita:
@@ -14231,29 +14398,6 @@ Mostra il totale dei fotogrammi estratti al termine.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation>Riproduci/Pausa (Spazio)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation>Trascina per navigare nel video</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation>Pausa (Spazio)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation>Riproduci (Spazio)</translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -14356,7 +14500,7 @@ Mostra tutte le AOI di tutte le immagini in una vista a griglia</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14588,7 +14732,7 @@ Il visualizzatore verrà chiuso.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1357"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Salta Nascoste ({count}) </translation>
     </message>
@@ -14745,41 +14889,41 @@ Vuoi leggere le dimensioni dai file immagine e aggiornare il file dei risultati?
         <translation>Attiva/disattiva Cerchi AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1532"/>
         <source>Missing Dependency</source>
         <translation>Dipendenza Mancante</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1534"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>Il modulo qimage2ndarray è richiesto per la funzione di upscale.
 Installalo usando: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1543"/>
         <source>Upscale Error</source>
         <translation>Errore di Upscale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1545"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Si è verificato un errore durante l&apos;apertura della finestra di upscale:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1871"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1968"/>
         <source>Unknown Reviewer</source>
         <translation>Revisore Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2031"/>
         <source>Loading gallery...</source>
         <translation>Caricamento galleria...</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -5254,67 +5254,72 @@ Vuoi continuare?</translation>
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="65"/>
         <source>No GPS data found in images</source>
         <translation>Nessun dato GPS trovato nelle immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
         <source>Not covered — no looks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="305"/>
         <source>Terrain occlusion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="306"/>
         <source>Canopy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="307"/>
         <source>Image resolution (GSD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="308"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="310"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="436"/>
+        <source>No canopy data covers this area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="460"/>
         <source>POD: {pod}%   Looks: {looks}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="463"/>
         <source>Limiting factor: {factor}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="471"/>
         <source>Image {n}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="472"/>
         <source>View {name}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="475"/>
         <source>Find location in images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="589"/>
         <source>GPS coordinate not in any images</source>
         <translation>Coordinata GPS non presente in nessuna immagine</translation>
     </message>
@@ -5348,7 +5353,7 @@ Vuoi continuare?</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="280"/>
         <source>Satellite View</source>
         <translation>Vista Satellitare</translation>
     </message>
@@ -5373,32 +5378,37 @@ Vuoi continuare?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="140"/>
+        <source>Canopy height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="150"/>
         <source>POD overlay opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="157"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Clicca su un punto per selezionare • Trascina per scorrere • Scorri per lo zoom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="277"/>
         <source>Map View</source>
         <translation>Vista Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="314"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="324"/>
         <source>Map Tile Loading Issue</source>
         <translation>Problema di Caricamento Tasselli Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="326"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -9905,7 +9905,7 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/Preferences.py" line="223"/>
-        <location filename="../app/core/controllers/Preferences.py" line="496"/>
+        <location filename="../app/core/controllers/Preferences.py" line="503"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
@@ -9926,34 +9926,34 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="431"/>
+        <location filename="../app/core/controllers/Preferences.py" line="438"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} tasselli ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="437"/>
+        <location filename="../app/core/controllers/Preferences.py" line="444"/>
         <source>Not available</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="439"/>
-        <location filename="../app/core/controllers/Preferences.py" line="447"/>
-        <location filename="../app/core/controllers/Preferences.py" line="475"/>
+        <location filename="../app/core/controllers/Preferences.py" line="446"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="482"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="448"/>
+        <location filename="../app/core/controllers/Preferences.py" line="455"/>
         <source>Terrain service not available.</source>
         <translation>Servizio terreno non disponibile.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="461"/>
         <source>Clear Terrain Cache</source>
         <translation>Cancella Cache Terreno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="456"/>
+        <location filename="../app/core/controllers/Preferences.py" line="463"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -9962,22 +9962,22 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;elevazione del terreno.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="469"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Cache Cleared</source>
         <translation>Cache Cancellata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="470"/>
+        <location filename="../app/core/controllers/Preferences.py" line="477"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>Cancellati {count} tasselli di terreno dalla cache.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="476"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Impossibile cancellare la cache: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="483"/>
+        <location filename="../app/core/controllers/Preferences.py" line="490"/>
         <source>Select a Drone Sensor File</source>
         <translation>Seleziona un File Sensore Drone</translation>
     </message>
@@ -10074,17 +10074,17 @@ Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="485"/>
+        <location filename="../app/core/controllers/Preferences.py" line="492"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="511"/>
+        <location filename="../app/core/controllers/Preferences.py" line="518"/>
         <source>Restart Required</source>
         <translation>Riavvio Richiesto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="512"/>
+        <location filename="../app/core/controllers/Preferences.py" line="519"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Riavvia l&apos;applicazione affinché le modifiche alla lingua abbiano effetto.</translation>
     </message>
@@ -13573,52 +13573,77 @@ Aggressivo</translation>
 <context>
     <name>TileFetchController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
         <source>Invalid Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="98"/>
         <source>Please enter a valid bounding box.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="101"/>
         <source>No Output Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="102"/>
         <source>Please choose an output folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="105"/>
         <source>No Dataset</source>
         <translation type="unfinished">Nessun Dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="106"/>
         <source>Please select at least one dataset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="144"/>
+        <source>No GPS Found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="145"/>
+        <source>No GPS positions were found in the {source} images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="158"/>
+        <source>Select image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="167"/>
+        <source>No Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="168"/>
+        <source>No images were found in the selected folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="199"/>
         <source>Download Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="200"/>
         <source>Downloaded {count} tiles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="214"/>
         <source>Download Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="215"/>
         <source>Tile download failed:
 {error}</source>
         <translation type="unfinished"></translation>
@@ -13627,77 +13652,107 @@ Aggressivo</translation>
 <context>
     <name>TileFetchDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="24"/>
         <source>Download Coverage Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="32"/>
         <source>Area of Interest (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="37"/>
+        <source>Use loaded mission extent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="40"/>
+        <source>Fill the AOI from the GPS positions of the currently loaded mission&apos;s images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
-        <source>Min longitude:</source>
+        <source>Load extent from image folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Read image GPS from a folder to fill the AOI (use when no mission is loaded).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="58"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="60"/>
         <source>Min latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="62"/>
         <source>Max longitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
         <source>Max latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="69"/>
+        <source>Footprint buffer (m):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="74"/>
+        <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="83"/>
         <source>Datasets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="85"/>
         <source>USGS 3DEP DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="87"/>
         <source>Meta/WRI Canopy Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="95"/>
         <source>Output folder:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="97"/>
         <source>Browse...</source>
         <translation type="unfinished">Sfoglia...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="103"/>
         <source>Register in Preferences when complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="119"/>
         <source>Select output folder</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -2144,39 +2144,6 @@ De items moeten nu zichtbaar zijn op uw kaart.</translation>
     </message>
 </context>
 <context>
-    <name>CalTopoMapDialog</name>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="35"/>
-        <source>Select CalTopo Map</source>
-        <translation>CalTopo-kaart selecteren</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="51"/>
-        <source>Select a CalTopo map to export flagged AOIs:</source>
-        <translation>Selecteer een CalTopo-kaart om gemarkeerde AOI&apos;s te exporteren:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="60"/>
-        <source>Search:</source>
-        <translation>Zoeken:</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="62"/>
-        <source>Filter maps by name...</source>
-        <translation>Kaarten filteren op naam...</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="83"/>
-        <source>Select Map</source>
-        <translation>Kaart selecteren</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMapDialog.py" line="87"/>
-        <source>Cancel</source>
-        <translation>Annuleren</translation>
-    </message>
-</context>
-<context>
     <name>CalTopoMethodDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="34"/>
@@ -3489,55 +3456,44 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
 <context>
     <name>ColorListDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="30"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="30"/>
         <source>Select Color from List</source>
         <translation>Kleur uit lijst selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="42"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="42"/>
         <source>Search:</source>
         <translation>Zoeken:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="44"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="44"/>
         <source>Filter by name or uses…</source>
         <translation>Filter op naam of toepassingen…</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>RGB</source>
         <translation>RGB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <source>HSV</source>
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="56"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="61"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Toepassingen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorListDialog.py" line="73"/>
         <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="73"/>
         <source>Use Color</source>
         <translation>Kleur gebruiken</translation>
@@ -3546,13 +3502,11 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
 <context>
     <name>ColorPickerDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="35"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="35"/>
         <source>Select Color from Image</source>
         <translation>Kleur uit afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerDialog.py" line="55"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerDialog.py" line="55"/>
         <source>Use Color</source>
         <translation>Kleur gebruiken</translation>
@@ -3561,29 +3515,22 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
 <context>
     <name>ColorPickerImageViewer</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="97"/>
         <source>Load Image</source>
         <translation>Afbeelding laden</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="102"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="102"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="290"/>
         <source>Color Selector</source>
         <translation>Kleurkiezer</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="159"/>
         <source>Select Image</source>
         <translation>Afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="173"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="230"/>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="588"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="173"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="230"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="588"/>
@@ -3591,37 +3538,31 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="174"/>
         <source>Could not load image: {path}</source>
         <translation>Kan afbeelding niet laden: {path}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="231"/>
         <source>Error loading image: {error}</source>
         <translation>Fout bij het laden van afbeelding: {error}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="286"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="358"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (onder cursor)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="589"/>
         <source>Error setting image: {error}</source>
         <translation>Fout bij het instellen van afbeelding: {error}</translation>
@@ -5313,12 +5254,67 @@ Wilt u doorgaan?</translation>
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="56"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
         <source>No GPS data found in images</source>
         <translation>Geen GPS-gegevens gevonden in afbeeldingen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="366"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <source>Not covered — no looks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <source>Terrain occlusion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <source>Canopy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <source>Image resolution (GSD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <source>None</source>
+        <translation type="unfinished">Geen</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <source>POD: {pod}%   Looks: {looks}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <source>Limiting factor: {factor}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <source>Image {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <source>View {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <source>Find location in images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
         <source>GPS coordinate not in any images</source>
         <translation>GPS-coördinaat in geen enkele afbeelding</translation>
     </message>
@@ -5326,58 +5322,83 @@ Wilt u doorgaan?</translation>
 <context>
     <name>GPSMapDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="42"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="48"/>
         <source>GPS Map View</source>
         <translation>GPS-kaartweergave</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="102"/>
         <source>Zoom In (+)</source>
         <translation>Inzoomen (+)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="106"/>
         <source>Zoom Out (-)</source>
         <translation>Uitzoomen (-)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="110"/>
         <source>Fit All (F)</source>
         <translation>Alles passend maken (F)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="108"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="114"/>
         <source>Rotate (R)</source>
         <translation>Roteren (R)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="116"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="202"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
         <source>Satellite View</source>
         <translation>Satellietweergave</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="124"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="129"/>
+        <source>POD Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="133"/>
+        <source>Run a map export with the POD option to generate this overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="138"/>
+        <source>POD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="139"/>
+        <source>Look count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <source>POD overlay opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Klik op punt om te selecteren • Sleep om te verplaatsen • Scrol om te zoomen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="199"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
         <source>Map View</source>
         <translation>Kaartweergave</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="236"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="246"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
         <source>Map Tile Loading Issue</source>
         <translation>Probleem met laden van kaarttegels</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5389,13 +5410,13 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
 <context>
     <name>GPSMapView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1129"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1216"/>
         <source>Copy Data</source>
         <translation>Gegevens kopiëren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1669"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1756"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1857"/>
         <source>Zoom FOV</source>
         <translation>Zoom-gezichtsveld</translation>
     </message>
@@ -9098,26 +9119,46 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="101"/>
+        <source>Probability of Detection (POD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <source>POD coverage heatmap (terrain-aware)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
+        <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). Writes coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson and stats.json. The GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <source>Show on map when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="123"/>
         <source>CalTopo Options</source>
         <translation>CalTopo-opties</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
         <source>Include Images</source>
         <translation>Afbeeldingen opnemen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="128"/>
         <source>Upload photos to CalTopo markers (CalTopo only)</source>
         <translation>Foto&apos;s uploaden naar CalTopo-markeringen (alleen CalTopo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="148"/>
         <source>Export</source>
         <translation>Exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="130"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="152"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -9418,89 +9459,6 @@ klik daarna nogmaals om het tweede punt te plaatsen.</translation>
         <location filename="../app/core/views/flight/MissionGalleryDock.py" line="151"/>
         <source>{n} detections</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>MotionDetectionWizard</name>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="12"/>
-        <source>Detection Mode</source>
-        <translation>Detectiemodus</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="16"/>
-        <source>Mode:</source>
-        <translation>Modus:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="22"/>
-        <source>Auto</source>
-        <translation>Automatisch</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="25"/>
-        <source>Static Camera</source>
-        <translation>Statische camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="28"/>
-        <source>Moving Camera</source>
-        <translation>Bewegende camera</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="37"/>
-        <source>Algorithm</source>
-        <translation>Algoritme</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="41"/>
-        <source>Algorithm:</source>
-        <translation>Algoritme:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="47"/>
-        <source>Frame Difference</source>
-        <translation>Frameverschil</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="50"/>
-        <source>MOG2 Background</source>
-        <translation>MOG2-achtergrond</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="53"/>
-        <source>KNN Background</source>
-        <translation>KNN-achtergrond</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="56"/>
-        <source>Optical Flow</source>
-        <translation>Optische stroming</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="59"/>
-        <source>Feature Matching</source>
-        <translation>Kenmerkovereenkomst</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="68"/>
-        <source>Detection Parameters</source>
-        <translation>Detectieparameters</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="72"/>
-        <source>Sensitivity: 50%</source>
-        <translation>Gevoeligheid: 50%</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="87"/>
-        <source>Min Area:</source>
-        <translation>Min. gebied:</translation>
-    </message>
-    <message>
-        <location filename="../resources/views/algorithms/MotionDetectionWizard.ui" line="103"/>
-        <source>Max Area:</source>
-        <translation>Max. gebied:</translation>
     </message>
 </context>
 <context>
@@ -10260,96 +10218,148 @@ All changes are saved automatically when modified.</source>
 Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="60"/>
+        <location filename="../app/core/controllers/Preferences.py" line="66"/>
         <source>Language:</source>
         <translation>Taal:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="79"/>
+        <location filename="../app/core/controllers/Preferences.py" line="85"/>
         <source>Terrain Elevation Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="83"/>
+        <location filename="../app/core/controllers/Preferences.py" line="89"/>
         <source>Provider:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="93"/>
+        <location filename="../app/core/controllers/Preferences.py" line="99"/>
+        <location filename="../app/core/controllers/Preferences.py" line="141"/>
         <source>Manifest CSV:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="95"/>
+        <location filename="../app/core/controllers/Preferences.py" line="101"/>
         <source>Path to dem_manifest.csv</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="96"/>
-        <location filename="../app/core/controllers/Preferences.py" line="107"/>
+        <location filename="../app/core/controllers/Preferences.py" line="102"/>
+        <location filename="../app/core/controllers/Preferences.py" line="113"/>
+        <location filename="../app/core/controllers/Preferences.py" line="144"/>
+        <location filename="../app/core/controllers/Preferences.py" line="154"/>
         <source>Browse...</source>
         <translation type="unfinished">Bladeren...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="104"/>
+        <location filename="../app/core/controllers/Preferences.py" line="110"/>
+        <location filename="../app/core/controllers/Preferences.py" line="151"/>
         <source>Tiles directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="106"/>
+        <location filename="../app/core/controllers/Preferences.py" line="112"/>
+        <location filename="../app/core/controllers/Preferences.py" line="153"/>
         <source>Folder containing the GeoTIFF tiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="160"/>
-        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <location filename="../app/core/controllers/Preferences.py" line="128"/>
+        <source>Canopy Data Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="132"/>
+        <source>Source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="143"/>
+        <source>Path to the canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="162"/>
+        <source>Download tiles...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="164"/>
+        <source>Download DEM and/or canopy tiles for an area of interest and register them here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="223"/>
+        <location filename="../app/core/controllers/Preferences.py" line="496"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="251"/>
+        <location filename="../app/core/controllers/Preferences.py" line="320"/>
         <source>Select 3DEP manifest CSV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="253"/>
+        <location filename="../app/core/controllers/Preferences.py" line="322"/>
+        <location filename="../app/core/controllers/Preferences.py" line="367"/>
         <source>CSV files (*.csv);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="263"/>
+        <location filename="../app/core/controllers/Preferences.py" line="332"/>
         <source>Select 3DEP tiles directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="301"/>
+        <location filename="../app/core/controllers/Preferences.py" line="366"/>
+        <source>Select canopy manifest CSV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="375"/>
+        <source>Select canopy tiles directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="386"/>
+        <source>Download Tiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="387"/>
+        <source>The tile downloader is unavailable:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/Preferences.py" line="431"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} tegels ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="307"/>
+        <location filename="../app/core/controllers/Preferences.py" line="437"/>
         <source>Not available</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="309"/>
-        <location filename="../app/core/controllers/Preferences.py" line="317"/>
-        <location filename="../app/core/controllers/Preferences.py" line="345"/>
+        <location filename="../app/core/controllers/Preferences.py" line="439"/>
+        <location filename="../app/core/controllers/Preferences.py" line="447"/>
+        <location filename="../app/core/controllers/Preferences.py" line="475"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="318"/>
+        <location filename="../app/core/controllers/Preferences.py" line="448"/>
         <source>Terrain service not available.</source>
         <translation>Terreinservice niet beschikbaar.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="324"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
         <source>Clear Terrain Cache</source>
         <translation>Terreincache wissen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="326"/>
+        <location filename="../app/core/controllers/Preferences.py" line="456"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -10358,37 +10368,37 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 Hierdoor moeten tegels opnieuw worden gedownload wanneer terreinhoogte wordt gebruikt.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="339"/>
+        <location filename="../app/core/controllers/Preferences.py" line="469"/>
         <source>Cache Cleared</source>
         <translation>Cache gewist</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="340"/>
+        <location filename="../app/core/controllers/Preferences.py" line="470"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>{count} gecachete terreintegels gewist.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="346"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Kan cache niet wissen: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="353"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Select a Drone Sensor File</source>
         <translation>Een dronesensorbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="355"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="381"/>
+        <location filename="../app/core/controllers/Preferences.py" line="511"/>
         <source>Restart Required</source>
         <translation>Herstart vereist</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="382"/>
+        <location filename="../app/core/controllers/Preferences.py" line="512"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Start de applicatie opnieuw om taalwijzigingen door te voeren.</translation>
     </message>
@@ -10608,42 +10618,42 @@ agressief</translation>
 <context>
     <name>RecentColorWidget</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="68"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="68"/>
         <source>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</source>
         <translation>&lt;b&gt;RGB:&lt;/b&gt; ({r}, {g}, {b})</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="97"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="97"/>
         <source>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;H (°):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="100"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="100"/>
         <source> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;S (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="103"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="103"/>
         <source> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;V (%):&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="112"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="112"/>
         <source>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</source>
         <translation>&lt;br&gt;&lt;b&gt;R:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="115"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="115"/>
         <source> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;G:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="118"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="118"/>
         <source> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</source>
         <translation> &lt;b&gt;B:&lt;/b&gt; {min}-{max}</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="124"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="124"/>
         <source>&lt;br&gt;&lt;b&gt;Threshold:&lt;/b&gt; {value}</source>
         <translation>&lt;br&gt;&lt;b&gt;Drempel:&lt;/b&gt; {value}</translation>
     </message>
@@ -10651,22 +10661,22 @@ agressief</translation>
 <context>
     <name>RecentColorsDialog</name>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="151"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="151"/>
         <source>Recent Colors</source>
         <translation>Recente kleuren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="162"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="162"/>
         <source>Select a recently used color:</source>
         <translation>Selecteer een recent gebruikte kleur:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="178"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="178"/>
         <source>No recent colors found</source>
         <translation>Geen recente kleuren gevonden</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/Shared/views/RecentColorsDialog.py" line="204"/>
+        <location filename="../app/algorithms/Shared/views/RecentColorsDialog.py" line="204"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -11782,14 +11792,6 @@ Ondersteunde formaten: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1340"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Videobestanden (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Alle bestanden (*)</translation>
-    </message>
-</context>
-<context>
-    <name>StreamGeneralPage</name>
-    <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamGeneralPage.py" line="55"/>
-        <source>Select Recording Folder</source>
-        <translation>Opnamemap selecteren</translation>
     </message>
 </context>
 <context>
@@ -13569,6 +13571,138 @@ agressief</translation>
     </message>
 </context>
 <context>
+    <name>TileFetchController</name>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <source>Invalid Area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <source>Please enter a valid bounding box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <source>No Output Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <source>Please choose an output folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <source>No Dataset</source>
+        <translation type="unfinished">Geen dataset</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <source>Please select at least one dataset.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <source>Download Complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <source>Downloaded {count} tiles.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <source>Download Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <source>Tile download failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TileFetchDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <source>Download Coverage Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <source>Area of Interest (WGS84)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Min latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <source>Max longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <source>Max latitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <source>Datasets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <source>USGS 3DEP DEM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <source>Meta/WRI Canopy Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <source>Output folder:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <source>Browse...</source>
+        <translation type="unfinished">Bladeren...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <source>Register in Preferences when complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <source>Select output folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TrackGalleryWidget</name>
     <message>
         <location filename="../app/core/views/streaming/components/TrackGalleryWidget.py" line="41"/>
@@ -13594,68 +13728,101 @@ agressief</translation>
 <context>
     <name>UnifiedMapExportController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="382"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="432"/>
         <source>No Data Selected</source>
         <translation>Geen gegevens geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="433"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Selecteer ten minste één type gegevens om te exporteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="408"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="509"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="543"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="577"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="622"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="458"/>
+        <source>Select folder for POD coverage files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="466"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="569"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="792"/>
         <source>Export Error</source>
         <translation>Exportfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="467"/>
         <source>An error occurred during export:
 {error}</source>
         <translation>Er is een fout opgetreden tijdens de export:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="426"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="484"/>
         <source>Save Map Export</source>
         <translation>Kaartexport opslaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="486"/>
         <source>KML files (*.kml)</source>
         <translation>KML-bestanden (*.kml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="510"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="570"/>
         <source>Failed to export to KML:
 {error}</source>
         <translation>Exporteren naar KML mislukt:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="544"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="680"/>
+        <source>POD Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="613"/>
+        <source>Could not start the POD calculation:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="653"/>
+        <source>POD coverage complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="673"/>
+        <source>POD calculation cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="681"/>
+        <source>POD calculation failed:
+{error}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
         <source>Failed to export to CalTopo:
 {error}</source>
         <translation>Exporteren naar CalTopo mislukt:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="594"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="764"/>
         <source>Map export completed successfully!</source>
         <translation>Kaartexport succesvol voltooid!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="609"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="779"/>
         <source>Map export cancelled</source>
         <translation>Kaartexport geannuleerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="623"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="793"/>
         <source>Map export failed:
 {error}</source>
         <translation>Kaartexport mislukt:
@@ -14231,29 +14398,6 @@ Toont het totaal aantal geëxtraheerde frames bij voltooien.</translation>
     </message>
 </context>
 <context>
-    <name>VideoTimelineWidget</name>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="46"/>
-        <source>Play/Pause (Space)</source>
-        <translation>Afspelen/pauzeren (spatie)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="59"/>
-        <source>Drag to seek through video</source>
-        <translation>Sleep om door video te zoeken</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Pause (Space)</source>
-        <translation>Pauzeren (spatie)</translation>
-    </message>
-    <message>
-        <location filename="../app/core/views/streaming/components/VideoTimelineWidget.py" line="100"/>
-        <source>Play (Space)</source>
-        <translation>Afspelen (spatie)</translation>
-    </message>
-</context>
-<context>
     <name>Viewer</name>
     <message>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="14"/>
@@ -14356,7 +14500,7 @@ Toont alle AOI&apos;s van alle afbeeldingen in een rasterweergave</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1863"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="405"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation type="unfinished"></translation>
@@ -14588,7 +14732,7 @@ De viewer wordt nu gesloten.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="212"/>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1353"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1357"/>
         <source>Skip Hidden ({count}) </source>
         <translation>Verborgen overslaan ({count}) </translation>
     </message>
@@ -14745,41 +14889,41 @@ Wilt u de afmetingen uit de afbeeldingsbestanden lezen en het resultatenbestand 
         <translation>AOI-cirkels in-/uitschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1528"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1532"/>
         <source>Missing Dependency</source>
         <translation>Ontbrekende afhankelijkheid</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1530"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1534"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>De qimage2ndarray-module is vereist voor de opschaalfunctie.
 Installeer deze met: pip install qimage2ndarray</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1543"/>
         <source>Upscale Error</source>
         <translation>Opschaalfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1545"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Er is een fout opgetreden bij het openen van het opschaaldialoogvenster:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1867"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1871"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1964"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1968"/>
         <source>Unknown Reviewer</source>
         <translation>Onbekende beoordelaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2027"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2031"/>
         <source>Loading gallery...</source>
         <translation>Galerij laden...</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -5254,67 +5254,72 @@ Wilt u doorgaan?</translation>
 <context>
     <name>GPSMapController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="65"/>
         <source>No GPS data found in images</source>
         <translation>Geen GPS-gegevens gevonden in afbeeldingen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="294"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
         <source>Not covered — no looks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="305"/>
         <source>Terrain occlusion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="306"/>
         <source>Canopy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="297"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="307"/>
         <source>Image resolution (GSD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="308"/>
         <source>None</source>
         <translation type="unfinished">Geen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="310"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="357"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="436"/>
+        <source>No canopy data covers this area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="460"/>
         <source>POD: {pod}%   Looks: {looks}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="360"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="463"/>
         <source>Limiting factor: {factor}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="368"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="471"/>
         <source>Image {n}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="369"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="472"/>
         <source>View {name}</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="372"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="475"/>
         <source>Find location in images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="486"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="589"/>
         <source>GPS coordinate not in any images</source>
         <translation>GPS-coördinaat in geen enkele afbeelding</translation>
     </message>
@@ -5348,7 +5353,7 @@ Wilt u doorgaan?</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="122"/>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="280"/>
         <source>Satellite View</source>
         <translation>Satellietweergave</translation>
     </message>
@@ -5373,32 +5378,37 @@ Wilt u doorgaan?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="149"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="140"/>
+        <source>Canopy height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="150"/>
         <source>POD overlay opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="156"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="157"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
         <translation>Klik op punt om te selecteren • Sleep om te verplaatsen • Scrol om te zoomen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="277"/>
         <source>Map View</source>
         <translation>Kaartweergave</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="287"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="314"/>
         <source>⚠ {error}</source>
         <translation>⚠ {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="324"/>
         <source>Map Tile Loading Issue</source>
         <translation>Probleem met laden van kaarttegels</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="299"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="326"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -10290,7 +10290,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
     </message>
     <message>
         <location filename="../app/core/controllers/Preferences.py" line="223"/>
-        <location filename="../app/core/controllers/Preferences.py" line="496"/>
+        <location filename="../app/core/controllers/Preferences.py" line="503"/>
         <source>{version}_{date}</source>
         <translation>{version}_{date}</translation>
     </message>
@@ -10332,34 +10332,34 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="431"/>
+        <location filename="../app/core/controllers/Preferences.py" line="438"/>
         <source>{tiles} tiles ({size_mb:.1f} MB)</source>
         <translation>{tiles} tegels ({size_mb:.1f} MB)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="437"/>
+        <location filename="../app/core/controllers/Preferences.py" line="444"/>
         <source>Not available</source>
         <translation>Niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="439"/>
-        <location filename="../app/core/controllers/Preferences.py" line="447"/>
-        <location filename="../app/core/controllers/Preferences.py" line="475"/>
+        <location filename="../app/core/controllers/Preferences.py" line="446"/>
+        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="482"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="448"/>
+        <location filename="../app/core/controllers/Preferences.py" line="455"/>
         <source>Terrain service not available.</source>
         <translation>Terreinservice niet beschikbaar.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="454"/>
+        <location filename="../app/core/controllers/Preferences.py" line="461"/>
         <source>Clear Terrain Cache</source>
         <translation>Terreincache wissen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="456"/>
+        <location filename="../app/core/controllers/Preferences.py" line="463"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -10368,37 +10368,37 @@ This will require re-downloading tiles when terrain elevation is used.</source>
 Hierdoor moeten tegels opnieuw worden gedownload wanneer terreinhoogte wordt gebruikt.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="469"/>
+        <location filename="../app/core/controllers/Preferences.py" line="476"/>
         <source>Cache Cleared</source>
         <translation>Cache gewist</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="470"/>
+        <location filename="../app/core/controllers/Preferences.py" line="477"/>
         <source>Cleared {count} cached terrain tiles.</source>
         <translation>{count} gecachete terreintegels gewist.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="476"/>
+        <location filename="../app/core/controllers/Preferences.py" line="483"/>
         <source>Failed to clear cache: {error}</source>
         <translation>Kan cache niet wissen: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="483"/>
+        <location filename="../app/core/controllers/Preferences.py" line="490"/>
         <source>Select a Drone Sensor File</source>
         <translation>Een dronesensorbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="485"/>
+        <location filename="../app/core/controllers/Preferences.py" line="492"/>
         <source>CSV Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="511"/>
+        <location filename="../app/core/controllers/Preferences.py" line="518"/>
         <source>Restart Required</source>
         <translation>Herstart vereist</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="512"/>
+        <location filename="../app/core/controllers/Preferences.py" line="519"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Start de applicatie opnieuw om taalwijzigingen door te voeren.</translation>
     </message>
@@ -13573,52 +13573,77 @@ agressief</translation>
 <context>
     <name>TileFetchController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="88"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
         <source>Invalid Area</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="89"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="98"/>
         <source>Please enter a valid bounding box.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="92"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="101"/>
         <source>No Output Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="93"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="102"/>
         <source>Please choose an output folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="96"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="105"/>
         <source>No Dataset</source>
         <translation type="unfinished">Geen dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="97"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="106"/>
         <source>Please select at least one dataset.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="146"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="144"/>
+        <source>No GPS Found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="145"/>
+        <source>No GPS positions were found in the {source} images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="158"/>
+        <source>Select image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="167"/>
+        <source>No Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="168"/>
+        <source>No images were found in the selected folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="199"/>
         <source>Download Complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="147"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="200"/>
         <source>Downloaded {count} tiles.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="161"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="214"/>
         <source>Download Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="162"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="215"/>
         <source>Tile download failed:
 {error}</source>
         <translation type="unfinished"></translation>
@@ -13627,77 +13652,107 @@ agressief</translation>
 <context>
     <name>TileFetchDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="20"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="24"/>
         <source>Download Coverage Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="28"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="32"/>
         <source>Area of Interest (WGS84)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="37"/>
+        <source>Use loaded mission extent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="40"/>
+        <source>Fill the AOI from the GPS positions of the currently loaded mission&apos;s images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="41"/>
-        <source>Min longitude:</source>
+        <source>Load extent from image folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="43"/>
+        <source>Read image GPS from a folder to fill the AOI (use when no mission is loaded).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="58"/>
+        <source>Min longitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="60"/>
         <source>Min latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="45"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="62"/>
         <source>Max longitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="47"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
         <source>Max latitude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="52"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="69"/>
+        <source>Footprint buffer (m):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="74"/>
+        <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="83"/>
         <source>Datasets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="54"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="85"/>
         <source>USGS 3DEP DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="56"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="87"/>
         <source>Meta/WRI Canopy Height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="95"/>
         <source>Output folder:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="66"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="97"/>
         <source>Browse...</source>
         <translation type="unfinished">Bladeren...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="72"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="103"/>
         <source>Register in Preferences when complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="78"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="81"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="112"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="88"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="119"/>
         <source>Select output folder</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
## Summary

Adds a **Coverage / Probability-of-Detection (POD) raster module**: instead of a flat union of FOV polygons, ADIAT now computes, per image, a terrain-aware detection-probability grid (`terrain visibility × canopy transmittance × GSD adequacy`) and accumulates it onto a mission-wide EPSG:3857 raster with angular-bin correlation handling, a per-frame cap (0.85), and a common-mode ceiling (0.90). The existing extent-based coverage export is kept as the fast, no-terrain mode.

### Engine (`app/core/services/coverage/`, `app/core/services/terrain/`)
- Shared lattice-snapped `GridSpec`/`GridSample` grid contract so DEM/CHM/cover co-register by construction; frame→mission accumulation is integer-offset numpy slicing (no per-frame warp).
- Ray-march kernel (48 samples/ray, quadratic schedule) for line-of-sight over the DEM; Beer–Lambert canopy attenuation; GSD adequacy ramp (2→10 cm/px, thermal preset 6→25).
- `sample_grid_spec` fast paths for USGS 3DEP local GeoTIFFs and Terrarium tiles, with **windowed COG reads** so 65k×65k Meta/WRI canopy tiles never load in full (previously a 16 GB allocation failure).
- Frame metadata read via piexif + direct XMP byte-parsing with a per-image ExifTool fallback — removes the one-ExifTool-process-per-image bottleneck.

### Canopy sources
- `CanopyService` supporting LANDFIRE EVH+EVC (30 m, class-code decode before resampling) and Meta/WRI CHM (1 m) local tiles, driven by a per-tile `product` manifest column.
- Tile fetch helper (Preferences → Download tiles…) that downloads USGS 3DEP DEM + Meta CHM tiles for an AOI and writes the manifests; AOI auto-fills from the loaded mission (or an image folder) with an editable footprint buffer.

### Outputs (written next to the exported KML in `<name>_coverage_pod/`)
- `coverage_pod.tif` — RGBA viridis heatmap GeoTIFF (EPSG:3857, alpha-tagged; auto-places in CalTopo/QGIS)
- `coverage_pod_values.tif` — single-band float32 POD probabilities (NaN = no looks), the GIS-queryable product
- `coverage_looks.tif` — uint16 look-count raster
- `coverage_gaps.geojson` — WGS84 re-tasking polygons where POD < threshold inside the flight hull
- `stats.json` — areas at POD thresholds, skip reasons, canopy/terrain provenance

### Viewer integration
- GPS map overlay with **POD / Look count / Canopy height** modes and an opacity slider; canopy mode works without a POD run when a canopy source is configured.
- Right-click cell inspect: POD %, looks, limiting factor (terrain/canopy/GSD), and jump-to contributing frames.

## Test plan

- [x] ~250 new unit tests across kernel physics (flat-plane area within 1%, ridge shadows vs brute-force LOS, closed-form Beer–Lambert, datum-shift invariance), accumulator multi-look math, writers read-back (rasterio), canopy LUT decode, fetch service (mocked HTTP), dialogs/controllers (pytest-qt)
- [x] `flake8 app/` clean on all changed files
- [x] Translations extracted + compiled (en/es/it/nl)
- [x] Manual end-to-end: POD export over a real Sierra mission with 3DEP DEM + Meta CHM tiles; verified outputs in QGIS and the in-viewer overlay/cell inspect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
