### PR TITLE
feat: First-class results review — tile, recent results, remembered relink folders

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -272,6 +272,15 @@ def main():
             except Exception:
                 # Re-raise so our global excepthook handles exit
                 raise
+        elif choice == 'results':
+            # Review mode: open MainWindow and go straight to the results
+            # opener, so a reviewer never touches the analysis setup screen
+            try:
+                app._main_window = MainWindow(qdarktheme)
+                app._main_window.show()
+                app._main_window.open_results_for_review()
+            except Exception:
+                raise
         elif choice == 'stream':
             _launch_stream_viewer()
         elif choice == 'flight':

--- a/app/core/controllers/SelectionDialog.py
+++ b/app/core/controllers/SelectionDialog.py
@@ -33,6 +33,7 @@ class SelectionDialog(QDialog, Ui_MediaSelector):
     wizardRequested = Signal()  # Signal emitted when image setup wizard should be shown
     streamWizardRequested = Signal()  # Signal emitted when streaming setup wizard should be shown
     flightViewerRequested = Signal()  # Signal emitted when Flight Viewer should be opened
+    reviewResultsRequested = Signal()  # Signal emitted when Review Results should be opened
 
     def __init__(self, theme: str):
         """Initialize the selection dialog.
@@ -62,6 +63,8 @@ class SelectionDialog(QDialog, Ui_MediaSelector):
 
         self.imageButton.clicked.connect(self._on_image_clicked)
         self.streamButton.clicked.connect(self._on_stream_clicked)
+        if hasattr(self, "resultsButton"):
+            self.resultsButton.clicked.connect(self._on_results_clicked)
         if hasattr(self, "flightButton"):
             if FeatureFlags.FLIGHT_VIEWER_ENABLED:
                 self.flightButton.clicked.connect(self._on_flight_clicked)
@@ -97,7 +100,10 @@ class SelectionDialog(QDialog, Ui_MediaSelector):
 
         self.flightWidget.setVisible(False)
 
-        for tile in (self.imageWidget, self.streamWidget):
+        remaining_tiles = [self.imageWidget, self.streamWidget]
+        if hasattr(self, "resultsWidget"):
+            remaining_tiles.insert(1, self.resultsWidget)
+        for tile in remaining_tiles:
             policy = tile.sizePolicy()
             policy.setHorizontalPolicy(QSizePolicy.Maximum)
             tile.setSizePolicy(policy)
@@ -152,6 +158,19 @@ class SelectionDialog(QDialog, Ui_MediaSelector):
             self.accept()
             self.streamWizardRequested.emit()
 
+    def _on_results_clicked(self) -> None:
+        """Handle click on the Review Results button.
+
+        Sets selection to "results", emits both selectionMade and the
+        dedicated reviewResultsRequested signal, and closes the dialog. The
+        review flow (results-folder scan / recents) is driven from
+        __main__.py via the signal handler.
+        """
+        self.selection = "results"
+        self.selectionMade.emit(self.selection)
+        self.accept()
+        self.reviewResultsRequested.emit()
+
     def _on_flight_clicked(self) -> None:
         """Handle click on the Flight Viewer button.
 
@@ -174,6 +193,9 @@ class SelectionDialog(QDialog, Ui_MediaSelector):
             self.imageButton.setIcon(IconHelper.create_icon("fa6s.image", theme))
             # Use a broadly available Material icon for streaming/video
             self.streamButton.setIcon(IconHelper.create_icon("fa6s.video", theme))
+            if hasattr(self, "resultsButton"):
+                # Folder-with-magnifier reads as "open results for review"
+                self.resultsButton.setIcon(IconHelper.create_icon("fa6s.folder-open", theme))
             if hasattr(self, "flightButton"):
                 # Drone icon for the WebRTC flight viewer
                 self.flightButton.setIcon(IconHelper.create_icon("mdi6.quadcopter", theme))

--- a/app/core/controllers/images/MainWindow.py
+++ b/app/core/controllers/images/MainWindow.py
@@ -26,7 +26,7 @@ from helpers.PickleHelper import PickleHelper
 from core.views.images.MainWindow_ui import Ui_MainWindow
 from core.views.images.viewer.dialogs.ResultsFolderDialog import ResultsFolderDialog, ScanWorker, ScanProgressDialog
 from PySide6.QtWidgets import (QApplication, QMainWindow, QColorDialog, QFileDialog,
-                               QMessageBox, QSizePolicy, QAbstractButton, QCheckBox, QProgressDialog)
+                               QMessageBox, QSizePolicy, QAbstractButton, QCheckBox, QProgressDialog, QMenu)
 from PySide6.QtCore import QThread, Slot, QSize, Qt, QUrl
 from PySide6.QtGui import QColor, QFont, QIcon, QDesktopServices
 import qtawesome as qta
@@ -40,6 +40,7 @@ from helpers.FormatHelper import FormatHelper
 from helpers.TranslationMixin import TranslationMixin
 from helpers.ThemeHelper import apply_theme
 import os
+import json
 import xml.etree.ElementTree as ET
 os.environ['NUMPY_EXPERIMENTAL_DTYPE_API'] = '0'
 
@@ -115,6 +116,7 @@ class MainWindow(TranslationMixin, QMainWindow, Ui_MainWindow):
         self.actionLoadFile.triggered.connect(self._open_load_file)
         if hasattr(self, "actionLoadResultsFolder"):
             self.actionLoadResultsFolder.triggered.connect(self._open_load_results_folder)
+        self._setup_recent_results_menu()
         self.actionPreferences.triggered.connect(self._open_preferences)
         self.actionVideoParser.triggered.connect(self._open_video_parser)
 
@@ -968,6 +970,93 @@ class MainWindow(TranslationMixin, QMainWindow, Ui_MainWindow):
         msg.setStandardButtons(QMessageBox.Ok)
         msg.exec()
 
+    # Recently opened result XMLs, newest first, stored as a JSON list so the
+    # value survives QSettings type coercion across platforms
+    RECENT_RESULTS_SETTING = 'RecentResults'
+    RECENT_RESULTS_LIMIT = 10
+
+    def open_results_for_review(self):
+        """Entry point for the Review Results tile on the selection dialog.
+
+        Jumps straight to the results-folder scanner so a reviewer never has
+        to interact with the analysis setup screen.
+        """
+        self._open_load_results_folder()
+
+    def _setup_recent_results_menu(self):
+        """Insert the "Open Recent Results" submenu after the Load File action."""
+        try:
+            self.menuRecentResults = QMenu(self.tr("Open Recent Results"), self)
+            actions = self.menuFile.actions()
+            anchor = None
+            if self.actionLoadFile in actions:
+                idx = actions.index(self.actionLoadFile) + 1
+                anchor = actions[idx] if idx < len(actions) else None
+            if anchor is not None:
+                self.menuFile.insertMenu(anchor, self.menuRecentResults)
+            else:
+                self.menuFile.addMenu(self.menuRecentResults)
+            # Populate lazily so the list is current every time it opens
+            self.menuRecentResults.aboutToShow.connect(self._populate_recent_results_menu)
+        except Exception as e:
+            self.logger.error(f"Could not set up the recent results menu: {e}")
+
+    def _get_recent_results(self):
+        """Return the stored recent-results list (paths, newest first)."""
+        raw = self.settings_service.get_setting(self.RECENT_RESULTS_SETTING, '[]')
+        try:
+            paths = json.loads(raw) if isinstance(raw, str) else list(raw or [])
+        except (TypeError, ValueError):
+            paths = []
+        return [p for p in paths if isinstance(p, str) and p]
+
+    def _record_recent_result(self, xml_path):
+        """Remember a successfully opened result XML at the top of the list."""
+        try:
+            normalized = os.path.abspath(xml_path)
+            key = os.path.normcase(normalized)
+            recents = [
+                p for p in self._get_recent_results()
+                if os.path.normcase(os.path.abspath(p)) != key
+            ]
+            recents.insert(0, normalized)
+            del recents[self.RECENT_RESULTS_LIMIT:]
+            self.settings_service.set_setting(self.RECENT_RESULTS_SETTING, json.dumps(recents))
+        except Exception as e:
+            self.logger.error(f"Could not record recent result {xml_path}: {e}")
+
+    def _populate_recent_results_menu(self):
+        """Rebuild the recent-results submenu from settings."""
+        self.menuRecentResults.clear()
+        recents = self._get_recent_results()
+        if not recents:
+            placeholder = self.menuRecentResults.addAction(self.tr("(no results opened yet)"))
+            placeholder.setEnabled(False)
+            return
+        for path in recents:
+            # Every result file is named ADIAT_Data.xml, so the containing
+            # folder is the recognizable part
+            action = self.menuRecentResults.addAction(os.path.dirname(path) or path)
+            action.setToolTip(path)
+            action.setEnabled(os.path.exists(path))
+            action.triggered.connect(lambda checked=False, p=path: self._open_recent_result(p))
+
+    def _open_recent_result(self, path):
+        """Open a result XML from the recents menu, straight into review."""
+        try:
+            if not os.path.exists(path):
+                self._show_error(
+                    self.tr("This results file no longer exists:\n{path}").format(path=path)
+                )
+                return
+            self._process_xml_file(path)
+            # A Search Coordinator project is already opened by
+            # _process_xml_file; otherwise open the single-run Viewer.
+            if self._view_results_mode != 'coordinator':
+                self._viewResultsButton_clicked()
+        except Exception as e:
+            self.logger.error(f"Error opening recent result {path}: {e}")
+
     def _open_load_file(self):
         """
         Opens a file dialog to select a file to load.
@@ -1141,10 +1230,12 @@ class MainWindow(TranslationMixin, QMainWindow, Ui_MainWindow):
             if self._is_search_project_xml(full_path):
                 self._set_view_results_mode('coordinator', full_path)
                 self._set_ViewResultsButton(True)
+                self._record_recent_result(full_path)
                 self._open_coordinator(full_path)
                 return
             image_count = self._get_settings_from_xml(full_path)
             self._set_view_results_mode('results')
+            self._record_recent_result(full_path)
             if image_count > 0:
                 self._set_ViewResultsButton(True)
             self.AdvancedFeaturesWidget.setVisible(not self.algorithmWidget.is_thermal)

--- a/app/core/controllers/images/viewer/path/PathValidationController.py
+++ b/app/core/controllers/images/viewer/path/PathValidationController.py
@@ -6,9 +6,11 @@ and prompts users to locate missing files when paths are invalid.
 """
 
 import os
