### PR TITLE
feat: Pack thumbnail cache into one SQLite container per cache directory

### DIFF
--- a/app/core/services/cache/ThumbnailBlobStore.py
+++ b/app/core/services/cache/ThumbnailBlobStore.py
@@ -1,0 +1,121 @@
+"""
+ThumbnailBlobStore - Single-file SQLite container for cached AOI thumbnails.
+
+A large search produces thousands of loose thumbnail JPEGs, and copying
+thousands of small files between drives or machines is dominated by per-file
+filesystem overhead rather than data size. This store packs them into one
+``thumbnails.db`` per cache directory - keyed by the same md5 cache keys the
+loose files used and holding the same JPEG bytes - so a results folder moves
+as a handful of large files instead of a swarm of small ones.
+
+Thread safety: a fresh connection is opened per operation, so the GUI thread
+and the thumbnail worker pool can call any method concurrently without a
+shared-connection registry. Connection setup is microseconds next to the JPEG
+decode each thumbnail already pays. The default rollback journal (not WAL) is
+used deliberately: it leaves exactly one file on disk when the app is closed,
+which is the whole point of the container.
+"""
+
+import os
+import sqlite3
+import time
+from contextlib import closing
+from typing import Optional
+
+
+class ThumbnailBlobStore:
+    """One-file SQLite blob store for thumbnail JPEG bytes."""
+
+    DB_FILENAME = 'thumbnails.db'
+
+    def __init__(self, directory, logger=None):
+        """
+        Initialize the store for a cache directory.
+
+        Args:
+            directory: Cache directory the container lives in (created by the
+                cache service before the store is constructed).
+            logger: Optional LoggerService for diagnostics.
+        """
+        self.db_path = os.path.join(str(directory), self.DB_FILENAME)
+        self.logger = logger
+        self._ensure_schema()
+
+    def _connect(self):
+        """Open a connection for a single operation."""
+        conn = sqlite3.connect(self.db_path, timeout=5.0)
+        # NORMAL keeps writes fast; a lost thumbnail on power failure is
+        # regenerated from the source image, so full durability buys nothing
+        conn.execute('PRAGMA synchronous=NORMAL')
+        return conn
+
+    def _ensure_schema(self):
+        try:
+            with closing(self._connect()) as conn, conn:
+                conn.execute(
+                    'CREATE TABLE IF NOT EXISTS thumbnails ('
+                    '    key TEXT PRIMARY KEY,'
+                    '    data BLOB NOT NULL,'
+                    '    created REAL NOT NULL'
+                    ')'
+                )
+        except sqlite3.Error as e:
+            if self.logger:
+                self.logger.error(f"Thumbnail store schema error at {self.db_path}: {e}")
+
+    def put(self, key: str, jpeg_bytes: bytes) -> bool:
+        """Store (or replace) the JPEG bytes for a cache key."""
+        try:
+            with closing(self._connect()) as conn, conn:
+                conn.execute(
+                    'INSERT OR REPLACE INTO thumbnails (key, data, created) VALUES (?, ?, ?)',
+                    (key, sqlite3.Binary(jpeg_bytes), time.time())
+                )
+            return True
+        except sqlite3.Error as e:
+            if self.logger:
+                self.logger.error(f"Thumbnail store write error for {key}: {e}")
+            return False
+
+    def get(self, key: str) -> Optional[bytes]:
+        """Return the JPEG bytes for a cache key, or None."""
+        try:
+            with closing(self._connect()) as conn, conn:
+                row = conn.execute(
+                    'SELECT data FROM thumbnails WHERE key = ?', (key,)
+                ).fetchone()
+            return bytes(row[0]) if row else None
+        except sqlite3.Error as e:
+            if self.logger:
+                self.logger.error(f"Thumbnail store read error for {key}: {e}")
+            return None
+
+    def has(self, key: str) -> bool:
+        """Return whether a cache key is stored, without loading its bytes."""
+        try:
+            with closing(self._connect()) as conn, conn:
+                row = conn.execute(
+                    'SELECT 1 FROM thumbnails WHERE key = ?', (key,)
+                ).fetchone()
+            return row is not None
+        except sqlite3.Error:
+            return False
+
+    def count(self) -> int:
+        """Number of stored thumbnails."""
+        try:
+            with closing(self._connect()) as conn, conn:
+                return conn.execute('SELECT COUNT(*) FROM thumbnails').fetchone()[0]
+        except sqlite3.Error:
+            return 0
+
+    def total_bytes(self) -> int:
+        """Total size of stored thumbnail data in bytes."""
+        try:
+            with closing(self._connect()) as conn, conn:
+                value = conn.execute(
+                    'SELECT COALESCE(SUM(LENGTH(data)), 0) FROM thumbnails'
+                ).fetchone()[0]
+            return int(value or 0)
+        except sqlite3.Error:
+            return 0

