### PR TITLE
fix: Search Coordinator merge — remove eval() on file content, merge AOIs across machines

### DIFF
--- a/app/core/services/coordinator/SearchProjectService.py
+++ b/app/core/services/coordinator/SearchProjectService.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import uuid
 from datetime import datetime
@@ -5,6 +6,7 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 from core.services.LoggerService import LoggerService
 from core.services.XmlService import XmlService
+from helpers.PathHelper import cross_platform_basename
 
 
 class SearchProjectService:
@@ -317,6 +319,48 @@ class SearchProjectService:
             self.logger.error(f"Error adding review: {e}")
             return False
 
+    @staticmethod
+    def _parse_center(text):
+        """Parse a stored AOI center like "(100, 200)" without executing it.
+
+        The previous implementation used eval() on file content, which runs
+        whatever a crafted or corrupted review XML contains; a center is only
+        ever two numbers. Malformed input degrades to (0, 0), matching the old
+        default.
+
+        Args:
+            text (str): Stored center text, e.g. "(100, 200)" or "[100, 200]".
+
+        Returns:
+            tuple: (x, y) as floats.
+        """
+        if text:
+            try:
+                parsed = ast.literal_eval(text.strip())
+                if isinstance(parsed, (list, tuple)) and len(parsed) >= 2:
+                    return (float(parsed[0]), float(parsed[1]))
+            except (ValueError, SyntaxError, TypeError):
+                pass
+        return (0.0, 0.0)
+
+    @staticmethod
+    def _image_match_key(image_path):
+        """Key used to decide two review rows refer to the same capture.
+
+        Reviewers run on different machines, so the same image arrives with
+        different absolute paths, separators, and casing. Raw string equality
+        made every cross-machine review create duplicates instead of merging.
+        The filename (case-insensitive, split on both separator styles) plus
+        the center-proximity check identifies the AOI across machines.
+
+        Args:
+            image_path (str): Stored image path from a review or the project.
+
+        Returns:
+            str: Normalized match key.
+        """
+        return cross_platform_basename(image_path or '').lower()
+
     def _merge_aoi_data(self, batch_id, images, review_meta):
         """
         Merge AOI data from a review into consolidated_aois.
@@ -329,30 +373,38 @@ class SearchProjectService:
         root = self.xml.getroot()
         consolidated_elem = root.find('consolidated_aois')
 
+        # Index existing AOIs by filename once, instead of rescanning (and
+        # re-parsing every center of) the whole consolidated list per AOI
+        existing_by_name = {}
+        for existing_aoi in consolidated_elem.findall('aoi'):
+            key = self._image_match_key(existing_aoi.findtext('image_path', ''))
+            center = self._parse_center(existing_aoi.findtext('center', '(0, 0)'))
+            existing_by_name.setdefault(key, []).append((existing_aoi, center))
+
         for image in images:
             image_path = image.get('path', '')
+            image_key = self._image_match_key(image_path)
 
             for aoi in image.get('areas_of_interest', []):
                 # Try to find matching AOI
                 matched = False
                 center = aoi.get('center', (0, 0))
 
-                for existing_aoi in consolidated_elem.findall('aoi'):
-                    # Match by image path and center coordinates (within tolerance)
-                    existing_path = existing_aoi.findtext('image_path', '')
-                    existing_center = eval(existing_aoi.findtext('center', '(0, 0)'))
-
-                    if existing_path == image_path:
-                        # Check if centers are close (within 10 pixels)
-                        if abs(existing_center[0] - center[0]) <= 10 and abs(existing_center[1] - center[1]) <= 10:
-                            # Match found - update existing AOI
-                            self._update_existing_aoi(existing_aoi, aoi, review_meta, batch_id)
-                            matched = True
-                            break
+                for existing_aoi, existing_center in existing_by_name.get(image_key, []):
+                    # Check if centers are close (within 10 pixels)
+                    if abs(existing_center[0] - center[0]) <= 10 and abs(existing_center[1] - center[1]) <= 10:
+                        # Match found - update existing AOI
+                        self._update_existing_aoi(existing_aoi, aoi, review_meta, batch_id)
+                        matched = True
+                        break
 
                 if not matched:
                     # Create new AOI entry
-                    self._create_new_aoi(consolidated_elem, aoi, image_path, review_meta, batch_id)
+                    new_elem = self._create_new_aoi(consolidated_elem, aoi, image_path, review_meta, batch_id)
+                    # Later AOIs in this same review must be able to match it
+                    existing_by_name.setdefault(image_key, []).append(
+                        (new_elem, (float(center[0]), float(center[1])) if len(center) >= 2 else (0.0, 0.0))
+                    )
 
     def _update_existing_aoi(self, aoi_elem, new_aoi, review_meta, batch_id):
         """Update an existing consolidated AOI with new review data."""
@@ -381,7 +433,11 @@ class SearchProjectService:
             ET.SubElement(review, 'comment').text = comment
 
     def _create_new_aoi(self, consolidated_elem, aoi, image_path, review_meta, batch_id):
-        """Create a new consolidated AOI entry."""
+        """Create a new consolidated AOI entry.
+
+        Returns:
+            xml.etree.ElementTree.Element: The created <aoi> element.
+        """
         aoi_elem = ET.SubElement(consolidated_elem, 'aoi')
         ET.SubElement(aoi_elem, 'image_path').text = image_path
         ET.SubElement(aoi_elem, 'center').text = str(aoi.get('center', (0, 0)))
@@ -402,6 +458,8 @@ class SearchProjectService:
         comment = aoi.get('user_comment', '')
         if comment:
             ET.SubElement(review, 'comment').text = comment
+
+        return aoi_elem
 
     def get_project_summary(self):
         """

