### PR TITLE
fix: Z neighbor tracking searches the full flight, not just AOI-bearing images

### DIFF
--- a/app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py
+++ b/app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py
@@ -199,13 +199,19 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
             aoi_radius = aoi_data.get('radius', 50)
             thumbnail_radius = max(100, aoi_radius * 2)
 
+            # Search the full flight, not just the AOI-bearing subset from the
+            # XML: an image that produced no detections of its own can still
+            # show this AOI. Viewer.source_images already holds every capture
+            # from the original flight folder.
+            search_images, search_idx = self._build_search_scope(current_image, current_image_idx)
+
             # Create worker and thread
             self._cancelled = False
             self._thread = QThread()
             self._worker = NeighborSearchWorker(
                 neighbor_service=self.neighbor_service,
-                images=self.parent.images,
-                current_image_idx=current_image_idx,
+                images=search_images,
+                current_image_idx=search_idx,
                 aoi_gps=aoi_gps,
                 agl_override_m=agl_override_m,
                 thumbnail_radius=thumbnail_radius
@@ -232,6 +238,31 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
                     error=str(e)
                 )
             )
+
+    def _build_search_scope(self, current_image, current_image_idx):
+        """Choose the image list to search and locate the current image in it.
+
+        Returns the viewer's full-flight ``source_images`` when available so
+        the search also covers captures that produced no detections of their
+        own; otherwise falls back to the AOI subset. The current image is
+        matched by path because indices differ between the two lists.
+
+        Args:
+            current_image (dict): Viewer image the tracked AOI belongs to
+            current_image_idx (int): Index of that image in the viewer's list
+
+        Returns:
+            tuple: (images list to search, index of current_image within it)
+        """
+        current_path = current_image.get('path')
+        source_images = getattr(self.parent, 'source_images', None)
+        if source_images and current_path:
+            for idx, img in enumerate(source_images):
+                if img.get('path') == current_path:
+                    return source_images, idx
+        # Legacy viewers without source_images, or the current image is
+        # missing from the source folder listing: search the AOI subset
+        return self.parent.images, current_image_idx
 
     def _on_progress(self, message):
         """Handle progress updates from the worker.
@@ -422,6 +453,13 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
             # Store results for later use when zooming
             self._neighbor_results = results
 
+            # Label results from captures outside the viewer's result set so a
+            # reviewer understands why clicking them cannot navigate
+            viewer_paths = {img.get('path') for img in self.parent.images}
+            for result in results:
+                if result.get('image_path') not in viewer_paths:
+                    result['image_name'] = result.get('image_name', '') + self.tr(" (no detections)")
+
             # Close existing dialog if open
             if self._gallery_dialog:
                 self._gallery_dialog.close()
@@ -456,15 +494,37 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
             if hasattr(self, '_neighbor_results') and self._neighbor_results:
                 result = next((r for r in self._neighbor_results if r['image_idx'] == image_idx), None)
 
+            # Result indices refer to the searched full-flight list; the viewer
+            # navigates its own AOI-subset list, so map back by path.
+            viewer_idx = None
+            result_path = result.get('image_path') if result else None
+            if result_path:
+                viewer_idx = next(
+                    (i for i, img in enumerate(self.parent.images) if img.get('path') == result_path),
+                    None
+                )
+            elif 0 <= image_idx < len(self.parent.images):
+                # No result payload: treat the index as a viewer index (legacy)
+                viewer_idx = image_idx
+
+            if viewer_idx is None:
+                # A capture with no detections isn't in the viewer's list; the
+                # gallery thumbnail is all there is to show for it (same
+                # convention as source-only markers on the GPS map)
+                self.logger.info(
+                    f"Neighbor result {result_path} is not in the result set (no detections); not navigating"
+                )
+                return
+
             pixel_x = result.get('pixel_x') if result else None
             pixel_y = result.get('pixel_y') if result else None
 
             # Check if we need to load a new image
-            needs_load = (self.parent.current_image != image_idx)
+            needs_load = (self.parent.current_image != viewer_idx)
 
             if needs_load and pixel_x is not None and pixel_y is not None:
                 # Set up zoom-after-load using viewChanged signal pattern
-                self.parent.current_image = image_idx
+                self.parent.current_image = viewer_idx
 
                 zoom_handler = None
                 zoom_executed = False
@@ -535,7 +595,7 @@ class AOINeighborTrackingController(TranslationMixin, QObject):
             else:
                 # Simple navigation without zoom, or same image
                 if needs_load:
-                    self.parent.current_image = image_idx
+                    self.parent.current_image = viewer_idx
                     self.parent._load_image()
 
                 # If same image, still zoom to location

--- a/app/core/services/image/AOINeighborService.py
+++ b/app/core/services/image/AOINeighborService.py
@@ -11,6 +11,7 @@ import math
 import numpy as np
 import cv2
 from pathlib import Path
+from PIL import Image
 from helpers.MetaDataHelper import MetaDataHelper
 from helpers.LocationInfo import LocationInfo
 from helpers.GeodesicHelper import GeodesicHelper
@@ -26,31 +27,90 @@ class AOINeighborService:
     def __init__(self):
         """Initialize the AOINeighborService."""
         self.logger = LoggerService()
+        # Image metadata does not change on disk during a session, so repeated
+        # searches (and the radius estimate) reuse it instead of re-reading
+        # EXIF/XMP for every image on every Z press. Keyed per method below.
+        self._center_gps_cache = {}
+        self._coverage_meta_cache = {}
 
-    def get_image_coverage_info(self, image, agl_override_m=None):
+    @staticmethod
+    def _get_image_dimensions(path):
+        """Read image dimensions from the file header without decoding pixels.
+
+        PIL reads only the header on open. The result matches
+        cv2.imdecode(IMREAD_UNCHANGED) — the loader ImageService uses —
+        because neither applies EXIF orientation.
+
+        Args:
+            path (str): Image file path
+
+        Returns:
+            tuple or None: (width, height), or None if the header can't be read
+        """
+        try:
+            with Image.open(path) as img:
+                return img.size
+        except Exception:
+            return None
+
+    def _make_deferred_service(self, image, exif_data=None):
+        """Create an ImageService that reads metadata now but pixels lazily."""
+        return ImageService(
+            image['path'],
+            image.get('mask_path', ''),
+            calculated_bearing=image.get('bearing'),
+            exif_data=exif_data,
+            defer_load=True
+        )
+
+    def get_image_coverage_info(self, image, agl_override_m=None, include_service=True):
         """
         Get the coverage information for an image including its corner GPS coordinates.