--- a/app/core/services/cache/ThumbnailCacheService.py
+++ b/app/core/services/cache/ThumbnailCacheService.py
@@ -25,6 +25,7 @@ from PySide6.QtGui import QPixmap, QIcon, QImage
 import qimage2ndarray
 
 from core.services.LoggerService import LoggerService
+from core.services.cache.ThumbnailBlobStore import ThumbnailBlobStore
 
 
 class ThumbnailCacheService:
@@ -63,6 +64,12 @@ class ThumbnailCacheService:
 
         # Thread safety
         self.mutex = QMutex()
+
+        # One SQLite blob container per cache directory, created lazily. New
+        # thumbnails are written there instead of as loose .jpg files, so a
+        # results folder copies as one file; legacy loose files stay readable.
+        self._blob_stores: Dict[str, ThumbnailBlobStore] = {}
+        self._blob_stores_lock = QMutex()
 
         # Memory cache size
         self.max_memory_cache = max_memory_cache
@@ -242,9 +249,37 @@ class ThumbnailCacheService:
         # Actual loading happens in get_thumbnail
         return None
 
+    def _resolve_cache_dir(self, cache_dir: Optional[Path] = None) -> Optional[Path]:
+        """Pick the effective cache directory (override > dataset > global)."""
+        if cache_dir:
+            return Path(cache_dir)
+        if self.dataset_cache_dir:
+            return self.dataset_cache_dir
+        return self.cache_dir
+
+    def _blob_store(self, cache_dir: Optional[Path]) -> Optional[ThumbnailBlobStore]:
+        """Get (or lazily create) the blob container for a cache directory."""
+        if cache_dir is None:
+            return None
+        key = str(cache_dir)
+        with QMutexLocker(self._blob_stores_lock):
+            store = self._blob_stores.get(key)
+            if store is None:
+                try:
+                    Path(cache_dir).mkdir(parents=True, exist_ok=True)
+                    store = ThumbnailBlobStore(cache_dir, logger=self.logger)
+                except Exception as e:
+                    self.logger.error(f"Could not open thumbnail store in {cache_dir}: {e}")
+                    return None
+                self._blob_stores[key] = store
+            return store
+
     def save_thumbnail_to_disk(self, cache_key: str, thumbnail_array: np.ndarray, cache_dir: Optional[Path] = None) -> bool:
         """
         Save thumbnail to disk cache.
+
+        Written into the directory's SQLite blob container rather than as a
+        loose .jpg, so large searches copy as one file per cache directory.
 
         Args:
             cache_key: Unique cache key
@@ -255,19 +290,22 @@ class ThumbnailCacheService:
             True if saved successfully
         """
         try:
-            cache_path = self.get_cache_path(cache_key, cache_dir)
+            store = self._blob_store(self._resolve_cache_dir(cache_dir))
+            if store is None:
+                return False
 
-            # Convert RGB to BGR for cv2.imwrite (cv2 expects BGR format)
+            # Convert RGB to BGR for cv2 encoding (cv2 expects BGR format)
             if len(thumbnail_array.shape) == 3 and thumbnail_array.shape[2] == 3:
                 thumbnail_bgr = cv2.cvtColor(thumbnail_array, cv2.COLOR_RGB2BGR)
             else:
                 thumbnail_bgr = thumbnail_array
 
-            # Save as JPEG with balanced quality (80 = good balance of quality and speed)
-            # Reduced from 90 for faster writes with minimal visual difference for thumbnails
-            cv2.imwrite(str(cache_path), thumbnail_bgr, [cv2.IMWRITE_JPEG_QUALITY, 80])
+            # Encode as JPEG with balanced quality (80 = good balance of quality and speed)
+            success, encoded = cv2.imencode('.jpg', thumbnail_bgr, [cv2.IMWRITE_JPEG_QUALITY, 80])
+            if not success:
+                return False
 
-            return True
+            return store.put(cache_key, encoded.tobytes())
 
         except Exception as e:
             self.logger.error(f"Error saving thumbnail to disk: {e}")