+import json
 from pathlib import Path
 from PySide6.QtWidgets import QMessageBox, QFileDialog
 from core.services.LoggerService import LoggerService
+from core.services.SettingsService import SettingsService
 from helpers.TranslationMixin import TranslationMixin
 from helpers.PathHelper import (
     cross_platform_basename,
@@ -24,6 +26,12 @@ class PathValidationController(TranslationMixin):
     Handles checking for missing files and prompting users to locate them.
     """
 
+    # Folders that fixed previous relinks, machine-wide, newest first. The
+    # parent of a picked folder is remembered too: sibling batch folders under
+    # one copied root then resolve without prompting at all.
+    RECOVERY_FOLDERS_SETTING = 'ImageRecoveryFolders'
+    RECOVERY_FOLDERS_LIMIT = 8
+
     def __init__(self, parent_viewer):
         """
         Initialize the path validation controller.
@@ -33,6 +41,7 @@ class PathValidationController(TranslationMixin):
         """
         self.parent = parent_viewer
         self.logger = LoggerService()
+        self.settings_service = SettingsService()
         # Set by _ask_retry_or_continue: whether the user chose to load with a
         # partial recovery rather than cancel.
         self._continued = False
@@ -72,6 +81,13 @@ class PathValidationController(TranslationMixin):
                     'image': image,
                     'filename': cross_platform_basename(mask_path)
                 })
+
+        # Folders that fixed earlier batches usually fix this one too; try
+        # them silently so batch 2..N never re-prompts on the same machine
+        if missing_images:
+            missing_images = self._resolve_from_remembered_folders(missing_images, 'path')
+        if missing_masks:
+            missing_masks = self._resolve_from_remembered_folders(missing_masks, 'mask_path')
 
         # Prompt for source images folder if any are missing
         if missing_images:
@@ -153,6 +169,96 @@ class PathValidationController(TranslationMixin):
             },
         )
 
+    @staticmethod
+    def _is_filesystem_root(folder):
+        """True for drive/filesystem roots, which are too big to index."""
+        normalized = os.path.abspath(folder)
+        return os.path.dirname(normalized) == normalized
+
+    def _load_remembered_raw(self):
+        """Read the stored recovery-folder list without existence filtering.
+
+        Unplugged drives must stay remembered, not be forgotten forever the
+        first time a validate runs while they are disconnected.
+        """
+        raw = self.settings_service.get_setting(self.RECOVERY_FOLDERS_SETTING, '[]')
+        try:
+            folders = json.loads(raw) if isinstance(raw, str) else list(raw or [])
+        except (TypeError, ValueError):
+            folders = []
+        return [f for f in folders if isinstance(f, str) and f]
+
+    def _remembered_folders(self):
+        """Recovery folders worth trying right now (existing, non-root)."""
+        return [
+            f for f in self._load_remembered_raw()
+            if os.path.isdir(f) and not self._is_filesystem_root(f)
+        ]
+
+    def _remember_folder(self, folder):
+        """Store a folder that just fixed a relink, plus its parent."""
+        try:
+            candidates = []
+            normalized = os.path.abspath(folder)
+            parent = os.path.dirname(normalized)
+            # Insert the parent first so the picked folder ends up on top
+            if parent != normalized and not self._is_filesystem_root(parent):
+                candidates.append(parent)
+            if not self._is_filesystem_root(normalized):
+                candidates.append(normalized)
+
+            stored = self._load_remembered_raw()
+            for cand in candidates:
+                key = os.path.normcase(cand)
+                stored = [f for f in stored if os.path.normcase(f) != key]
+                stored.insert(0, cand)
+            del stored[self.RECOVERY_FOLDERS_LIMIT:]
+            self.settings_service.set_setting(self.RECOVERY_FOLDERS_SETTING, json.dumps(stored))
+        except Exception as e:
+            self.logger.warning(f"Could not remember recovery folder {folder}: {e}")
+
+    def _resolve_from_remembered_folders(self, missing, path_key):
+        """Try previously successful folders before prompting the user.
+
+        Args:
+            missing (list): Dicts with 'image' and 'filename' keys.
+            path_key (str): Key on the image dict to repair ('path'/'mask_path').
+
+        Returns:
+            list: The subset of ``missing`` that is still unresolved.
+        """
+        remaining = list(missing)
+        for folder in self._remembered_folders():
+            if not remaining:
+                break
+            try:
+                index = index_folder_by_filename(folder)
+            except Exception as e:
+                self.logger.warning(f"Could not index remembered folder {folder}: {e}")
+                continue
+
+            resolved = {}
+            next_remaining = []
+            for item in remaining:
+                located = find_in_index(item['filename'], index)
+                if located:
+                    resolved[id(item)] = located
+                else:
+                    next_remaining.append(item)
+
+            if resolved:
+                # Point input_dir at the actual folder holding the files when
+                # they share one, not at the (possibly much broader) index root
+                parents = {os.path.dirname(p) for p in resolved.values()}
+                input_dir = parents.pop() if len(parents) == 1 else folder
+                self._apply_resolved(remaining, resolved, path_key, input_dir)
+                self.logger.info(
+                    f"Auto-relinked {len(resolved)} {path_key} entries via "
+                    f"remembered folder {folder}"
+                )
+            remaining = next_remaining
+        return remaining
+
     def _recover_missing_files(self, missing, path_key, labels):
         """Prompt for a replacement folder and relocate *missing* files in it.
 
@@ -211,6 +317,7 @@ class PathValidationController(TranslationMixin):
 
             if not still_missing:
                 self._apply_resolved(missing, resolved, path_key, folder)
+                self._remember_folder(folder)
                 self.logger.info(
                     f"Relocated {len(resolved)} {path_key} entries to {folder}"
                 )
@@ -219,6 +326,8 @@ class PathValidationController(TranslationMixin):
             # Apply whatever was found before asking, so "Continue Anyway"
             # keeps the partial recovery instead of discarding it.
             self._apply_resolved(missing, resolved, path_key, folder)
+            if resolved:
+                self._remember_folder(folder)
             self.logger.warning(
                 f"Relocated {len(resolved)} of {len(missing)} {path_key} entries "
                 f"in {folder}; {len(still_missing)} unresolved"

--- a/app/core/views/SelectionDialog_ui.py
+++ b/app/core/views/SelectionDialog_ui.py
@@ -23,7 +23,7 @@ class Ui_MediaSelector(object):
     def setupUi(self, MediaSelector):
         if not MediaSelector.objectName():
             MediaSelector.setObjectName(u"MediaSelector")
-        MediaSelector.resize(600, 290)
+        MediaSelector.resize(770, 290)
         self.verticalLayout_3 = QVBoxLayout(MediaSelector)
         self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.label = QLabel(MediaSelector)
@@ -75,6 +75,34 @@ class Ui_MediaSelector(object):
 
 
         self.horizontalLayout_2.addWidget(self.imageWidget)
+
+        self.resultsWidget = QWidget(self.selectionWidget)
+        self.resultsWidget.setObjectName(u"resultsWidget")
+        sizePolicy1.setHeightForWidth(self.resultsWidget.sizePolicy().hasHeightForWidth())
+        self.resultsWidget.setSizePolicy(sizePolicy1)
+        self.verticalLayout_5 = QVBoxLayout(self.resultsWidget)
+        self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.verticalSpacer_top_4 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout_5.addItem(self.verticalSpacer_top_4)
+
+        self.resultsButton = QToolButton(self.resultsWidget)
+        self.resultsButton.setObjectName(u"resultsButton")
+        self.resultsButton.setMinimumSize(QSize(150, 150))
+        self.resultsButton.setMaximumSize(QSize(150, 150))
+        self.resultsButton.setFont(font1)
+        self.resultsButton.setStyleSheet(u"QToolButton { border: 3px solid palette(mid); border-radius: 8px; }")
+        self.resultsButton.setIconSize(QSize(100, 100))
+        self.resultsButton.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
+
+        self.verticalLayout_5.addWidget(self.resultsButton, 0, Qt.AlignHCenter)
+
+        self.verticalSpacer_bottom_4 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout_5.addItem(self.verticalSpacer_bottom_4)
+
+
+        self.horizontalLayout_2.addWidget(self.resultsWidget)
 
         self.streamWidget = QWidget(self.selectionWidget)
         self.streamWidget.setObjectName(u"streamWidget")
@@ -145,6 +173,10 @@ class Ui_MediaSelector(object):
         MediaSelector.setWindowTitle(QCoreApplication.translate("MediaSelector", u"Automated Drone Image Analysis Tool (ADIAT)", None))
         self.label.setText(QCoreApplication.translate("MediaSelector", u"What would you like to do?", None))
         self.imageButton.setText(QCoreApplication.translate("MediaSelector", u"Image Analysis", None))
+#if QT_CONFIG(tooltip)
+        self.resultsButton.setToolTip(QCoreApplication.translate("MediaSelector", u"Open a completed analysis for review: scan a folder for results or reopen a recent one.", None))
+#endif // QT_CONFIG(tooltip)
+        self.resultsButton.setText(QCoreApplication.translate("MediaSelector", u"Review Results", None))
 #if QT_CONFIG(tooltip)
         self.streamButton.setToolTip(QCoreApplication.translate("MediaSelector", u"RTMP, Video Files, HDMI Capture", None))
 #endif // QT_CONFIG(tooltip)

--- a/app/tests/core/controllers/images/test_main_window.py
+++ b/app/tests/core/controllers/images/test_main_window.py
@@ -569,3 +569,94 @@ def test_load_single_result_not_routed_to_coordinator(main_window, tmp_path):
     open_coord.assert_not_called()
     assert main_window._view_results_mode == 'results'
     assert main_window.viewResultsButton.isEnabled()
+
+# --------------------------------------------------------------------------- #
+#  Recent results MRU: recorded on open, surfaced in the File menu             #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSettingsStore:
+    """In-memory settings so tests never write to the real registry."""
+
+    def __init__(self):
+        self.store = {}
+
+    def get_setting(self, name, default_value=None):
+        return self.store.get(name, default_value)
+
+    def set_setting(self, name, value):
+        self.store[name] = value
+
+
+def testRecentResultsRoundtripDedupeAndCap(main_window, tmp_path):
+    """Recording keeps newest first, dedupes by path, and caps the list."""
+    main_window.settings_service = _FakeSettingsStore()
+
+    paths = []
+    for i in range(12):
+        p = tmp_path / f"batch{i}" / "ADIAT_Data.xml"
+        p.parent.mkdir(parents=True)
+        p.write_text("<data/>")
+        paths.append(str(p))
+        main_window._record_recent_result(str(p))
+    # Re-opening an old one moves it back to the top instead of duplicating
+    main_window._record_recent_result(paths[5])
+
+    recents = main_window._get_recent_results()
+    assert recents[0] == os.path.abspath(paths[5])
+    assert len(recents) <= main_window.RECENT_RESULTS_LIMIT
+    assert len(set(os.path.normcase(p) for p in recents)) == len(recents)
+
+
+def testRecentResultsMenuPlaceholderWhenEmpty(main_window):
+    main_window.settings_service = _FakeSettingsStore()
+
+    main_window._populate_recent_results_menu()
+
+    actions = main_window.menuRecentResults.actions()
+    assert len(actions) == 1
+    assert not actions[0].isEnabled()
+
+
+def testRecentResultsMenuDisablesMissingFiles(main_window, tmp_path):
+    """Entries whose files vanished stay listed but cannot be clicked."""
+    import json as _json
+    main_window.settings_service = _FakeSettingsStore()
+    existing = tmp_path / "run1" / "ADIAT_Data.xml"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("<data/>")
+    gone = str(tmp_path / "gone" / "ADIAT_Data.xml")
+    main_window.settings_service.store[main_window.RECENT_RESULTS_SETTING] = _json.dumps(
+        [str(existing), gone]
+    )
+
+    main_window._populate_recent_results_menu()
+
+    actions = main_window.menuRecentResults.actions()
+    assert len(actions) == 2
+    assert actions[0].isEnabled()
+    assert not actions[1].isEnabled()
+
+
+def testProcessXmlFileRecordsRecent(main_window, tmp_path):
+    """Opening a result XML lands it at the top of the recents list."""
+    main_window.settings_service = _FakeSettingsStore()
+    xml_path = tmp_path / "ADIAT_Data.xml"
+    xml_path.write_text("<data/>")
+
+    with patch.object(main_window, '_is_search_project_xml', return_value=False), \
+            patch.object(main_window, '_get_settings_from_xml', return_value=3), \
+            patch.object(main_window, '_set_view_results_mode'), \
+            patch.object(main_window, '_set_ViewResultsButton'):
+        main_window._process_xml_file(str(xml_path))
+
+    recents = main_window._get_recent_results()
+    assert recents
+    assert os.path.normcase(recents[0]) == os.path.normcase(os.path.abspath(str(xml_path)))
+
+
+def testOpenResultsForReviewRoutesToFolderScan(main_window):
+    """The Review Results tile entry point drives the folder scanner."""
+    with patch.object(main_window, '_open_load_results_folder') as mock_open:
+        main_window.open_results_for_review()
+    mock_open.assert_called_once()

--- a/app/tests/core/controllers/images/viewer/path/test_path_validation_controller.py
+++ b/app/tests/core/controllers/images/viewer/path/test_path_validation_controller.py
@@ -1,18 +1,42 @@
 """Unit tests for PathValidationController."""
 
+import json
 import os
 import pytest
 from unittest.mock import MagicMock, patch
 from PySide6.QtWidgets import QMessageBox
 
+import importlib
+
 from core.controllers.images.viewer.path.PathValidationController import (
     PathValidationController,
 )
 
+# The path package re-exports the class under the same name, so a plain
+# "import ... as path_module" would bind the class; resolve the real module.
+path_module = importlib.import_module(
+    "core.controllers.images.viewer.path.PathValidationController"
+)
+
+
+class _FakeSettings:
+    """In-memory SettingsService stand-in so tests never touch real QSettings."""
+
+    def __init__(self):
+        self.store = {}
+
+    def get_setting(self, name, default_value=None):
+        return self.store.get(name, default_value)
+
+    def set_setting(self, name, value):
+        self.store[name] = value
+
 
 @pytest.fixture
 def controller():
-    return PathValidationController(MagicMock())
+    with patch.object(path_module, 'SettingsService', side_effect=_FakeSettings):
+        instance = PathValidationController(MagicMock())
+    return instance
 
 
 def test_validate_no_missing_paths(controller, tmp_path):
@@ -321,3 +345,126 @@ def test_mask_recovery_repairs_mask_path_only(controller, tmp_path):
     assert image["path"] == str(img), "image path must be untouched"
     assert controller.parent.settings["input_dir"] == r"C:\old", \
         "mask recovery must not repoint the source image folder"
+
+# --------------------------------------------------------------------------- #
+#  Remembered recovery folders: batch 2..N must not re-prompt on this machine #
+# --------------------------------------------------------------------------- #
+
+
+def _remember(controller, *folders):
+    controller.settings_service.store[
+        PathValidationController.RECOVERY_FOLDERS_SETTING
+    ] = json.dumps(list(folders))
+
+
+def test_remembered_folder_auto_resolves_without_prompt(controller, tmp_path):
+    """A folder that fixed a previous batch fixes this one silently."""
+    flight = tmp_path / "copied" / "flight2"
+    flight.mkdir(parents=True)
+    (flight / "DJI_0042.JPG").write_text("fake")
+    _remember(controller, str(tmp_path / "copied"))
+
+    images = [{"path": r"C:\old\flight2\DJI_0042.JPG", "mask_path": ""}]
+
+    with patch.object(controller, "_prompt_for_source_folder") as mock_prompt:
+        result = controller.validate_and_fix_paths(images)
+
+    assert result is True
+    mock_prompt.assert_not_called()
+    assert images[0]["path"] == str(flight / "DJI_0042.JPG")
+
+
+def test_partial_auto_resolve_prompts_only_for_remainder(controller, tmp_path):
+    """Auto-relink applies what it finds; only the rest goes to the prompt."""
+    folder = tmp_path / "root"
+    folder.mkdir()
+    (folder / "found.jpg").write_text("fake")
+    _remember(controller, str(folder))
+
+    images = [
+        {"path": r"C:\old\found.jpg", "mask_path": ""},
+        {"path": r"C:\old\gone.jpg", "mask_path": ""},
+    ]
+
+    with patch.object(controller, "_prompt_for_source_folder", return_value=True) as mock_prompt:
+        result = controller.validate_and_fix_paths(images)
+
+    assert result is True
+    assert images[0]["path"] == str(folder / "found.jpg")
+    remaining = mock_prompt.call_args.args[0]
+    assert [item["filename"] for item in remaining] == ["gone.jpg"]
+
+
+def test_unplugged_remembered_folder_is_skipped_but_kept(controller, tmp_path):
+    """A disconnected drive is skipped for now but not forgotten."""
+    gone = r"E:\unplugged\flight"
+    _remember(controller, gone)
+
+    images = [{"path": r"C:\old\a.jpg", "mask_path": ""}]
+    with patch.object(controller, "_prompt_for_source_folder", return_value=True):
+        controller.validate_and_fix_paths(images)
+
+    stored = json.loads(
+        controller.settings_service.store[PathValidationController.RECOVERY_FOLDERS_SETTING]
+    )
+    assert gone in stored
+
+
+def test_remember_folder_stores_folder_and_parent(controller, tmp_path):
+    picked = tmp_path / "copied" / "flight1"
+    picked.mkdir(parents=True)
+
+    controller._remember_folder(str(picked))
+
+    stored = json.loads(
+        controller.settings_service.store[PathValidationController.RECOVERY_FOLDERS_SETTING]
+    )
+    # Picked folder first (most specific), then its parent for sibling batches
+    assert stored[0] == str(picked)
+    assert stored[1] == str(tmp_path / "copied")
+
+
+def test_remember_folder_dedupes_and_caps(controller, tmp_path):
+    for i in range(12):
+        folder = tmp_path / f"batch{i}" / "images"
+        folder.mkdir(parents=True)
+        controller._remember_folder(str(folder))
+    controller._remember_folder(str(tmp_path / "batch0" / "images"))  # re-pick
+
+    stored = json.loads(
+        controller.settings_service.store[PathValidationController.RECOVERY_FOLDERS_SETTING]
+    )
+    assert len(stored) <= PathValidationController.RECOVERY_FOLDERS_LIMIT
+    assert stored[0] == str(tmp_path / "batch0" / "images")
+    assert len(set(os.path.normcase(f) for f in stored)) == len(stored)
+
+
+def test_filesystem_roots_are_never_remembered(controller):
+    controller._remember_folder(os.path.abspath(os.sep))
+
+    stored = json.loads(
+        controller.settings_service.store.get(
+            PathValidationController.RECOVERY_FOLDERS_SETTING, "[]"
+        )
+    )
+    assert stored == []
+
+
+def test_successful_manual_recovery_remembers_the_folder(controller, tmp_path):
+    """The interactive flow records the picked folder for future batches."""
+    folder = tmp_path / "relinked"
+    folder.mkdir()
+    (folder / "img.jpg").write_text("fake")
+
+    image = {"path": r"C:\old\img.jpg", "mask_path": ""}
+
+    with patch(f"{_MODULE}.QMessageBox") as MockMsgBox, \
+            patch(f"{_MODULE}.QFileDialog") as MockFileDialog:
+        _mock_msgbox(MockMsgBox)
+        MockFileDialog.getExistingDirectory.return_value = str(folder)
+        assert controller.validate_and_fix_paths([image]) is True
+
+    stored = json.loads(
+        controller.settings_service.store[PathValidationController.RECOVERY_FOLDERS_SETTING]
+    )
+    assert str(folder) in stored

--- a/app/tests/core/controllers/test_selection_dialog_controller.py
+++ b/app/tests/core/controllers/test_selection_dialog_controller.py
@@ -49,10 +49,10 @@ def test_flight_viewer_button_hidden_when_feature_disabled(qtbot):
     # before the dialog is shown (isVisible() would be False either way).
     assert dialog.flightWidget.isHidden()
     assert dialog.streamWidget.isVisible() or not dialog.streamWidget.isHidden()
-    # Dialog shrinks below the three-button design width (600). The exact
-    # width is font/DPI-dependent (the heading label can set the floor), so
-    # assert the relationship rather than a pixel value.
-    assert dialog.width() < 600
+    # Dialog shrinks below the full design width (770). The exact width is
+    # font/DPI-dependent (the heading label can set the floor), so assert the
+    # relationship rather than a pixel value.
+    assert dialog.width() < 770
     # Height is unchanged from the .ui design (two rows are identical).
     assert dialog.height() == 290
 
@@ -66,8 +66,9 @@ def test_flight_viewer_button_shown_when_feature_enabled(qtbot):
         qtbot.addWidget(dialog)
 
     assert not dialog.flightWidget.isHidden()
-    # Three-button layout keeps its designed size.
-    assert dialog.width() == 600
+    # Full four-tile layout keeps its designed size (Image / Review Results /
+    # Stream / Flight Viewer).
+    assert dialog.width() == 770
 
 
 def test_flight_viewer_disabled_by_default():
@@ -78,3 +79,25 @@ def test_flight_viewer_disabled_by_default():
     has to be a deliberate edit here and in helpers/FeatureFlags.py.
     """
     assert selection_module.FeatureFlags.FLIGHT_VIEWER_ENABLED is False
+
+
+def test_review_results_tile_emits_selection(qtbot):
+    """The Review Results tile records the choice and signals __main__.
+
+    The dedicated signal fires after accept() so the handler constructs the
+    MainWindow with the dialog already dismissed, mirroring the flight tile.
+    """
+    with patch.object(selection_module, "UpdateController"),             patch.object(selection_module, "SettingsService"):
+        dialog = SelectionDialog("Dark")
+        qtbot.addWidget(dialog)
+
+    selections = []
+    requested = []
+    dialog.selectionMade.connect(selections.append)
+    dialog.reviewResultsRequested.connect(lambda: requested.append(True))
+
+    dialog.resultsButton.click()
+
+    assert dialog.selection == "results"
+    assert selections == ["results"]
+    assert requested == [True]

--- a/resources/views/SelectionDialog.ui
+++ b/resources/views/SelectionDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>770</width>
     <height>290</height>
    </rect>
   </property>
@@ -34,7 +34,7 @@
    </item>
    <item>
     <widget class="QWidget" name="selectionWidget" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0">
+     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0,0">
       <item>
        <widget class="QWidget" name="imageWidget" native="true">
         <property name="sizePolicy">
@@ -98,6 +98,89 @@
          </item>
          <item>
           <spacer name="verticalSpacer_bottom">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="resultsWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <spacer name="verticalSpacer_top_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QToolButton" name="resultsButton">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>150</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>150</width>
+             <height>150</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>12</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string>Open a completed analysis for review: scan a folder for results or reopen a recent one.</string>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QToolButton { border: 3px solid palette(mid); border-radius: 8px; }</string>
+           </property>
+           <property name="text">
+            <string>Review Results</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>100</width>
+             <height>100</height>
+            </size>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextUnderIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_bottom_4">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -8906,7 +8906,7 @@ The Results Viewer provides:
 Use to review, verify, and export analysis results.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1595"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1686"/>
         <location filename="../resources/views/images/MainWindow.ui" line="1018"/>
         <source> View Results</source>
         <translation> View Results</translation>
@@ -9161,12 +9161,12 @@ Ask questions, report issues, and suggest new features.</translation>
         <translation>YouTube Channel</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="81"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="82"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="266"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="268"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -9243,223 +9243,239 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
   • Limitation: Only detects people, slower processing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="345"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="347"/>
         <source>Select AOI Highlight Color</source>
         <translation>Select AOI Highlight Color</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="359"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="377"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="361"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="379"/>
         <source>Select Directory</source>
         <translation>Select Directory</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="394"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
         <source>Select a Reference Image</source>
         <translation>Select a Reference Image</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="398"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Images (*.png *.jpg)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="444"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="476"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
         <source>Value Adjusted</source>
         <translation>Value Adjusted</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="448"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="480"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="592"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="594"/>
         <source>Please set the input and output directories.</source>
         <translation>Please set the input and output directories.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="599"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="601"/>
         <source>--- Starting image processing ---</source>
         <translation>--- Starting image processing ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="795"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="797"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="818"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="820"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Area of Interest Limit ({limit}) exceeded. Continue?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="821"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="823"/>
         <source>Area of Interest Limit Exceeded</source>
         <translation>Area of Interest Limit Exceeded</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="873"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="875"/>
         <source>--- Image Processing Completed ---</source>
         <translation>--- Image Processing Completed ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="874"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="876"/>
         <source>Image processing complete</source>
         <translation>Image processing complete</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="877"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="879"/>
         <source>{count} images with areas of interest identified</source>
         <translation>{count} images with areas of interest identified</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="883"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>No areas of interest identified</source>
         <translation>No areas of interest identified</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="967"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1412"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1435"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1465"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1481"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1497"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1513"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="969"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1503"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1526"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1556"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1572"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1588"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1604"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="989"/>
+        <source>Open Recent Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1033"/>
+        <source>(no results opened yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1049"/>
+        <source>This results file no longer exists:
+{path}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>Select File</source>
         <translation>Select File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>XML Files (*.xml);;All Files (*)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="998"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1087"/>
         <source>Select Results Folder</source>
         <translation>Select Results Folder</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1031"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1120"/>
         <source>Failed to scan folder: {error}</source>
         <translation>Failed to scan folder: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1053"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1142"/>
         <source>No Results Found</source>
         <translation>No Results Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1054"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1143"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>No ADIAT_DATA.XML files were found in the selected folder.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1071"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1160"/>
         <source>Failed to display results: {error}</source>
         <translation>Failed to display results: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1082"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1171"/>
         <source>Scan failed: {error}</source>
         <translation>Scan failed: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1125"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1214"/>
         <source>Failed to open viewer: {error}</source>
         <translation>Failed to open viewer: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1245"/>
         <source>The selected file is not a valid XML file: {path}</source>
         <translation>The selected file is not a valid XML file: {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1358"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1449"/>
         <source>Error Loading Results</source>
         <translation>Error Loading Results</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1359"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1450"/>
         <source>Failed to load results file:
 {error}</source>
         <translation>Failed to load results file:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1413"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1504"/>
         <source>Failed to open Streaming Detector:
 {error}</source>
         <translation>Failed to open Streaming Detector:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1527"/>
         <source>Failed to open Flight Viewer:
 {error}</source>
         <translation>Failed to open Flight Viewer:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1466"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1557"/>
         <source>Failed to open Search Coordinator:
 {error}</source>
         <translation>Failed to open Search Coordinator:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1482"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1573"/>
         <source>Failed to open Help documentation:
 {error}</source>
         <translation>Failed to open Help documentation:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1498"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
         <source>Failed to open Community Help:
 {error}</source>
         <translation>Failed to open Community Help:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1514"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1605"/>
         <source>Failed to open YouTube Channel:
 {error}</source>
         <translation>Failed to open YouTube Channel:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1680"/>
         <source> Open Search Coordinator</source>
         <translation> Open Search Coordinator</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1591"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1682"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Open the Search Coordinator to review every batch in this run.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1597"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1688"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Open the Results Viewer to review detection results.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1684"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1775"/>
         <source>Invalid Value</source>
         <translation>Invalid Value</translation>
     </message>
@@ -9817,22 +9833,32 @@ then click again to place the second point.</translation>
         <translation>Image Analysis</translation>
     </message>
     <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <source>Open a completed analysis for review: scan a folder for results or reopen a recent one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../resources/views/SelectionDialog.ui" line="169"/>
+        <source>Review Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
         <source>Stream Analysis</source>
         <translation>Stream Analysis</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="329"/>
         <source>Pair with ADIAT Mobile drone controllers to receive their live camera feeds with detections.</source>
         <translation>Pair with ADIAT Mobile drone controllers to receive their live camera feeds with detections.</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
         <source>RTMP, Video Files, HDMI Capture</source>
         <translation>RTMP, Video Files, HDMI Capture</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="335"/>
         <source>Flight Viewer</source>
         <translation>Flight Viewer</translation>
     </message>
@@ -10056,14 +10082,14 @@ Please flag at least one AOI, or check &apos;Include images without flagged AOIs
 <context>
     <name>PathValidationController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="358"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="467"/>
         <source>
   ... and {count} more</source>
         <translation>
   ... and {count} more</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="104"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="120"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10076,22 +10102,22 @@ Please select the folder containing the source images.</source>
 Please select the folder containing the source images.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="102"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="118"/>
         <source>Source Images Not Found</source>
         <translation>Source Images Not Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="108"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="124"/>
         <source>Select Source Images Folder</source>
         <translation>Select Source Images Folder</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="109"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="125"/>
         <source>Some Images Still Missing</source>
         <translation>Some Images Still Missing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="154"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10104,12 +10130,12 @@ Please select the folder containing the mask files.</source>
 Please select the folder containing the mask files.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="136"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="152"/>
         <source>Detection Masks Not Found</source>
         <translation>Detection Masks Not Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="111"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="127"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10120,7 +10146,7 @@ Still missing:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="115"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10131,17 +10157,17 @@ Expected to find files named:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="158"/>
         <source>Select Masks Folder</source>
         <translation>Select Masks Folder</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="159"/>
         <source>Some Masks Still Missing</source>
         <translation>Some Masks Still Missing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="161"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10152,7 +10178,7 @@ Still missing:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="149"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10163,12 +10189,12 @@ Expected to find files named:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="264"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="373"/>
         <source>Choose Another Folder</source>
         <translation>Choose Another Folder</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="271"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="380"/>
         <source>Continue Anyway</source>
         <translation>Continue Anyway</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -8906,7 +8906,7 @@ El Visor de resultados ofrece:
 Úselo para revisar, verificar y exportar los resultados del análisis.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1595"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1686"/>
         <location filename="../resources/views/images/MainWindow.ui" line="1018"/>
         <source> View Results</source>
         <translation> Ver resultados</translation>
@@ -9161,12 +9161,12 @@ Haga preguntas, reporte problemas y sugiera nuevas funciones.</translation>
         <translation>Canal de YouTube</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="81"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="82"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Herramienta automatizada de análisis de imágenes de dron v{version} - Patrocinado por TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="266"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="268"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -9243,223 +9243,239 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
   • Limitación: Solo detecta personas, procesamiento más lento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="345"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="347"/>
         <source>Select AOI Highlight Color</source>
         <translation>Seleccionar color de resaltado del AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="359"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="377"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="361"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="379"/>
         <source>Select Directory</source>
         <translation>Seleccionar directorio</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="394"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
         <source>Select a Reference Image</source>
         <translation>Seleccionar una imagen de referencia</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="398"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Imágenes (*.png *.jpg)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="444"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="476"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
         <source>Value Adjusted</source>
         <translation>Valor ajustado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="448"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>El área máxima se ha ajustado a {value} píxeles para mantener un rango válido.
 (El área mínima debe ser menor que el área máxima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="480"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>El área mínima se ha ajustado a {value} píxeles para mantener un rango válido.
 (El área máxima debe ser mayor que el área mínima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="592"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="594"/>
         <source>Please set the input and output directories.</source>
         <translation>Establezca los directorios de entrada y salida.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="599"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="601"/>
         <source>--- Starting image processing ---</source>
         <translation>--- Iniciando procesamiento de imágenes ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="795"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="797"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>No se pudo analizar el archivo XML. Compruebe las rutas de archivo en &quot;{file_name}&quot;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="818"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="820"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Se ha superado el límite de áreas de interés ({limit}). ¿Continuar?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="821"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="823"/>
         <source>Area of Interest Limit Exceeded</source>
         <translation>Límite de áreas de interés superado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="873"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="875"/>
         <source>--- Image Processing Completed ---</source>
         <translation>--- Procesamiento de imágenes completado ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="874"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="876"/>
         <source>Image processing complete</source>
         <translation>Procesamiento de imágenes completado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="877"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="879"/>
         <source>{count} images with areas of interest identified</source>
         <translation>{count} imágenes con áreas de interés identificadas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="883"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>No areas of interest identified</source>
         <translation>No se identificaron áreas de interés</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="967"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1412"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1435"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1465"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1481"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1497"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1513"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="969"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1503"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1526"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1556"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1572"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1588"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1604"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="989"/>
+        <source>Open Recent Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1033"/>
+        <source>(no results opened yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1049"/>
+        <source>This results file no longer exists:
+{path}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>Select File</source>
         <translation>Seleccionar archivo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>Archivos XML (*.xml);;Todos los archivos (*)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="998"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1087"/>
         <source>Select Results Folder</source>
         <translation>Seleccionar carpeta de resultados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1031"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1120"/>
         <source>Failed to scan folder: {error}</source>
         <translation>Error al escanear la carpeta: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1053"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1142"/>
         <source>No Results Found</source>
         <translation>No se encontraron resultados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1054"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1143"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>No se encontraron archivos ADIAT_DATA.XML en la carpeta seleccionada.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1071"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1160"/>
         <source>Failed to display results: {error}</source>
         <translation>Error al mostrar los resultados: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1082"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1171"/>
         <source>Scan failed: {error}</source>
         <translation>Error en el escaneo: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1125"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1214"/>
         <source>Failed to open viewer: {error}</source>
         <translation>Error al abrir el visor: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1245"/>
         <source>The selected file is not a valid XML file: {path}</source>
         <translation>El archivo seleccionado no es un archivo XML válido: {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1358"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1449"/>
         <source>Error Loading Results</source>
         <translation>Error al cargar los resultados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1359"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1450"/>
         <source>Failed to load results file:
 {error}</source>
         <translation>Error al cargar el archivo de resultados:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1413"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1504"/>
         <source>Failed to open Streaming Detector:
 {error}</source>
         <translation>Error al abrir el Detector de transmisión:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1527"/>
         <source>Failed to open Flight Viewer:
 {error}</source>
         <translation>No se pudo abrir el visor de vuelo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1466"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1557"/>
         <source>Failed to open Search Coordinator:
 {error}</source>
         <translation>Error al abrir el Coordinador de búsqueda:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1482"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1573"/>
         <source>Failed to open Help documentation:
 {error}</source>
         <translation>Error al abrir la documentación de Ayuda:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1498"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
         <source>Failed to open Community Help:
 {error}</source>
         <translation>Error al abrir la Ayuda de la comunidad:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1514"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1605"/>
         <source>Failed to open YouTube Channel:
 {error}</source>
         <translation>Error al abrir el canal de YouTube:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1680"/>
         <source> Open Search Coordinator</source>
         <translation> Abrir Coordinador de búsqueda</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1591"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1682"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Abra el Coordinador de búsqueda para revisar todos los lotes de esta ejecución.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1597"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1688"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Abra el Visor de resultados para revisar los resultados de las detecciones.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1684"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1775"/>
         <source>Invalid Value</source>
         <translation>Valor no válido</translation>
     </message>
@@ -9817,22 +9833,32 @@ y luego vuelva a hacer clic para colocar el segundo punto.</translation>
         <translation>Análisis de imágenes</translation>
     </message>
     <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <source>Open a completed analysis for review: scan a folder for results or reopen a recent one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../resources/views/SelectionDialog.ui" line="169"/>
+        <source>Review Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
         <source>Stream Analysis</source>
         <translation>Análisis de transmisión</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="329"/>
         <source>Pair with ADIAT Mobile drone controllers to receive their live camera feeds with detections.</source>
         <translation>Empareje controladores de dron de ADIAT Mobile para recibir sus transmisiones de cámara en vivo con detecciones.</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
         <source>RTMP, Video Files, HDMI Capture</source>
         <translation>RTMP, archivos de vídeo, captura HDMI</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="335"/>
         <source>Flight Viewer</source>
         <translation>Visor de vuelo</translation>
     </message>
@@ -10056,14 +10082,14 @@ Marque al menos un AOI, o active &apos;Incluir imágenes sin AOI marcados&apos; 
 <context>
     <name>PathValidationController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="358"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="467"/>
         <source>
   ... and {count} more</source>
         <translation>
   ... y {count} más</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="104"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="120"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10076,22 +10102,22 @@ Please select the folder containing the source images.</source>
 Seleccione la carpeta que contiene las imágenes de origen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="102"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="118"/>
         <source>Source Images Not Found</source>
         <translation>Imágenes de origen no encontradas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="108"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="124"/>
         <source>Select Source Images Folder</source>
         <translation>Seleccionar carpeta de imágenes origen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="109"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="125"/>
         <source>Some Images Still Missing</source>
         <translation>Aún faltan algunas imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="154"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10104,12 +10130,12 @@ Please select the folder containing the mask files.</source>
 Seleccione la carpeta que contiene los archivos de máscara.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="136"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="152"/>
         <source>Detection Masks Not Found</source>
         <translation>Máscaras de detección no encontradas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="111"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="127"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10120,7 +10146,7 @@ Aún faltan:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="115"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10131,17 +10157,17 @@ Se esperaba encontrar archivos con estos nombres:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="158"/>
         <source>Select Masks Folder</source>
         <translation>Seleccionar carpeta de máscaras</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="159"/>
         <source>Some Masks Still Missing</source>
         <translation>Aún faltan algunas máscaras</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="161"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10152,7 +10178,7 @@ Aún faltan:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="149"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10163,12 +10189,12 @@ Se esperaba encontrar archivos con estos nombres:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="264"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="373"/>
         <source>Choose Another Folder</source>
         <translation>Elegir otra carpeta</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="271"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="380"/>
         <source>Continue Anyway</source>
         <translation>Continuar de todos modos</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -8396,132 +8396,148 @@ Risoluzioni più basse = elaborazione più veloce ma possono perdere oggetti pic
         <translation>Risoluzione Elaborazione:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="81"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="82"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Strumento Automatico di Analisi Immagini Drone v{version} - Sponsorizzato da TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="592"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="594"/>
         <source>Please set the input and output directories.</source>
         <translation>Imposta le cartelle di input e output.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="599"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="601"/>
         <source>--- Starting image processing ---</source>
         <translation>--- Inizio elaborazione immagini ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="873"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="875"/>
         <source>--- Image Processing Completed ---</source>
         <translation>--- Elaborazione Immagini Completata ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="877"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="879"/>
         <source>{count} images with areas of interest identified</source>
         <translation>{count} immagini con aree di interesse identificate</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="883"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>No areas of interest identified</source>
         <translation>Nessuna area di interesse identificata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="967"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1412"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1435"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1465"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1481"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1497"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1513"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="969"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1503"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1526"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1556"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1572"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1588"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1604"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="989"/>
+        <source>Open Recent Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1033"/>
+        <source>(no results opened yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1049"/>
+        <source>This results file no longer exists:
+{path}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1245"/>
         <source>The selected file is not a valid XML file: {path}</source>
         <translation>Il file selezionato non è un file XML valido: {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1358"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1449"/>
         <source>Error Loading Results</source>
         <translation>Errore Caricamento Risultati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1359"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1450"/>
         <source>Failed to load results file:
 {error}</source>
         <translation>Impossibile caricare il file dei risultati:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1413"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1504"/>
         <source>Failed to open Streaming Detector:
 {error}</source>
         <translation>Impossibile aprire il Rilevatore Streaming:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1527"/>
         <source>Failed to open Flight Viewer:
 {error}</source>
         <translation>Impossibile aprire il Visore voli:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1466"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1557"/>
         <source>Failed to open Search Coordinator:
 {error}</source>
         <translation>Impossibile aprire il Coordinatore di Ricerca:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1482"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1573"/>
         <source>Failed to open Help documentation:
 {error}</source>
         <translation>Impossibile aprire la documentazione di Aiuto:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1498"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
         <source>Failed to open Community Help:
 {error}</source>
         <translation>Impossibile aprire l&apos;Aiuto della Community:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1514"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1605"/>
         <source>Failed to open YouTube Channel:
 {error}</source>
         <translation>Impossibile aprire il canale YouTube:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1680"/>
         <source> Open Search Coordinator</source>
         <translation> Apri Coordinatore di Ricerca</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1591"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1682"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Apri il Coordinatore di Ricerca per esaminare tutti i batch di questa esecuzione.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1597"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1688"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Apri il Visualizzatore Risultati per esaminare i risultati dei rilevamenti.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1684"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1775"/>
         <source>Invalid Value</source>
         <translation>Valore Non Valido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="345"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="347"/>
         <source>Select AOI Highlight Color</source>
         <translation>Seleziona Colore Evidenziazione AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="266"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="268"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -8598,98 +8614,98 @@ AI PERSON DETECTOR: modello di deep learning per il rilevamento accurato di pers
   • Limite: rileva solo persone, elaborazione più lenta</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="359"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="377"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="361"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="379"/>
         <source>Select Directory</source>
         <translation>Seleziona Cartella</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="394"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
         <source>Select a Reference Image</source>
         <translation>Seleziona un&apos;Immagine di Riferimento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="398"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Immagini (*.png *.jpg)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="444"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="476"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
         <source>Value Adjusted</source>
         <translation>Valore Regolato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="448"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>L&apos;area massima è stata regolata a {value} pixel per mantenere un intervallo valido.
 (L&apos;area minima deve essere inferiore all&apos;area massima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="480"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>L&apos;area minima è stata regolata a {value} pixel per mantenere un intervallo valido.
 (L&apos;area massima deve essere maggiore dell&apos;area minima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="818"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="820"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Limite Area di Interesse ({limit}) superato. Continuare?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="821"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="823"/>
         <source>Area of Interest Limit Exceeded</source>
         <translation>Limite Area di Interesse Superato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="874"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="876"/>
         <source>Image processing complete</source>
         <translation>Elaborazione immagini completata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>Select File</source>
         <translation>Seleziona File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>File XML (*.xml);;Tutti i File (*)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="998"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1087"/>
         <source>Select Results Folder</source>
         <translation>Seleziona Cartella Risultati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1031"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1120"/>
         <source>Failed to scan folder: {error}</source>
         <translation>Impossibile scansionare la cartella: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1053"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1142"/>
         <source>No Results Found</source>
         <translation>Nessun Risultato Trovato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1054"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1143"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>Nessun file ADIAT_DATA.XML trovato nella cartella selezionata.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1071"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1160"/>
         <source>Failed to display results: {error}</source>
         <translation>Impossibile visualizzare i risultati: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1082"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1171"/>
         <source>Scan failed: {error}</source>
         <translation>Scansione fallita: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1125"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1214"/>
         <source>Failed to open viewer: {error}</source>
         <translation>Impossibile aprire il visualizzatore: {error}</translation>
     </message>
@@ -9209,7 +9225,7 @@ Il Visualizzatore Risultati offre:
 Usa per rivedere, verificare ed esportare i risultati dell&apos;analisi.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1595"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1686"/>
         <location filename="../resources/views/images/MainWindow.ui" line="1018"/>
         <source> View Results</source>
         <translation> Visualizza Risultati</translation>
@@ -9459,7 +9475,7 @@ Fai domande, segnala problemi e suggerisci nuove funzionalità.</translation>
         <translation>Canale YouTube</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="795"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="797"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>Impossibile analizzare il file XML. Controlla i percorsi dei file in &quot;{file_name}&quot;</translation>
     </message>
@@ -9817,22 +9833,32 @@ poi clicca di nuovo per posizionare il secondo punto.</translation>
         <translation>Analisi immagini</translation>
     </message>
     <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <source>Open a completed analysis for review: scan a folder for results or reopen a recent one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../resources/views/SelectionDialog.ui" line="169"/>
+        <source>Review Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
         <source>Stream Analysis</source>
         <translation>Analisi streaming</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="329"/>
         <source>Pair with ADIAT Mobile drone controllers to receive their live camera feeds with detections.</source>
         <translation>Abbina i controller drone ADIAT Mobile per ricevere i loro flussi video live con rilevamenti.</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
         <source>RTMP, Video Files, HDMI Capture</source>
         <translation>RTMP, File Video, Acquisizione HDMI</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="335"/>
         <source>Flight Viewer</source>
         <translation>Visore voli</translation>
     </message>
@@ -10056,14 +10082,14 @@ Contrassegna almeno una AOI oppure seleziona &apos;Includi immagini senza AOI co
 <context>
     <name>PathValidationController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="358"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="467"/>
         <source>
   ... and {count} more</source>
         <translation>
   ... e altri {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="104"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="120"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10076,22 +10102,22 @@ Please select the folder containing the source images.</source>
 Seleziona la cartella contenente le immagini sorgente.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="102"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="118"/>
         <source>Source Images Not Found</source>
         <translation>Immagini Sorgente Non Trovate</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="108"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="124"/>
         <source>Select Source Images Folder</source>
         <translation>Seleziona Cartella Immagini Sorgente</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="109"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="125"/>
         <source>Some Images Still Missing</source>
         <translation>Alcune Immagini Mancano Ancora</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="154"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10104,12 +10130,12 @@ Please select the folder containing the mask files.</source>
 Seleziona la cartella contenente i file delle maschere.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="136"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="152"/>
         <source>Detection Masks Not Found</source>
         <translation>Maschere di Rilevamento Non Trovate</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="111"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="127"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10120,7 +10146,7 @@ Ancora mancanti:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="115"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10131,17 +10157,17 @@ Nomi dei file cercati:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="158"/>
         <source>Select Masks Folder</source>
         <translation>Seleziona Cartella Maschere</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="159"/>
         <source>Some Masks Still Missing</source>
         <translation>Alcune Maschere Mancano Ancora</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="161"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10152,7 +10178,7 @@ Ancora mancanti:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="149"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10163,12 +10189,12 @@ Nomi dei file cercati:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="264"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="373"/>
         <source>Choose Another Folder</source>
         <translation>Scegli Un&apos;Altra Cartella</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="271"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="380"/>
         <source>Continue Anyway</source>
         <translation>Continua Comunque</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -8906,7 +8906,7 @@ De resultatenviewer biedt:
 Gebruik om analyseresultaten te bekijken, verifiëren en exporteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1595"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1686"/>
         <location filename="../resources/views/images/MainWindow.ui" line="1018"/>
         <source> View Results</source>
         <translation> Resultaten bekijken</translation>
@@ -9161,12 +9161,12 @@ Stel vragen, meld problemen en stel nieuwe functies voor.</translation>
         <translation>YouTube-kanaal</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="81"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="82"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Geautomatiseerd drone-beeldanalyse-instrument v{version} - Gesponsord door TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="266"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="268"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -9243,223 +9243,239 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
   • Beperking: detecteert alleen personen, langzamere verwerking</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="345"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="347"/>
         <source>Select AOI Highlight Color</source>
         <translation>AOI-markeerkleur selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="359"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="377"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="361"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="379"/>
         <source>Select Directory</source>
         <translation>Map selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="394"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
         <source>Select a Reference Image</source>
         <translation>Een referentie-afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="396"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="398"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Afbeeldingen (*.png *.jpg)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="444"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="476"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
         <source>Value Adjusted</source>
         <translation>Waarde aangepast</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="446"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="448"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>Het maximale gebied is aangepast naar {value} pixels om een geldig bereik te behouden.
 (Minimumgebied moet kleiner zijn dan maximumgebied)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="478"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="480"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>Het minimale gebied is aangepast naar {value} pixels om een geldig bereik te behouden.
 (Maximumgebied moet groter zijn dan minimumgebied)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="592"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="594"/>
         <source>Please set the input and output directories.</source>
         <translation>Stel de invoer- en uitvoermappen in.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="599"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="601"/>
         <source>--- Starting image processing ---</source>
         <translation>--- Beeldverwerking starten ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="795"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="797"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>Kan XML-bestand niet parseren. Controleer bestandspaden in &quot;{file_name}&quot;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="818"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="820"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Limiet voor interessegebieden ({limit}) overschreden. Doorgaan?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="821"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="823"/>
         <source>Area of Interest Limit Exceeded</source>
         <translation>Limiet voor interessegebieden overschreden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="873"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="875"/>
         <source>--- Image Processing Completed ---</source>
         <translation>--- Beeldverwerking voltooid ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="874"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="876"/>
         <source>Image processing complete</source>
         <translation>Beeldverwerking voltooid</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="877"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="879"/>
         <source>{count} images with areas of interest identified</source>
         <translation>{count} afbeeldingen met interessegebieden geïdentificeerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="883"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>No areas of interest identified</source>
         <translation>Geen interessegebieden geïdentificeerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="967"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1412"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1435"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1465"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1481"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1497"/>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1513"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="969"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1503"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1526"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1556"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1572"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1588"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1604"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="989"/>
+        <source>Open Recent Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1033"/>
+        <source>(no results opened yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1049"/>
+        <source>This results file no longer exists:
+{path}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>Select File</source>
         <translation>Bestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="977"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1066"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>XML-bestanden (*.xml);;Alle bestanden (*)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="998"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1087"/>
         <source>Select Results Folder</source>
         <translation>Resultatenmap selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1031"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1120"/>
         <source>Failed to scan folder: {error}</source>
         <translation>Map scannen mislukt: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1053"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1142"/>
         <source>No Results Found</source>
         <translation>Geen resultaten gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1054"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1143"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>Er zijn geen ADIAT_DATA.XML-bestanden gevonden in de geselecteerde map.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1071"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1160"/>
         <source>Failed to display results: {error}</source>
         <translation>Kan resultaten niet weergeven: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1082"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1171"/>
         <source>Scan failed: {error}</source>
         <translation>Scannen mislukt: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1125"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1214"/>
         <source>Failed to open viewer: {error}</source>
         <translation>Kan viewer niet openen: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1245"/>
         <source>The selected file is not a valid XML file: {path}</source>
         <translation>Het geselecteerde bestand is geen geldig XML-bestand: {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1358"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1449"/>
         <source>Error Loading Results</source>
         <translation>Fout bij laden van resultaten</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1359"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1450"/>
         <source>Failed to load results file:
 {error}</source>
         <translation>Kan resultatenbestand niet laden:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1413"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1504"/>
         <source>Failed to open Streaming Detector:
 {error}</source>
         <translation>Kan streamingdetector niet openen:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1527"/>
         <source>Failed to open Flight Viewer:
 {error}</source>
         <translation>Kan Vluchtviewer niet openen:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1466"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1557"/>
         <source>Failed to open Search Coordinator:
 {error}</source>
         <translation>Kan zoekcoördinator niet openen:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1482"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1573"/>
         <source>Failed to open Help documentation:
 {error}</source>
         <translation>Kan hulpdocumentatie niet openen:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1498"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
         <source>Failed to open Community Help:
 {error}</source>
         <translation>Kan communityhulp niet openen:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1514"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1605"/>
         <source>Failed to open YouTube Channel:
 {error}</source>
         <translation>Kan YouTube-kanaal niet openen:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1589"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1680"/>
         <source> Open Search Coordinator</source>
         <translation> Zoekcoördinator openen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1591"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1682"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Open de Zoekcoördinator om elke batch in deze run te beoordelen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1597"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1688"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Open de resultatenviewer om detectieresultaten te beoordelen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1684"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1775"/>
         <source>Invalid Value</source>
         <translation>Ongeldige waarde</translation>
     </message>
@@ -9817,22 +9833,32 @@ klik daarna nogmaals om het tweede punt te plaatsen.</translation>
         <translation>Beeldanalyse</translation>
     </message>
     <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <source>Open a completed analysis for review: scan a folder for results or reopen a recent one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../resources/views/SelectionDialog.ui" line="169"/>
+        <source>Review Results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
         <source>Stream Analysis</source>
         <translation>Streamanalyse</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="329"/>
         <source>Pair with ADIAT Mobile drone controllers to receive their live camera feeds with detections.</source>
         <translation>Koppel met ADIAT Mobile-dronecontrollers om hun live camerafeeds met detecties te ontvangen.</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="163"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="246"/>
         <source>RTMP, Video Files, HDMI Capture</source>
         <translation>RTMP, videobestanden, HDMI-opname</translation>
     </message>
     <message>
-        <location filename="../resources/views/SelectionDialog.ui" line="252"/>
+        <location filename="../resources/views/SelectionDialog.ui" line="335"/>
         <source>Flight Viewer</source>
         <translation>Vluchtviewer</translation>
     </message>
@@ -10056,14 +10082,14 @@ Markeer ten minste één AOI of vink &apos;Afbeeldingen zonder gemarkeerde AOI&a
 <context>
     <name>PathValidationController</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="358"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="467"/>
         <source>
   ... and {count} more</source>
         <translation>
   ... en nog {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="104"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="120"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10076,22 +10102,22 @@ Please select the folder containing the source images.</source>
 Selecteer de map die de bronafbeeldingen bevat.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="102"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="118"/>
         <source>Source Images Not Found</source>
         <translation>Bronafbeeldingen niet gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="108"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="124"/>
         <source>Select Source Images Folder</source>
         <translation>Map met bronafbeeldingen selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="109"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="125"/>
         <source>Some Images Still Missing</source>
         <translation>Sommige afbeeldingen ontbreken nog</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="154"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10104,12 +10130,12 @@ Please select the folder containing the mask files.</source>
 Selecteer de map die de maskerbestanden bevat.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="136"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="152"/>
         <source>Detection Masks Not Found</source>
         <translation>Detectiemaskers niet gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="111"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="127"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10120,7 +10146,7 @@ Nog ontbrekend:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="115"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10131,17 +10157,17 @@ Verwachte bestandsnamen:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="158"/>
         <source>Select Masks Folder</source>
         <translation>Maskermap selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="159"/>
         <source>Some Masks Still Missing</source>
         <translation>Sommige maskers ontbreken nog</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="161"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10152,7 +10178,7 @@ Nog ontbrekend:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="149"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10163,12 +10189,12 @@ Verwachte bestandsnamen:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="264"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="373"/>
         <source>Choose Another Folder</source>
         <translation>Andere map kiezen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="271"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="380"/>
         <source>Continue Anyway</source>
         <translation>Toch doorgaan</translation>
     </message>


### PR DESCRIPTION
## The problem

On real searches, reviewers receiving a results package intuitively click into the analysis setup screen and pick the input data set, because *reviewing* results is buried behind the *analysis* workflow. And when results move between machines (the normal case for distributed review), every batch re-prompts for the same image folders one by one.

## What this adds

**1. Review Results tile on the selection dialog.** A fourth tile alongside Image Analysis / Stream Analysis / Flight Viewer that opens the MainWindow directly into the existing recursive results-folder scanner — a reviewer never sees the analysis setup screen. (`.ui` updated and `SelectionDialog_ui.py` regenerated at uic 6.10.2.)

**2. File → Open Recent Results.** The last 10 opened result files, recorded on every successful open (Search Coordinator projects included), rebuilt each time the menu opens. Entries whose files have vanished stay listed but disabled. Clicking one opens straight into review.

**3. Remembered relink folders (the big reviewer-time win).** `PathValidationController` now remembers every folder that fixes a relink — plus its **parent**, so sibling batch folders under one copied root also match — and silently tries those before ever prompting. Copy a 20-batch search to a new drive: batch 1 prompts once, batches 2–20 relink with **no dialog at all**. Unplugged drives are skipped but not forgotten; filesystem roots are never indexed; everything still persists back into the XML as before.

## Tests

- 26 path-validation tests pass (8 new: silent auto-relink, partial resolve prompting only for the remainder, folder+parent remembering, dedupe/cap, unplugged-drive retention, root exclusion, interactive-flow recording).
- Selection dialog: new tile signal test; two width assertions updated for the four-tile design.
- 5 new MainWindow tests for the recents store and menu.
- Existing path-validation tests were switched to an in-memory settings fake so test runs can never write the real registry.
- Translations re-extracted for the new strings; `flake8` clean.