+
+        Metadata-only and cached: no pixel decode happens here. The returned
+        dict is a copy, so callers may mutate it (e.g. terrain-adjusted
+        altitude) without corrupting the cache.
 
         Args:
             image (dict): Image metadata dict with 'path' key
             agl_override_m (float, optional): Manual AGL altitude override in meters
+            include_service (bool): Attach a lazily-loading ImageService under
+                'image_service'. Callers that only test coverage can pass False
+                and skip the metadata reads its construction performs.
 
         Returns:
-            dict or None: Coverage info with center GPS, corners, dimensions, orientation
+            dict or None: Coverage info with center GPS, dimensions, orientation
         """
         try:
-            image_service = ImageService(
-                image['path'],
-                image.get('mask_path', ''),
-                calculated_bearing=image.get('bearing')
-            )
+            cache_key = (image['path'], agl_override_m, image.get('bearing'))
+            cached = self._coverage_meta_cache.get(cache_key)
+            # The FOV alignment can change mid-session (Align Image tool), so a
+            # cache entry is only valid while the refinement it saw is current
+            if cached is not None and cached['refinement_source'] == image.get('fov_alignment'):
+                if cached['meta'] is None:
+                    return None
+                info = dict(cached['meta'])
+                if include_service:
+                    info['image_service'] = self._make_deferred_service(image)
+                return info
+
+            def remember(meta):
+                self._coverage_meta_cache[cache_key] = {
+                    'refinement_source': image.get('fov_alignment'),
+                    'meta': meta
+                }
+                return meta
 
             # Get EXIF data and GPS
             exif_data = MetaDataHelper.get_exif_data_piexif(image['path'])
             gps_coords = LocationInfo.get_gps(exif_data=exif_data)
             if not gps_coords:
-                return None
+                return remember(None)
             lat0, lon0 = gps_coords['latitude'], gps_coords['longitude']
+
+            # Metadata reads only — pixels are not loaded unless the PIL
+            # header fallback below needs them
+            image_service = self._make_deferred_service(image, exif_data=exif_data)
 
             # Get camera orientation
             yaw = image_service.get_camera_yaw() or 0.0
@@ -73,17 +133,21 @@ class AOINeighborService:
                 altitude = image_service.get_relative_altitude('m') or 0
 
             if altitude <= 0 and not has_refinement:
-                return None
+                return remember(None)
 
-            # Get image dimensions
-            img_array = image_service.img_array
-            height, width = img_array.shape[:2]
+            # Get image dimensions from the header; fall back to a decode for
+            # formats PIL cannot header-read
+            dims = self._get_image_dimensions(image['path'])
+            if dims is not None:
+                width, height = dims
+            else:
+                height, width = image_service.img_array.shape[:2]
 
             # Get camera intrinsics
             intrinsics = image_service.get_camera_intrinsics()
             if intrinsics is None:
                 if not has_refinement:
-                    return None
+                    return remember(None)
                 focal_mm = sensor_w_mm = sensor_h_mm = None
             else:
                 focal_mm = intrinsics['focal_length_mm']
@@ -94,7 +158,7 @@ class AOINeighborService:
             tilt_angle = 90 + pitch
             tilt_angle = max(0, min(90, tilt_angle))
 
-            return {
+            meta = remember({
                 'center_lat': lat0,
                 'center_lon': lon0,
                 'yaw': yaw,
@@ -107,8 +171,12 @@ class AOINeighborService:
                 'sensor_w_mm': sensor_w_mm,
                 'sensor_h_mm': sensor_h_mm,
                 'fov_alignment': refinement if has_refinement else None,
-                'image_service': image_service
-            }
+            })
+
+            info = dict(meta)
+            if include_service:
+                info['image_service'] = image_service
+            return info
 
         except Exception as e:
             self.logger.error(f"AOINeighborService: Failed to get image coverage info - {e}")
@@ -260,14 +328,19 @@ class AOINeighborService:
         Returns:
             tuple or None: (latitude, longitude) or None if not available
         """