--- a/app/tests/core/services/coordinator/test_search_project_service.py
+++ b/app/tests/core/services/coordinator/test_search_project_service.py
@@ -7,6 +7,7 @@ Tests search project management and coordination functionality.
 import pytest
 import tempfile
 import os
+import xml.etree.ElementTree as ET
 from unittest.mock import patch, MagicMock
 from core.services.coordinator.SearchProjectService import SearchProjectService
 
@@ -81,3 +82,141 @@ def test_get_batch_status(search_project_service):
     status = search_project_service.get_batch_status()
 
     assert isinstance(status, list)
+
+# --------------------------------------------------------------------------- #
+#  Merge hardening: no eval() on file content, cross-machine path matching     #
+# --------------------------------------------------------------------------- #
+
+
+def _project_with_consolidated(*aoi_specs):
+    """Build a service whose consolidated_aois holds the given entries.
+
+    Each spec: (image_path, center_text, flag_count)
+    """
+    service = SearchProjectService()
+    root = ET.Element('search_project')
+    ET.SubElement(root, 'batches')
+    consolidated = ET.SubElement(root, 'consolidated_aois')
+    for image_path, center_text, flag_count in aoi_specs:
+        aoi = ET.SubElement(consolidated, 'aoi')
+        ET.SubElement(aoi, 'image_path').text = image_path
+        ET.SubElement(aoi, 'center').text = center_text
+        ET.SubElement(aoi, 'radius').text = '20'
+        ET.SubElement(aoi, 'area').text = '400'
+        ET.SubElement(aoi, 'flag_count').text = str(flag_count)
+        ET.SubElement(aoi, 'reviews')
+    service.xml = ET.ElementTree(root)
+    return service, consolidated
+
+
+_REVIEW_META = {'review_id': 'r1', 'reviewer_name': 'Reviewer One'}
+
+
+def test_parse_center_reads_legacy_tuple_format():
+    """Old projects store centers as str((x, y)); they must keep parsing."""
+    assert SearchProjectService._parse_center('(100, 200)') == (100.0, 200.0)
+    assert SearchProjectService._parse_center('[15, 25]') == (15.0, 25.0)
+
+
+def test_parse_center_never_executes_content(tmp_path):
+    """A crafted center must be inert data, not code."""
+    marker = tmp_path / 'pwned.txt'
+    payload = f"__import__('pathlib').Path(r'{marker}').write_text('x')"
+
+    result = SearchProjectService._parse_center(payload)
+
+    assert result == (0.0, 0.0)
+    assert not marker.exists()
+
+
+def test_parse_center_malformed_degrades_to_origin():
+    assert SearchProjectService._parse_center('') == (0.0, 0.0)
+    assert SearchProjectService._parse_center('garbage') == (0.0, 0.0)
+    assert SearchProjectService._parse_center('(1,)') == (0.0, 0.0)
+
+
+def test_merge_matches_same_image_across_machines():
+    """A Windows-authored path and a POSIX path to the same capture merge."""
+    service, consolidated = _project_with_consolidated(
+        (r'C:\Search\Batch1\DJI_0042.JPG', '(100, 200)', 1),
+    )
+    images = [{
+        'path': '/mnt/usb/Batch1/DJI_0042.JPG',
+        'areas_of_interest': [{'center': (103, 198), 'flagged': True}],
+    }]
+
+    service._merge_aoi_data('batch1', images, _REVIEW_META)
+
+    aois = consolidated.findall('aoi')
+    assert len(aois) == 1  # merged, not duplicated
+    assert aois[0].findtext('flag_count') == '2'
+
+
+def test_merge_still_separates_different_filenames():
+    service, consolidated = _project_with_consolidated(
+        (r'C:\Search\Batch1\DJI_0042.JPG', '(100, 200)', 1),
+    )
+    images = [{
+        'path': r'C:\Search\Batch1\DJI_0043.JPG',
+        'areas_of_interest': [{'center': (100, 200), 'flagged': False}],
+    }]
+
+    service._merge_aoi_data('batch1', images, _REVIEW_META)
+
+    assert len(consolidated.findall('aoi')) == 2
+
+
+def test_merge_separates_distant_centers_on_same_image():
+    service, consolidated = _project_with_consolidated(
+        (r'C:\Search\Batch1\DJI_0042.JPG', '(100, 200)', 0),
+    )
+    images = [{
+        'path': r'C:\Search\Batch1\DJI_0042.JPG',
+        'areas_of_interest': [{'center': (400, 500), 'flagged': True}],
+    }]
+
+    service._merge_aoi_data('batch1', images, _REVIEW_META)
+
+    assert len(consolidated.findall('aoi')) == 2
+
+
+def test_merge_matches_within_review_after_new_aoi_created():
+    """Two reviewers' rows arriving in one merge call still consolidate."""
+    service, consolidated = _project_with_consolidated()
+    images = [{
+        'path': r'C:\Search\Batch1\DJI_0042.JPG',
+        'areas_of_interest': [{'center': (100, 200), 'flagged': True}],
+    }]
+    service._merge_aoi_data('batch1', images, _REVIEW_META)
+
+    # Second review of the same AOI from another machine
+    images2 = [{
+        'path': '/home/rev2/Batch1/DJI_0042.JPG',
+        'areas_of_interest': [{'center': (98, 202), 'flagged': True}],
+    }]
+    service._merge_aoi_data('batch1', images2, {'review_id': 'r2', 'reviewer_name': 'Reviewer Two'})
+
+    aois = consolidated.findall('aoi')
+    assert len(aois) == 1
+    assert aois[0].findtext('flag_count') == '2'
+    reviews = aois[0].find('reviews').findall('review')
+    assert {r.get('review_id') for r in reviews} == {'r1', 'r2'}
+
+
+def test_merge_survives_malicious_center_in_project_file(tmp_path):
+    """A hostile center in the stored project neither runs nor kills the merge."""
+    marker = tmp_path / 'pwned.txt'
+    payload = f"__import__('pathlib').Path(r'{marker}').write_text('x')"
+    service, consolidated = _project_with_consolidated(
+        (r'C:\Search\Batch1\DJI_0042.JPG', payload, 0),
+    )
+    images = [{
+        'path': r'C:\Search\Batch1\DJI_0042.JPG',
+        'areas_of_interest': [{'center': (5, 5), 'flagged': False}],
+    }]
+
+    service._merge_aoi_data('batch1', images, _REVIEW_META)
+
+    assert not marker.exists()
+    # (5,5) is within 10px of the degraded (0,0) center, so it merges there
+    assert len(consolidated.findall('aoi')) == 1