@@ -305,7 +343,7 @@ class ThumbnailCacheService:
         """
         Load thumbnail from disk cache.
 
-        Checks in order:
+        Checks in order (blob container first, then legacy loose files):
         1. Per-dataset cache (if configured)
         2. Global cache
 
@@ -316,16 +354,21 @@ class ThumbnailCacheService:
             Numpy array or None
         """
         try:
-            # Try dataset cache first if available
-            if self.dataset_cache_dir:
-                dataset_cache_path = self.get_cache_path(cache_key, self.dataset_cache_dir)
-                if dataset_cache_path.exists():
-                    img = Image.open(dataset_cache_path)
-                    return np.array(img)
+            for base_dir in (self.dataset_cache_dir, self.cache_dir):
+                if not base_dir:
+                    continue
 
-            # Fall back to global cache (if available)
-            if self.cache_dir:
-                cache_path = self.get_cache_path(cache_key)
+                # Blob container (where new thumbnails live)
+                store = self._blob_store(base_dir)
+                if store is not None:
+                    jpeg_bytes = store.get(cache_key)
+                    if jpeg_bytes:
+                        decoded = cv2.imdecode(np.frombuffer(jpeg_bytes, dtype=np.uint8), cv2.IMREAD_COLOR)
+                        if decoded is not None:
+                            return cv2.cvtColor(decoded, cv2.COLOR_BGR2RGB)
+
+                # Legacy loose .jpg written by older builds
+                cache_path = self.get_cache_path(cache_key, base_dir)
                 if cache_path.exists():
                     with Image.open(cache_path) as img:
                         return np.array(img.convert('RGB'))
@@ -357,33 +400,23 @@ class ThumbnailCacheService:
         if cached_icon is not None:
             return True
 
-        # Check per-dataset cache
-        if self.dataset_cache_dir:
-            dataset_cache_path = Path(self.dataset_cache_dir) / f"{cache_key}.jpg"
-            if dataset_cache_path.exists():
-                return True
-
-        # Check global cache (if available)
-        if self.cache_dir:
-            cache_path = self.get_cache_path(cache_key)
-            if cache_path.exists():
-                return True
-
-        # Fallback: Try legacy cache key (for backward compatibility with old caches)
+        # Legacy key covers caches written by old builds (loose files only)
         xml_path = aoi_data.get('_xml_path')  # Extract original XML path if provided
         legacy_key = self.get_legacy_cache_key(image_path, aoi_data, xml_path)
-        if legacy_key != cache_key:  # Only try if different
-            # Check per-dataset cache with legacy key
-            if self.dataset_cache_dir:
-                legacy_dataset_path = Path(self.dataset_cache_dir) / f"{legacy_key}.jpg"
-                if legacy_dataset_path.exists():
-                    return True
 
-            # Check global cache with legacy key (if available)
-            if self.cache_dir:
-                legacy_cache_path = self.get_cache_path(legacy_key)
-                if legacy_cache_path.exists():
-                    return True
+        for base_dir in (self.dataset_cache_dir, self.cache_dir):
+            if not base_dir:
+                continue
+
+            store = self._blob_store(base_dir)
+            if store is not None and store.has(cache_key):
+                return True
+
+            if self.get_cache_path(cache_key, base_dir).exists():
+                return True
+
+            if legacy_key != cache_key and self.get_cache_path(legacy_key, base_dir).exists():
+                return True
 
         return False
 
@@ -460,6 +493,10 @@ class ThumbnailCacheService:
     def clear_disk_cache(self):
         """Clear all thumbnails from disk cache."""
         try:
+            # Drop the store handles first: their database files are about to
+            # be deleted, and fresh stores will recreate the schema lazily
+            with QMutexLocker(self._blob_stores_lock):
+                self._blob_stores = {}
             if self.cache_dir:
                 shutil.rmtree(self.cache_dir)
                 self.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -477,15 +514,18 @@ class ThumbnailCacheService:
         Returns:
             Dictionary with cache statistics
         """
-        # Count disk cache files
+        # Count disk cache entries: blob containers plus legacy loose files
         disk_count = 0
         disk_size = 0
-        if self.cache_dir:
-            disk_count += sum(1 for _ in self.cache_dir.rglob("*.jpg"))
-            disk_size += sum(f.stat().st_size for f in self.cache_dir.rglob("*.jpg"))
-        if self.dataset_cache_dir:
-            disk_count += sum(1 for _ in self.dataset_cache_dir.rglob("*.jpg"))
-            disk_size += sum(f.stat().st_size for f in self.dataset_cache_dir.rglob("*.jpg"))
+        for base_dir in (self.cache_dir, self.dataset_cache_dir):
+            if not base_dir:
+                continue
+            store = self._blob_store(base_dir)
+            if store is not None:
+                disk_count += store.count()
+                disk_size += store.total_bytes()
+            disk_count += sum(1 for _ in base_dir.rglob("*.jpg"))
+            disk_size += sum(f.stat().st_size for f in base_dir.rglob("*.jpg"))
 
         # Get memory cache stats
         cache_info = self.get_thumbnail_from_memory.cache_info()

--- a/app/tests/core/services/cache/test_cache_services.py
+++ b/app/tests/core/services/cache/test_cache_services.py
@@ -12,6 +12,9 @@ from unittest.mock import patch, MagicMock
 from core.services.cache.ThumbnailCacheService import ThumbnailCacheService
 from core.services.cache.ColorCacheService import ColorCacheService
 from core.services.cache.TemperatureCacheService import TemperatureCacheService
+from core.services.cache.ThumbnailBlobStore import ThumbnailBlobStore
+from pathlib import Path
+from PIL import Image
 
 
 @pytest.fixture
@@ -161,3 +164,113 @@ def test_temperature_cache_service_save():
 
     # Verify temperature was stored
     assert 'temperature' in aoi or service.get_temperature('test_image.jpg', aoi) is not None
+
+# ---------------------------------------------------------------------------
+# SQLite blob container: thousands of loose thumbnail files become one
+# thumbnails.db per cache directory; legacy loose files stay readable.
+# ---------------------------------------------------------------------------
+
+
+def test_saved_thumbnails_land_in_one_container_not_loose_files(thumbnail_cache_service, sample_aoi):
+    svc = thumbnail_cache_service
+    thumbnail = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
+
+    for i in range(5):
+        aoi = dict(sample_aoi, center=(100 + i, 100))
+        key = svc.get_cache_key(f'img_{i}.jpg', aoi)
+        assert svc.save_thumbnail_to_disk(key, thumbnail) is True
+
+    cache_dir = Path(svc.dataset_cache_dir)
+    assert (cache_dir / ThumbnailBlobStore.DB_FILENAME).exists()
+    assert list(cache_dir.rglob('*.jpg')) == []  # no loose files anymore
+
+
+def test_blob_roundtrip_preserves_thumbnail(thumbnail_cache_service, sample_aoi):
+    svc = thumbnail_cache_service
+    thumbnail = np.full((64, 64, 3), (200, 30, 90), dtype=np.uint8)
+    key = svc.get_cache_key('roundtrip.jpg', sample_aoi)
+
+    assert svc.save_thumbnail_to_disk(key, thumbnail) is True
+    loaded = svc.load_thumbnail_from_disk(key)
+
+    assert loaded is not None
+    assert loaded.shape == (64, 64, 3)
+    # JPEG at quality 80 is lossy but close; channel order must be preserved
+    assert np.allclose(loaded.mean(axis=(0, 1)), thumbnail.mean(axis=(0, 1)), atol=6)
+
+
+def test_is_cached_sees_blob_entries(thumbnail_cache_service, sample_aoi):
+    svc = thumbnail_cache_service
+    thumbnail = np.zeros((32, 32, 3), dtype=np.uint8)
+
+    assert svc.is_cached('blobbed.jpg', sample_aoi) is False
+    key = svc.get_cache_key('blobbed.jpg', sample_aoi)
+    svc.save_thumbnail_to_disk(key, thumbnail)
+    assert svc.is_cached('blobbed.jpg', sample_aoi) is True
+
+
+def test_legacy_loose_files_remain_readable(thumbnail_cache_service, sample_aoi):
+    """Caches written by older builds (loose .jpg per thumbnail) still load."""
+    svc = thumbnail_cache_service
+    key = svc.get_cache_key('legacy.jpg', sample_aoi)
+    legacy_path = Path(svc.dataset_cache_dir) / f"{key}.jpg"
+    Image.new('RGB', (48, 48), (10, 250, 10)).save(legacy_path)
+
+    loaded = svc.load_thumbnail_from_disk(key)
+
+    assert loaded is not None
+    assert loaded.shape == (48, 48, 3)
+    assert loaded[0, 0, 1] > 200  # green channel survived (RGB order)
+    assert svc.is_cached('legacy.jpg', sample_aoi) is True
+
+
+def test_clear_disk_cache_resets_container(thumbnail_cache_service, sample_aoi):
+    svc = thumbnail_cache_service
+    thumbnail = np.zeros((32, 32, 3), dtype=np.uint8)
+    key = svc.get_cache_key('cleared.jpg', sample_aoi)
+    svc.save_thumbnail_to_disk(key, thumbnail)
+
+    svc.clear_disk_cache()
+
+    assert svc.load_thumbnail_from_disk(key) is None
+    # And the cache still works after the reset
+    assert svc.save_thumbnail_to_disk(key, thumbnail) is True
+    assert svc.load_thumbnail_from_disk(key) is not None
+
+
+def test_cache_stats_count_blob_entries(thumbnail_cache_service, sample_aoi):
+    svc = thumbnail_cache_service
+    thumbnail = np.zeros((32, 32, 3), dtype=np.uint8)
+    for i in range(3):
+        key = svc.get_cache_key(f'stat_{i}.jpg', sample_aoi)
+        svc.save_thumbnail_to_disk(key, thumbnail)
+
+    stats = svc.get_cache_stats()
+
+    assert stats['disk_count'] == 3
+    assert stats['disk_size_mb'] > 0
+
+
+def test_blob_store_concurrent_writes(tmp_path):
+    """The GUI thread and worker pool write concurrently; nothing may be lost."""
+    import threading
+
+    store = ThumbnailBlobStore(tmp_path)
+    errors = []
+
+    def write_batch(offset):
+        try:
+            for i in range(25):
+                assert store.put(f'key_{offset}_{i}', b'\xff\xd8jpegbytes')
+        except Exception as e:  # pragma: no cover - failure detail for the assert below
+            errors.append(e)
+
+    threads = [threading.Thread(target=write_batch, args=(t,)) for t in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert store.count() == 100
+    assert store.get('key_3_24') == b'\xff\xd8jpegbytes'

--- a/app/tests/core/services/image/test_aoi_similarity_service.py
+++ b/app/tests/core/services/image/test_aoi_similarity_service.py
@@ -368,8 +368,9 @@ class TestCropFallback:
         assert crop.shape == (THUMB_SIZE, THUMB_SIZE, 3)
 
         key = service.thumbnail_cache.get_cache_key(str(source_path), aoi)
-        cached = service.thumbnail_cache.dataset_cache_dir / f'{key}.jpg'
-        assert cached.exists()
+        # The write-back lands in the cache's blob container; assert through
+        # the cache API rather than the on-disk layout
+        assert service.thumbnail_cache.load_thumbnail_from_disk(key) is not None
 
         descriptor = service.compute_descriptor(crop, aoi)
         assert descriptor.is_chromatic


### PR DESCRIPTION
## The problem

A large search leaves **thousands of loose thumbnail JPEGs** in `.thumbnails` directories. Copying results between drives or machines (routine for distributed review) is dominated by per-file filesystem overhead — thousands of tiny files copy far slower than the same bytes in one large file.

## The change

New thumbnails are written into a single **`thumbnails.db`** (SQLite blob store) per cache directory, keyed by the **same portable md5 cache keys** and holding the **same JPEG bytes** as the loose files did. A results folder now moves as a handful of large files. Rendering is untouched — the cache service decodes the same JPEG bytes into the same arrays/icons it always produced.

**Backward compatibility (no migration needed):** reads check the container first, then fall back to legacy loose `.jpg` files — under both the current portable key and the legacy key — so existing caches keep working as-is. `clear_disk_cache` and cache stats account for both.

**Concurrency:** the store opens a connection per operation (safe across the GUI thread and the 4-worker thumbnail pool, no shared-connection registry), uses the rollback journal so an idle cache is exactly one file, and `synchronous=NORMAL` since a lost thumbnail is simply regenerated. Connections are explicitly closed — sqlite3's context manager only manages the transaction, and an open handle locks the file on Windows.

## Tests

24 cache tests pass (7 new: single-container layout with zero loose files, JPEG roundtrip with channel-order check, `is_cached` via the container, legacy loose-file readability, clear-and-recreate, stats counting, and a 4-thread concurrent-write integrity test), plus 33 similarity-service tests and 625 viewer controller tests. `flake8` clean.