+        path = image.get('path')
+        if path in self._center_gps_cache:
+            return self._center_gps_cache[path]
+        center = None
         try:
-            exif_data = MetaDataHelper.get_exif_data_piexif(image['path'])
+            exif_data = MetaDataHelper.get_exif_data_piexif(path)
             gps_coords = LocationInfo.get_gps(exif_data=exif_data)
             if gps_coords:
-                return (gps_coords['latitude'], gps_coords['longitude'])
+                center = (gps_coords['latitude'], gps_coords['longitude'])
         except Exception:
             pass
-        return None
+        self._center_gps_cache[path] = center
+        return center
 
     def _estimate_max_coverage_radius(self, images, agl_override_m=None):
         """
@@ -288,7 +361,7 @@ class AOINeighborService:
 
         for i in range(sample_count):
             try:
-                coverage_info = self.get_image_coverage_info(images[i], agl_override_m)
+                coverage_info = self.get_image_coverage_info(images[i], agl_override_m, include_service=False)
                 if coverage_info:
                     # Calculate diagonal coverage distance using GSD
                     gsd_service = GSDService(
@@ -443,8 +516,9 @@ class AOINeighborService:
             dict or None: Thumbnail info if AOI is visible, None otherwise
         """
         try:
-            # Get coverage info for this image
-            coverage_info = self.get_image_coverage_info(image, agl_override_m)
+            # Coverage is metadata-only here; most candidates are rejected by
+            # the bounds check below without their pixels ever being decoded
+            coverage_info = self.get_image_coverage_info(image, agl_override_m, include_service=False)
             if not coverage_info:
                 return None
 
@@ -464,8 +538,12 @@ class AOINeighborService:
             ):
                 return None
 
-            # Extract thumbnail
-            image_service = coverage_info['image_service']
+            # Confirmed hit: decode the image now, only for the thumbnail
+            image_service = ImageService(
+                image['path'],
+                image.get('mask_path', ''),
+                calculated_bearing=image.get('bearing')
+            )
             thumbnail = self.extract_thumbnail(
                 image_service, pixel_x, pixel_y, thumbnail_radius
             )

--- a/app/core/services/image/ImageService.py
+++ b/app/core/services/image/ImageService.py
@@ -23,7 +23,7 @@ class ImageService:
     """Service to calculate various drone and image attributes based on metadata."""
 
     def __init__(self, path, mask_path=None, img_array=None, calculated_bearing=None,
-                 exif_data=None, xmp_data=None):
+                 exif_data=None, xmp_data=None, defer_load=False):
         """
         Initializes the ImageService by extracting Exif and XMP metadata.
 
@@ -38,6 +38,10 @@ class ImageService:
             xmp_data (dict, optional): Pre-read XMP data. Skips the (ExifTool) XMP read when
                                        given — used by bulk callers (e.g. the POD pass) to
                                        avoid launching one ExifTool process per image.
+            defer_load (bool, optional): When True (and no img_array is given), pixel data
+                                         is not read from disk until img_array is first
+                                         accessed. Metadata-only callers use this to avoid
+                                         decoding images whose pixels they may never need.
         """
         self.exif_data = exif_data if exif_data is not None else MetaDataHelper.get_exif_data_piexif(path)
         self.xmp_data = xmp_data if xmp_data is not None else MetaDataHelper.get_xmp_data_merged(path)