### PR DESCRIPTION
## Two defects in the review merge

**1. `eval()` on file content (security).** `_merge_aoi_data` parsed each stored AOI center with `eval(existing_aoi.findtext('center', '(0, 0)'))`. A crafted or merely corrupted review/project XML could execute arbitrary code on the coordinator's machine the moment the file was ingested. Centers are only ever two numbers — they're now parsed with `ast.literal_eval` (data only, no execution), and malformed input degrades to `(0, 0)`, the old default. A regression test plants an actual payload string and asserts it is inert.

**2. Raw path equality broke cross-machine consolidation (correctness).** AOIs merged only when `existing_path == image_path` — but every reviewer machine stores a different absolute path for the same capture (drive letters, separators, casing). So multi-reviewer consolidation, the whole point of the coordinator, always produced duplicates for remote reviews. Matching now uses the cross-platform filename (case-insensitive, splits both separator styles — same helper the path-relink flow uses) plus the existing 10 px center-proximity rule.

Also: the merge now indexes consolidated AOIs by filename once per call instead of rescanning (and re-parsing every center of) the whole list for each incoming AOI, and newly created entries join the index so later AOIs in the same merge can match them.

## Compatibility

- Old projects' center format (`str((x, y))`) parses unchanged — covered by a regression test.
- Same-machine merges behave exactly as before (filename matching is a superset of exact-path matching).

## Tests

18 coordinator tests pass — 8 new: legacy center format, crafted-center inertness (payload file never created), malformed-center degradation, cross-machine merge with flag_count accumulation, distinct-filename separation, same-image distant-center separation, and two-review consolidation. `flake8` clean.