### PR TITLE
build: pin PySide6 and fix stale RangeViewer uic output path

### DIFF
--- a/app/algorithms/Shared/views/RangeViewer_ui.py
+++ b/app/algorithms/Shared/views/RangeViewer_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'RangeViewer.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.2
+## Created by: Qt User Interface Compiler version 6.10.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
+++ b/app/core/views/images/viewer/ui/GridReviewDialog_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'GridReviewDialog.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.9.2
+## Created by: Qt User Interface Compiler version 6.10.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################

--- a/pyuic.json
+++ b/pyuic.json
@@ -58,7 +58,7 @@
     ],
     [
       "resources/views/algorithms/RangeViewer.ui",
-      "app/algorithms/images/Shared/views"
+      "app/algorithms/Shared/views"
     ],
     [
       "resources/views/algorithms/MatchedFilter.ui",

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -1,4 +1,4 @@
-PySide6
+PySide6==6.10.2
 opencv-python
 numpy
 qimage2ndarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PySide6
+PySide6==6.10.2
 opencv-python
 numpy
 qimage2ndarray


### PR DESCRIPTION
## Problem

`requirements.txt` and `requirements-mac.txt` list `PySide6` with **no version constraint**, so every contributor installs whatever release is current — `6.11.1` as of today. `pyside6-uic` stamps each generated `*_ui.py` with its own version, which makes the committed UI artifacts depend on when a given contributor last ran `pip install`.

The drift is already visible in `dev`: 36 generated files are stamped `6.10.2` while two are stamped `6.9.2`, purely as a function of who regenerated them and when. The practical cost is that `python setup.py build_res` produces a large spurious diff, which buries real changes during review.

## Changes

**1. Pin `PySide6==6.10.2`** in both requirements files — matching the version the majority of the tree was generated with.

Pinned exactly rather than with a compatible-release specifier (`~=`) because stamp determinism requires an exact version. Bumping then becomes a deliberate, reviewable change rather than a side effect of when someone set up their venv.

**2. Fix a stale `pyuic.json` output path.** `fa26572` consolidated `app/algorithms/images/Shared/` into `app/algorithms/Shared/`, but `pyuic.json` still mapped `resources/views/algorithms/RangeViewer.ui` to the old `app/algorithms/images/Shared/views` path. That path holds no tracked files, so `build_res` recreated the stale directory and wrote `RangeViewer_ui.py` into it, while the live file at `app/algorithms/Shared/views/RangeViewer_ui.py` was never regenerated.

All four importers use `algorithms.Shared.views.RangeViewer_ui`, so generated output was landing where nothing reads it. This is also why that file was stuck at stamp `6.9.2` — `build_res` had not been touching it.

This was **latent, not active**: `RangeViewer.ui` has not changed since the file was last generated, so no stale UI shipped. But any future edit to `RangeViewer.ui` would have silently failed to take effect.

**3. Regenerate the two `6.9.2`-stamped files** at `6.10.2` so the tree is internally consistent.

## Verification

- uic `6.9.2` and `6.10.2` produce **byte-identical generated bodies** for every `.ui` file in this project — confirmed by regenerating and diffing; the only difference is the `## Created by:` comment. So commit 3 carries no functional change.
- After the pin, `build_res` no longer modifies any `*_ui.py`, and creates no stray files.
- Full suite run before and after the local `6.9.2 → 6.10.2` upgrade on the same commit: **identical results** (2852 passed, same 26 pre-existing failures, same 4 errors). No Qt 6.10 regressions.
- `flake8` clean on both changed Python files.
- 238 tests covering the regenerated dialogs/widgets pass.

No new functionality, so no new tests are added; this is build-configuration and generated-artifact hygiene.

## Follow-up, not included here

`build_res` is still not a true no-op, for an unrelated reason: `pyside6-rcc` embeds each resource's **file mtime** into `*_rc.py`, so all six `resources_rc.py` files regenerate with ~128 changed lines on any fresh checkout. Output is stable on a single machine but differs across machines.

`pyside6-rcc` **does** honour `SOURCE_DATE_EPOCH` (verified: same epoch → identical output, different epoch → different output). Setting a fixed value in `build_res` would make resource generation reproducible. Left out of this PR because it is a separate concern and would regenerate all six files at once — happy to open it separately if wanted.

Two dead `pyuic.json` entries also remain — `resources/views/components/*.ui` (matches no files) and `resources/views/algorithms/MotionDetectionWizard.ui` (source and target both removed upstream). Both are inert, since `build_res` globs and silently skips them. Left alone to keep this diff focused.