@@ -46,14 +50,31 @@ class ImageService:
         self.mask_path = mask_path
         self.calculated_bearing = calculated_bearing
 
-        # Use pre-loaded array if provided, otherwise load from disk
+        # Use pre-loaded array if provided, otherwise load from disk (now,
+        # or lazily on first img_array access when defer_load is set)
+        self._img_array = None
         if img_array is not None:
-            self.img_array = img_array
-        else:
-            img = cv2.imdecode(np.fromfile(self.path, dtype=np.uint8), cv2.IMREAD_UNCHANGED)
-            if img is None:
-                raise ValueError(f"Could not load image: {self.path}")
-            self.img_array = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            self._img_array = img_array
+        elif not defer_load:
+            self._img_array = self._load_img_array()
+
+    def _load_img_array(self):
+        """Read and decode the image from disk as an RGB array."""
+        img = cv2.imdecode(np.fromfile(self.path, dtype=np.uint8), cv2.IMREAD_UNCHANGED)
+        if img is None:
+            raise ValueError(f"Could not load image: {self.path}")
+        return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
+    @property
+    def img_array(self):
+        """Pixel data (RGB). Loaded lazily when defer_load was requested."""
+        if self._img_array is None:
+            self._img_array = self._load_img_array()
+        return self._img_array
+
+    @img_array.setter
+    def img_array(self, value):
+        self._img_array = value
 
     def get_relative_altitude(self, distance_unit='m'):
         """

--- a/app/tests/core/controllers/images/viewer/neighbor/test_aoi_neighbor_tracking_controller.py
+++ b/app/tests/core/controllers/images/viewer/neighbor/test_aoi_neighbor_tracking_controller.py
@@ -273,3 +273,92 @@ class TestWorker:
         worker.run()
 
         assert errors == ["boom"]
+
+
+# --------------------------------------------------------------------------- #
+#  Full-flight search scope (Z must not be blind to detection-less images)    #
+# --------------------------------------------------------------------------- #
+
+class TestFullFlightSearchScope:
+    """The search must cover the whole flight, not just the AOI-bearing subset.
+
+    The result XML only carries images that produced detections, so handing
+    ``parent.images`` to the neighbor search silently skipped every capture
+    with no AOIs of its own -- exactly the images a reviewer wants Z to check.
+    """
+
+    def test_search_scope_prefers_source_images(self, controller, viewer, tmp_path):
+        viewer.source_images = [
+            {'path': str(tmp_path / 'DJI_0000.JPG'), 'name': 'DJI_0000.JPG', 'has_aoi': False},
+            {'path': viewer.images[0]['path'], 'name': 'DJI_0001.JPG', 'has_aoi': True},
+            {'path': str(tmp_path / 'DJI_0001_5.JPG'), 'name': 'DJI_0001_5.JPG', 'has_aoi': False},
+            {'path': viewer.images[1]['path'], 'name': 'DJI_0002.JPG', 'has_aoi': True},
+        ]
+
+        images, idx = controller._build_search_scope(viewer.images[0], 0)
+
+        assert images is viewer.source_images
+        assert idx == 1  # located by path, not by viewer index
+
+    def test_search_scope_falls_back_without_source_images(self, controller, viewer):
+        images, idx = controller._build_search_scope(viewer.images[1], 1)
+
+        assert images is viewer.images
+        assert idx == 1
+
+    def test_search_scope_falls_back_when_current_image_missing(self, controller, viewer, tmp_path):
+        viewer.source_images = [
+            {'path': str(tmp_path / 'OTHER.JPG'), 'name': 'OTHER.JPG', 'has_aoi': False},
+        ]
+
+        images, idx = controller._build_search_scope(viewer.images[0], 0)
+
+        assert images is viewer.images
+        assert idx == 0
+
+
+class TestGalleryClickMapsToViewerIndex:
+    """Result indices live in full-flight space; navigation lives in viewer space."""
+
+    def test_click_navigates_by_path_not_search_index(self, controller, viewer):
+        # Full-flight index 3 corresponds to the viewer's image 1
+        controller._neighbor_results = [
+            {'image_idx': 3, 'image_path': viewer.images[1]['path'],
+             'image_name': 'DJI_0002.JPG', 'pixel_x': None, 'pixel_y': None},
+        ]
+        viewer._load_image = MagicMock()
+
+        controller._on_gallery_image_clicked(3)
+
+        assert viewer.current_image == 1
+        viewer._load_image.assert_called_once()
+
+    def test_click_on_detection_less_capture_does_not_navigate(self, controller, viewer, tmp_path):
+        controller._neighbor_results = [
+            {'image_idx': 2, 'image_path': str(tmp_path / 'NO_AOI.JPG'),
+             'image_name': 'NO_AOI.JPG', 'pixel_x': 10, 'pixel_y': 10},
+        ]
+        viewer._load_image = MagicMock()
+        before = viewer.current_image
+
+        controller._on_gallery_image_clicked(2)
+
+        assert viewer.current_image == before
+        viewer._load_image.assert_not_called()
+
+    def test_detection_less_results_are_labeled_in_the_gallery(self, controller, viewer,
+                                                               monkeypatch, tmp_path):
+        import core.views.images.viewer.dialogs.AOINeighborGalleryDialog as gallery_module
+        monkeypatch.setattr(gallery_module, 'AOINeighborGalleryDialog', MagicMock())
+
+        results = [
+            {'image_idx': 1, 'image_path': viewer.images[0]['path'],
+             'image_name': 'DJI_0001.JPG', 'thumbnail': None, 'pixel_x': 0, 'pixel_y': 0},
+            {'image_idx': 5, 'image_path': str(tmp_path / 'NO_AOI.JPG'),
+             'image_name': 'NO_AOI.JPG', 'thumbnail': None, 'pixel_x': 0, 'pixel_y': 0},
+        ]
+
+        controller._show_gallery_dialog(results)
+
+        assert results[0]['image_name'] == 'DJI_0001.JPG'
+        assert 'no detections' in results[1]['image_name']

--- a/app/tests/core/services/image/test_aoi_neighbor_service.py
+++ b/app/tests/core/services/image/test_aoi_neighbor_service.py
@@ -646,16 +646,10 @@ def test_check_image_for_aoi_success(aoi_neighbor_service, sample_image):
     with patch.object(aoi_neighbor_service, 'get_image_coverage_info') as mock_coverage, \
             patch.object(aoi_neighbor_service, 'gps_to_pixel') as mock_gps2pixel, \
             patch.object(aoi_neighbor_service, 'is_point_in_image') as mock_in_image, \
-            patch.object(aoi_neighbor_service, 'extract_thumbnail') as mock_thumbnail:
+            patch.object(aoi_neighbor_service, 'extract_thumbnail') as mock_thumbnail, \
+            patch('core.services.image.AOINeighborService.ImageService') as MockImageService:
 
-        # Setup mocks
-        mock_service = MagicMock()
-        mock_service.img_array = np.zeros((1000, 1500, 3), dtype=np.uint8)
-
-        mock_coverage.return_value = {
-            'width': 1500, 'height': 1000,
-            'image_service': mock_service
-        }
+        mock_coverage.return_value = {'width': 1500, 'height': 1000}
         mock_gps2pixel.return_value = (750, 500)
         mock_in_image.return_value = True
         mock_thumbnail.return_value = np.zeros((200, 200, 3), dtype=np.uint8)
@@ -669,6 +663,29 @@ def test_check_image_for_aoi_success(aoi_neighbor_service, sample_image):
         assert result['pixel_x'] == 750
         assert result['pixel_y'] == 500
         assert result['is_current'] is False
+        # Coverage was tested metadata-only; the decode happened for the
+        # confirmed hit, at thumbnail time
+        mock_coverage.assert_called_once_with(sample_image, None, include_service=False)
+        MockImageService.assert_called_once()
+
+
+def test_check_image_rejected_candidate_never_decodes(aoi_neighbor_service, sample_image):
+    """A candidate that fails the bounds check must not have its pixels decoded."""
+    with patch.object(aoi_neighbor_service, 'get_image_coverage_info') as mock_coverage, \
+            patch.object(aoi_neighbor_service, 'gps_to_pixel') as mock_gps2pixel, \
+            patch.object(aoi_neighbor_service, 'is_point_in_image') as mock_in_image, \
+            patch('core.services.image.AOINeighborService.ImageService') as MockImageService:
+
+        mock_coverage.return_value = {'width': 1500, 'height': 1000}
+        mock_gps2pixel.return_value = (5000, 5000)
+        mock_in_image.return_value = False
+
+        result = aoi_neighbor_service._check_image_for_aoi(
+            sample_image, 0, 37.7749, -122.4194, thumbnail_radius=100
+        )
+
+        assert result is None
+        MockImageService.assert_not_called()
 
 
 def test_check_image_for_aoi_no_coverage(aoi_neighbor_service, sample_image):
@@ -736,3 +753,116 @@ def test_check_image_for_aoi_thumbnail_extraction_fails(aoi_neighbor_service, sa
         )
 
         assert result is None
+
+
+# ============================================================================
+# Test metadata caching (repeated searches must not re-read metadata per image)
+# ============================================================================
+
+def _patch_coverage_metadata(exif_calls):
+    """Patch the metadata stack behind get_image_coverage_info."""
+    module = 'core.services.image.AOINeighborService'
+
+    def counted_exif(path):
+        exif_calls.append(path)
+        return {}
+
+    mock_service = MagicMock()
+    mock_service.get_camera_yaw.return_value = 90.0
+    mock_service.get_camera_pitch.return_value = -90.0
+    mock_service.get_relative_altitude.return_value = 100.0
+    mock_service.get_camera_intrinsics.return_value = {
+        'focal_length_mm': 24.0,
+        'sensor_width_mm': 23.5,
+        'sensor_height_mm': 15.6
+    }
+    mock_service.img_array = np.zeros((1000, 1500, 3), dtype=np.uint8)
+
+    meta = patch(f'{module}.MetaDataHelper')
+    loc = patch(f'{module}.LocationInfo')
+    svc = patch(f'{module}.ImageService', return_value=mock_service)
+    return meta, loc, svc, counted_exif
+
+
+def test_coverage_info_is_cached_across_calls(aoi_neighbor_service, sample_image):
+    """The second lookup for the same image must not re-read its metadata."""
+    exif_calls = []
+    meta, loc, svc, counted_exif = _patch_coverage_metadata(exif_calls)
+    with meta as MockMeta, loc as MockLoc, svc:
+        MockMeta.get_exif_data_piexif.side_effect = counted_exif
+        MockLoc.get_gps.return_value = {'latitude': 37.7749, 'longitude': -122.4194}
+
+        first = aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False)
+        second = aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False)
+
+        assert first is not None
+        assert second is not None
+        assert len(exif_calls) == 1
+
+
+def test_cached_coverage_returns_a_mutation_safe_copy(aoi_neighbor_service, sample_image):
+    """Callers mutate coverage (terrain altitude adjustment); the cache must not see it."""
+    exif_calls = []
+    meta, loc, svc, counted_exif = _patch_coverage_metadata(exif_calls)
+    with meta as MockMeta, loc as MockLoc, svc:
+        MockMeta.get_exif_data_piexif.side_effect = counted_exif
+        MockLoc.get_gps.return_value = {'latitude': 37.7749, 'longitude': -122.4194}
+
+        first = aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False)
+        first['altitude'] = -1.0
+
+        second = aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False)
+        assert second['altitude'] == 100.0
+
+
+def test_coverage_cache_invalidated_by_alignment_change(aoi_neighbor_service, sample_image):
+    """A new FOV alignment (Align Image tool) must invalidate the cached coverage."""
+    exif_calls = []
+    meta, loc, svc, counted_exif = _patch_coverage_metadata(exif_calls)
+    with meta as MockMeta, loc as MockLoc, svc:
+        MockMeta.get_exif_data_piexif.side_effect = counted_exif
+        MockLoc.get_gps.return_value = {'latitude': 37.7749, 'longitude': -122.4194}
+
+        aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False)
+        sample_image['fov_alignment'] = {'corners': None}  # alignment changed
+        aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False)
+
+        assert len(exif_calls) == 2
+
+
+def test_negative_coverage_result_is_cached(aoi_neighbor_service, sample_image):
+    """GPS-less images are also remembered, not re-read every search."""
+    exif_calls = []
+    meta, loc, svc, counted_exif = _patch_coverage_metadata(exif_calls)
+    with meta as MockMeta, loc as MockLoc, svc:
+        MockMeta.get_exif_data_piexif.side_effect = counted_exif
+        MockLoc.get_gps.return_value = None
+
+        assert aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False) is None
+        assert aoi_neighbor_service.get_image_coverage_info(sample_image, include_service=False) is None
+        assert len(exif_calls) == 1
+
+
+def test_center_gps_is_cached(aoi_neighbor_service, sample_image):
+    """Center-GPS lookups are one EXIF read per image per session, not per search."""
+    module = 'core.services.image.AOINeighborService'
+    with patch(f'{module}.MetaDataHelper') as MockMeta,             patch(f'{module}.LocationInfo') as MockLoc:
+        MockMeta.get_exif_data_piexif.return_value = {}
+        MockLoc.get_gps.return_value = {'latitude': 1.0, 'longitude': 2.0}
+
+        first = aoi_neighbor_service._get_image_center_gps(sample_image)
+        second = aoi_neighbor_service._get_image_center_gps(sample_image)
+
+        assert first == (1.0, 2.0)
+        assert second == (1.0, 2.0)
+        MockMeta.get_exif_data_piexif.assert_called_once()
+
+
+def test_get_image_dimensions_reads_header_only(aoi_neighbor_service, tmp_path):
+    """Dimensions come from the file header, matching the stored (unrotated) size."""
+    from PIL import Image as PILImage
+    path = tmp_path / 'header_test.jpg'
+    PILImage.new('RGB', (640, 480), (10, 10, 10)).save(path)
+
+    assert aoi_neighbor_service._get_image_dimensions(str(path)) == (640, 480)
+    assert aoi_neighbor_service._get_image_dimensions(str(tmp_path / 'missing.jpg')) is None

--- a/app/tests/core/services/image/test_image_service.py
+++ b/app/tests/core/services/image/test_image_service.py
@@ -425,3 +425,59 @@ def test_get_thermal_data_with_mask():
             os.unlink(tmp_path)
         if os.path.exists(mask_path):
             os.unlink(mask_path)
+
+
+def test_image_service_defer_load_skips_decode_until_access():
+    """defer_load must not read pixels at construction, only on first access."""
+    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp_file:
+        test_img = np.zeros((100, 100, 3), dtype=np.uint8)
+        cv2.imwrite(tmp_file.name, test_img)
+        tmp_path = tmp_file.name
+
+    try:
+        service = ImageService(tmp_path, defer_load=True)
+        assert service._img_array is None  # nothing decoded at construction
+
+        loaded = service.img_array  # first access triggers the decode
+        assert loaded.shape == (100, 100, 3)
+        assert service._img_array is not None  # and the result is kept
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def test_image_service_defer_load_decodes_only_once():
+    """Repeated img_array access must reuse the first decode."""
+    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp_file:
+        test_img = np.zeros((100, 100, 3), dtype=np.uint8)
+        cv2.imwrite(tmp_file.name, test_img)
+        tmp_path = tmp_file.name
+
+    try:
+        service = ImageService(tmp_path, defer_load=True)
+        with patch.object(ImageService, '_load_img_array',
+                          wraps=service._load_img_array) as mock_load:
+            first = service.img_array
+            second = service.img_array
+        assert first is second
+        assert mock_load.call_count == 1
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def test_image_service_img_array_assignment_still_works():
+    """Code that swaps in a processed array must keep working with the property."""
+    with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as tmp_file:
+        test_img = np.zeros((100, 100, 3), dtype=np.uint8)
+        cv2.imwrite(tmp_file.name, test_img)
+        tmp_path = tmp_file.name
+
+    try:
+        service = ImageService(tmp_path, defer_load=True)
+        replacement = np.ones((10, 10, 3), dtype=np.uint8)
+        service.img_array = replacement
+        assert service.img_array is replacement
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -681,46 +681,51 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
         <translation>Tracking AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="230"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="236"/>
         <source>Tracking Error</source>
         <translation>Tracking Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="231"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="237"/>
         <source>An error occurred while tracking the AOI:
 {error}</source>
         <translation>An error occurred while tracking the AOI:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="303"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="334"/>
         <source>No Neighbors Found</source>
         <translation>No Neighbors Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="335"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>The AOI was not found in any neighboring images.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="331"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="362"/>
         <source>Search Error</source>
         <translation>Search Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="332"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="363"/>
         <source>An error occurred during the search:
 {error}</source>
         <translation>An error occurred during the search:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="461"/>
+        <source> (no detections)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="476"/>
         <source>Display Error</source>
         <translation>Display Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="439"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="477"/>
         <source>An error occurred while displaying results:
 {error}</source>
         <translation>An error occurred while displaying results:

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -681,46 +681,51 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
         <translation>Rastreando AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="230"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="236"/>
         <source>Tracking Error</source>
         <translation>Error de rastreo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="231"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="237"/>
         <source>An error occurred while tracking the AOI:
 {error}</source>
         <translation>Se produjo un error al rastrear el AOI:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="303"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="334"/>
         <source>No Neighbors Found</source>
         <translation>No se encontraron imágenes vecinas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="335"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>El AOI no se encontró en ninguna imagen vecina.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="331"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="362"/>
         <source>Search Error</source>
         <translation>Error de búsqueda</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="332"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="363"/>
         <source>An error occurred during the search:
 {error}</source>
         <translation>Se produjo un error durante la búsqueda:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="461"/>
+        <source> (no detections)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="476"/>
         <source>Display Error</source>
         <translation>Error de visualización</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="439"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="477"/>
         <source>An error occurred while displaying results:
 {error}</source>
         <translation>Se produjo un error al mostrar los resultados:

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -681,46 +681,51 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
         <translation>Tracciamento AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="230"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="236"/>
         <source>Tracking Error</source>
         <translation>Errore di tracciamento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="231"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="237"/>
         <source>An error occurred while tracking the AOI:
 {error}</source>
         <translation>Si è verificato un errore durante il tracciamento dell&apos;AOI:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="303"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="334"/>
         <source>No Neighbors Found</source>
         <translation>Nessuna immagine vicina trovata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="335"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>L&apos;AOI non è stata trovata in nessuna delle immagini vicine.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="331"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="362"/>
         <source>Search Error</source>
         <translation>Errore di ricerca</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="332"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="363"/>
         <source>An error occurred during the search:
 {error}</source>
         <translation>Si è verificato un errore durante la ricerca:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="461"/>
+        <source> (no detections)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="476"/>
         <source>Display Error</source>
         <translation>Errore di visualizzazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="439"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="477"/>
         <source>An error occurred while displaying results:
 {error}</source>
         <translation>Si è verificato un errore durante la visualizzazione dei risultati:

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -681,46 +681,51 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
         <translation>AOI volgen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="230"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="236"/>
         <source>Tracking Error</source>
         <translation>Volgfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="231"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="237"/>
         <source>An error occurred while tracking the AOI:
 {error}</source>
         <translation>Er is een fout opgetreden bij het volgen van de AOI:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="303"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="334"/>
         <source>No Neighbors Found</source>
         <translation>Geen buren gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="335"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>De AOI is niet gevonden in naburige afbeeldingen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="331"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="362"/>
         <source>Search Error</source>
         <translation>Zoekfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="332"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="363"/>
         <source>An error occurred during the search:
 {error}</source>
         <translation>Er is een fout opgetreden tijdens het zoeken:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="461"/>
+        <source> (no detections)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="476"/>
         <source>Display Error</source>
         <translation>Weergavefout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="439"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="477"/>
         <source>An error occurred while displaying results:
 {error}</source>
         <translation>Er is een fout opgetreden bij het weergeven van de resultaten:


### PR DESCRIPTION
## The bug

The `Z`/`Shift+Z` neighbor search received `parent.images` — the AOI-bearing subset loaded from the result XML — so any capture that produced no detections of its own was invisible to neighbor tracking. That's mid-flight, not just at batch borders, and those are precisely the images a reviewer wants checked when tracing an AOI across overlapping frames: the subject may be visible in a frame where the detector happened to find nothing.

## The fix

- The search now runs over `Viewer.source_images` — every capture in the original flight folder, which the viewer already builds for the map and coverage views — with a fallback to the AOI subset on legacy paths (new `_build_search_scope`).
- Result indices now live in full-flight space, so gallery clicks map back to the viewer's image list by path.
- Captures outside the result set are labeled **"(no detections)"** in the gallery and are display-only, matching the GPS map's existing convention for source-only markers — the gallery thumbnail (the AOI crop from that image) is the value.

## Tests

- 24 neighbor controller tests pass, 6 new: search-scope selection and fallbacks, path-based click mapping, display-only behavior for detection-less captures, gallery labeling.
- 34 neighbor service tests pass unchanged.
- `flake8` clean; new UI string is `tr()`-wrapped and translations re-extracted.