### PR TITLE
fix: WALDO pre-pass measures stored image orientation instead of assuming the mounting model

### DIFF
--- a/app/core/services/image/AOIService.py
+++ b/app/core/services/image/AOIService.py
@@ -155,6 +155,9 @@ class AOIService:
             roll = self.image_service.get_gimbal_roll() or 0.0
             if abs(roll) > 90.0:
                 roll = 0.0
+            # WALDO v6 stamps expect the roll about the flight axis; None keeps
+            # the historical yaw-axis behaviour for everything else
+            roll_axis = self.image_service.get_roll_axis_azimuth() if roll else None
 
             # Get altitude - use override or get from ImageService
             if agl_override_m and agl_override_m > 0:
@@ -238,7 +241,8 @@ class AOIService:
             initial_result = self._calculate_ground_position(
                 lat0, lon0, u, v, cx, cy, img_width, img_height,
                 focal_mm, sensor_w_mm, sensor_h_mm,
-                reported_agl, pitch, yaw, roll
+                reported_agl, pitch, yaw, roll,
+                roll_axis_azimuth_deg=roll_axis
             )
 
             if initial_result is None:
@@ -258,7 +262,8 @@ class AOIService:
                     reported_agl, pitch, yaw, roll,
                     terrain_service,
                     absolute_alt,
-                    geoid_undulation
+                    geoid_undulation,
+                    roll_axis_azimuth_deg=roll_axis
                 )
 
             # No terrain data - return flat terrain result
@@ -453,7 +458,8 @@ class AOIService:
         img_width: int, img_height: int,
         focal_mm: float, sensor_w_mm: float, sensor_h_mm: float,
         altitude_m: float, pitch_deg: float, yaw_deg: float,
-        roll_deg: float = 0.0
+        roll_deg: float = 0.0,
+        roll_axis_azimuth_deg: Optional[float] = None
     ) -> Optional[Tuple[float, float]]:
         """
         Calculate ground position using 3D ray-casting projection.
@@ -475,6 +481,11 @@ class AOIService:
                 Positive rotates the optical axis to the left of heading; negative
                 to the right. Used for fixed-wing rigs (WALDO ±22.5°) where the
                 pod is mounted with outward roll relative to flight direction.
+            roll_axis_azimuth_deg: Compass azimuth of the axis the roll rotates
+                about. Default None keeps the historical behaviour (the axis at
+                the yaw azimuth). WALDO processor version >= 6 stamps roll about
+                the flight axis, which can differ arbitrarily from the stored
+                image orientation.
 
         Returns:
             (lat, lon) or None
@@ -536,7 +547,11 @@ class AOIService:
         # behaviour is preserved at roll_deg = 0.
         if roll_deg != 0.0:
             roll_rad = math.radians(roll_deg)
-            heading_axis = np.array([math.cos(opt_azimuth), math.sin(opt_azimuth), 0.0])
+            if roll_axis_azimuth_deg is not None:
+                axis_azimuth = math.radians(roll_axis_azimuth_deg)
+            else:
+                axis_azimuth = opt_azimuth
+            heading_axis = np.array([math.cos(axis_azimuth), math.sin(axis_azimuth), 0.0])
             kx, ky, kz = heading_axis
             K = np.array([
                 [0.0, -kz, ky],
@@ -643,7 +658,8 @@ class AOIService:
         roll: float,
         terrain_service,
         absolute_alt: Optional[float] = None,
-        precomputed_geoid: Optional[float] = None
+        precomputed_geoid: Optional[float] = None,
+        roll_axis_azimuth_deg: Optional[float] = None
     ) -> AOIGPSResult:
         """
         Calculate AOI position using terrain elevation data with iterative refinement.
@@ -732,7 +748,8 @@ class AOIService:
             new_result = self._calculate_ground_position(
                 drone_lat, drone_lon, u, v, cx, cy, img_width, img_height,
                 focal_mm, sensor_w_mm, sensor_h_mm,
-                effective_agl, pitch, yaw, roll
+                effective_agl, pitch, yaw, roll,
+                roll_axis_azimuth_deg=roll_axis_azimuth_deg
             )
 
             if new_result is None:

--- a/app/core/services/image/ImageService.py
+++ b/app/core/services/image/ImageService.py
@@ -204,6 +204,62 @@ class ImageService:
         except (TypeError, ValueError):
             return None
 
+    def get_flight_yaw(self):
+        """Retrieve the aircraft/drone flight heading from XMP metadata.
+
+        Distinct from the gimbal yaw: for WALDO imagery the stored image
+        orientation (GimbalYawDegree) and the plane's travel direction
+        (FlightYawDegree) can differ arbitrarily, and the pod-tilt roll is
+        physically anchored to the flight direction.
+
+        Returns:
+            float or None: Heading in degrees [0, 360), or None if unavailable.
+        """
+        if self.xmp_data is None:
+            return None
+        for key in ('FlightYawDegree', 'drone-dji:FlightYawDegree'):
+            value = self.xmp_data.get(key)
+            if value is not None:
+                try:
+                    return float(value) % 360.0
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    def get_waldo_processor_version(self):
+        """Return the WALDO pre-pass processor version stamped on this image.
+
+        Returns:
+            int or None: Version number, or None for non-WALDO imagery.
+        """
+        if self.xmp_data is None:
+            return None
+        for key in ('waldo:ProcessorVersion', 'ProcessorVersion',
+                    'XMP-waldo:ProcessorVersion'):
+            value = self.xmp_data.get(key)
+            if value is not None:
+                try:
+                    return int(str(value))
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    def get_roll_axis_azimuth(self):
+        """Compass azimuth of the axis the stamped gimbal roll rotates about.
+
+        WALDO processor version >= 6 stamps the pod-tilt roll about the FLIGHT
+        axis, decoupled from the stored image orientation. Returns None for
+        everything else, which keeps the historical behaviour (roll about the
+        gimbal-yaw axis).
+
+        Returns:
+            float or None: Axis azimuth in degrees, or None for legacy handling.
+        """
+        version = self.get_waldo_processor_version()
+        if version is None or version < 6:
+            return None
+        return self.get_flight_yaw()
+
     def get_camera_yaw(self):
         """
         Get the camera yaw/bearing (direction the camera is pointing).
@@ -582,6 +638,7 @@ class ImageService:
                 'pitch': fg.pitch_deg,
                 'yaw': fg.yaw_deg,
                 'roll': fg.roll_deg,
+                'roll_axis': self.get_roll_axis_azimuth() if fg.roll_deg else None,
                 'reported_agl': reported_agl,
                 'drone_terrain_elev_m': drone_terrain_elev_m,
                 'drone_absolute_elev_m': drone_absolute_elev_m,
@@ -634,6 +691,7 @@ class ImageService:
             ctx['cx'], ctx['cy'], ctx['img_w'], ctx['img_h'],
             ctx['focal_mm'], ctx['sensor_w_mm'], ctx['sensor_h_mm'],
             reported_agl, ctx['pitch'], ctx['yaw'], ctx['roll'],
+            roll_axis_azimuth_deg=ctx['roll_axis'],
         )
         if initial is None:
             cache[ck] = None
@@ -660,6 +718,7 @@ class ImageService:
                 ctx['cx'], ctx['cy'], ctx['img_w'], ctx['img_h'],
                 ctx['focal_mm'], ctx['sensor_w_mm'], ctx['sensor_h_mm'],
                 effective_agl, ctx['pitch'], ctx['yaw'], ctx['roll'],
+                roll_axis_azimuth_deg=ctx['roll_axis'],
             )
             if new_pos is None:
                 break

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -112,6 +112,7 @@ class WaldoProcessResult:
     already_current: int = 0
     skipped: int = 0  # non-WALDO files
     errors: List[Tuple[str, str]] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
     cancelled: bool = False
 
 
@@ -367,6 +368,125 @@ class WaldoMetadataService:
         )
         return mean_deg
 
+    # ------------------------------------------------------------------
+    # Capture-time audit
+    # ------------------------------------------------------------------
+    #
+    # A field camera with a mis-set clock silently poisons every time-based
+    # computation (solar position, shadows) while looking perfectly healthy:
+    # a 12-hour AM/PM flip produces nearly the same solar ELEVATION, so
+    # nothing obvious breaks. These checks catch the detectable symptoms and
+    # warn the operator; they never modify the files.
+
+    AUDIT_SAMPLE_FILES = 3
+    AUDIT_TZ_TOLERANCE_H = 1.75     # |stamped offset - longitude/15| beyond this is suspect
+    AUDIT_MTIME_SLACK_S = 3600.0    # claimed capture this far after file-write is impossible
+    AUDIT_DAYLIGHT_BRIGHTNESS = 45  # mean pixel value that cannot be a night exposure
+
+    @staticmethod
+    def _parse_offset_hours(raw) -> Optional[float]:
+        """Parse an EXIF OffsetTime like '-06:00' into hours, or None."""
+        if raw is None:
+            return None
+        try:
+            text = raw.decode() if isinstance(raw, bytes) else str(raw)
+            m = re.match(r'^([+-])(\d{2}):(\d{2})$', text.strip())
+            if not m:
+                return None
+            sign = -1.0 if m.group(1) == '-' else 1.0
+            return sign * (int(m.group(2)) + int(m.group(3)) / 60.0)
+        except Exception:
+            return None
+
+    def audit_capture_times(self, paths: List[str]) -> List[str]:
+        """Sanity-check the capture-time metadata of a few WALDO images.
+
+        Checks:
+        - Timezone vs GPS longitude: the stamped OffsetTime should be within
+          ~AUDIT_TZ_TOLERANCE_H hours of longitude/15 (solar time; the margin
+          absorbs civil-timezone and DST skew). A camera set to the wrong
+          zone fails this deterministically.
+        - Impossible file times: a capture time later than the file's own
+          last-modified time means the clock runs ahead (mtime survives
+          Windows copies, so this works even on relocated datasets when the
+          post-flight files were written soon after the flight).
+        - Sun below the horizon at the claimed time while the imagery is
+          clearly daylight.
+
+        Returns:
+            Human-readable warning strings (empty when nothing is suspect).
+        """
+        warnings: List[str] = []
+        sampled = paths[:self.AUDIT_SAMPLE_FILES]
+        for path in sampled:
+            name = os.path.basename(path)
+            try:
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                exif_ifd = exif.get('Exif', {})
+                raw_dt = exif_ifd.get(piexif.ExifIFD.DateTimeOriginal)
+                offset_h = self._parse_offset_hours(
+                    exif_ifd.get(piexif.ExifIFD.OffsetTimeOriginal)
+                    or exif_ifd.get(piexif.ExifIFD.OffsetTime))
+                gps = LocationInfo.get_gps(exif_data=exif)
+                if raw_dt is None or gps is None:
+                    continue
+                local_dt = datetime.strptime(
+                    (raw_dt.decode() if isinstance(raw_dt, bytes) else str(raw_dt)).strip(),
+                    '%Y:%m:%d %H:%M:%S')
+
+                # 1. Timezone field vs longitude
+                if offset_h is not None:
+                    solar_offset = gps['longitude'] / 15.0
+                    if abs(offset_h - solar_offset) > self.AUDIT_TZ_TOLERANCE_H:
+                        warnings.append(
+                            f"{name}: camera timezone {offset_h:+.0f}h does not match its "
+                            f"GPS longitude (expects about {solar_offset:+.1f}h). The "
+                            f"camera clock settings are suspect; sun/shadow features "
+                            f"will be unreliable."
+                        )
+
+                # 2. Capture claimed after the file was written
+                if offset_h is not None:
+                    claimed_utc = local_dt.replace(tzinfo=timezone.utc) - timedelta(hours=offset_h)
+                    mtime_utc = datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+                    ahead_s = (claimed_utc - mtime_utc).total_seconds()
+                    if ahead_s > self.AUDIT_MTIME_SLACK_S:
+                        warnings.append(
+                            f"{name}: claimed capture time is {ahead_s / 3600.0:.1f}h AFTER "
+                            f"the file was last written - the camera clock runs ahead "
+                            f"(a 12-hour AM/PM error is the usual cause)."
+                        )
+
+                    # 3. Night-time claim on daylight imagery
+                    try:
+                        elev, _az = get_solar_position(
+                            gps['latitude'], gps['longitude'], claimed_utc)
+                    except Exception:
+                        elev = None
+                    if elev is not None and elev < -2.0:
+                        img = cv2.imdecode(np.fromfile(path, dtype=np.uint8),
+                                           cv2.IMREAD_GRAYSCALE)
+                        if img is not None:
+                            small = img[::8, ::8]
+                            if float(small.mean()) > self.AUDIT_DAYLIGHT_BRIGHTNESS:
+                                warnings.append(
+                                    f"{name}: the sun was below the horizon at the claimed "
+                                    f"capture time, but the image is clearly daylight - "
+                                    f"the camera clock is wrong."
+                                )
+            except Exception as e:
+                self.logger.warning(f"Capture-time audit failed for {name}: {e}")
+
+        # One warning per distinct message class is enough; drop duplicates
+        deduped: List[str] = []
+        seen_kinds = set()
+        for w in warnings:
+            kind = w.split(': ', 1)[1][:40]
+            if kind not in seen_kinds:
+                seen_kinds.add(kind)
+                deduped.append(w)
+        return deduped
+
     def compute_relative_altitude_m(
         self, lat: float, lon: float, gps_alt_ellipsoidal_m: float
     ) -> Tuple[float, float]:
@@ -607,6 +727,7 @@ class WaldoMetadataService:
         #    folder of 500+ images doesn't sit at 0% during this pass).
         emit(0, 0, "Reading image metadata...")
         records: List[WaldoImageRecord] = []
+        waldo_paths: List[str] = []
         n_paths = len(image_paths)
         for i, path in enumerate(image_paths):
             if cancel_cb():
@@ -618,11 +739,20 @@ class WaldoMetadataService:
             if cam_idx is None:
                 result.skipped += 1
                 continue
+            waldo_paths.append(path)
             if self.is_already_processed(path):
                 result.already_current += 1
                 continue
             rec = self._read_record(path, cam_idx)
             records.append(rec)
+
+        # Capture-time audit runs on every open (already-current files too):
+        # a mis-set camera clock stays wrong until the operator fixes it
+        if waldo_paths:
+            emit(0, 0, "Auditing capture-time metadata...")
+            result.warnings.extend(self.audit_capture_times(waldo_paths))
+            for warning in result.warnings:
+                self.logger.warning(f"WALDO time audit: {warning}")
 
         if not records:
             return result

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -28,13 +28,26 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Dict, List, Optional, Tuple
 
+import cv2
+import numpy as np
+
 from helpers.MetaDataHelper import MetaDataHelper
 from helpers.LocationInfo import LocationInfo
 from core.services.LoggerService import LoggerService
+from core.services.shadow.SolarPosition import (
+    SolarTimeUnresolvable,
+    get_solar_position,
+    resolve_capture_utc,
+)
 
 
 WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
-WALDO_PROCESSOR_VERSION = "5"
+# Version 6: GimbalYawDegree is the *measured* image-top bearing (from
+# inter-frame content motion vs GPS track) rather than the assumed
+# heading+180 mounting model, and GimbalRollDegree is expressed about the
+# FLIGHT axis (FlightYawDegree) rather than the gimbal-yaw axis. Consumers
+# key the roll-axis convention off this version.
+WALDO_PROCESSOR_VERSION = "6"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 
@@ -42,6 +55,33 @@ DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 STATIONARY_THRESHOLD_M = 5.0
 MAX_NEIGHBOR_DT_S = 30.0
 OUTWARD_ROLL_DEG = 22.5
+
+# Orientation-measurement tunables. Field imagery showed the mounting-model
+# yaw assumption off by ~41 degrees (post-flight software had normalized the
+# frames north-up), so orientation is measured from the imagery itself.
+#
+# Two complementary measurements:
+# - Sun-shadow axis: capture time + GPS give the exact solar azimuth, and the
+#   dominant dark-streak direction in the frame gives where that shadow lies
+#   in image coordinates. Precise (a few degrees) but ambiguous by 180.
+# - Inter-frame motion vs GPS track: feature matching between consecutive
+#   frames. Coarse on tilted fixed-wing imagery (tens of degrees of scatter)
+#   but unambiguous - exactly what is needed to pick the shadow's half-plane.
+ORIENTATION_SAMPLE_PAIRS = 8       # consecutive-image pairs sampled per camera
+ORIENTATION_MIN_PAIRS = 3          # accept a measurement only with this many good pairs
+ORIENTATION_MAX_SPREAD_DEG = 12.0  # ...agreeing to within this circular std-dev
+ORIENTATION_MIN_BASELINE_M = 30.0  # pairs closer than this give unreliable bearings
+ORIENTATION_MIN_INLIERS = 20       # ORB/RANSAC inliers required per pair
+ORIENTATION_DOWNSCALE = 6          # feature matching runs at 1/N resolution
+SHADOW_SAMPLE_IMAGES = 7           # frames sampled per camera for the shadow axis
+SHADOW_MIN_STREAKS = 40            # dark elongated components needed per frame
+SHADOW_MIN_SUN_ELEV_DEG = 5.0      # below this the sun casts no usable shadows
+SHADOW_MIN_SAMPLES = 3             # accept the shadow route with this many frames
+# Terrain slope shears individual frames' shadows by up to ~20 deg, but the
+# shear direction is random across a flight, so the per-frame samples are
+# gated on the standard error of their circular mean rather than raw spread.
+SHADOW_MAX_SPREAD_DEG = 30.0       # raw-spread sanity cap (systematic problem)
+SHADOW_MAX_STDERR_DEG = 6.0        # confidence required of the aggregated mean
 
 # Filename prefix → cam index. 0_* = left, 1_* = right.
 _WALDO_PREFIX_RE = re.compile(r'^(?P<cam>[01])_')
@@ -130,40 +170,323 @@ class WaldoMetadataService:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def compute_optical_axis_angles(heading_deg: float, cam_idx: int) -> Dict[str, float]:
+    def compute_optical_axis_angles(heading_deg: float, cam_idx: int,
+                                    image_up_deg: Optional[float] = None) -> Dict[str, float]:
         """Return drone-dji-style gimbal triple for a WALDO capture.
 
-        Pod mounting (per WALDO operator, 2026-05-04 + screenshot):
+        Yaw — the compass bearing of the stored JPEG's top edge, which is
+        what AOIService and the FOV-box renderer consume:
 
-        - Cam 0 (`0_*`) — RIGHT pod. Body lens-down, body top forward,
-          body rotated CCW (lens tilts to plane's RIGHT). The on-disk
-          JPEG is rotated 180° by WALDO post-flight software so that
-          reflies in the opposite direction render consistently with the
-          forward pass. Net effect: stored image-top = plane backward.
-        - Cam 1 (`1_*`) — LEFT pod. Body lens-down, body top backward,
-          body rotated CCW (lens tilts to plane's LEFT). No software
-          rotation. Stored image-top = body top = plane backward.
+        - When `image_up_deg` is given it is the *measured* orientation
+          (from inter-frame content motion vs the GPS track; see
+          measure_image_up_bearing) and is used directly. Field imagery
+          proved the mounting model below wrong by ~41° on flights whose
+          post-flight software had normalized frames north-up, so a
+          measurement always wins over the model.
+        - Fallback (no measurement): the pod-mounting model, per WALDO
+          operator 2026-05-04 + screenshot. Cam 0 (`0_*`, RIGHT pod) is
+          stored rotated 180° by post-flight software; cam 1 (`1_*`,
+          LEFT pod) has body top facing the tail. Both stored images then
+          share image-top = plane backward: `yaw = heading + 180°`.
 
-        Both stored images therefore share image-top = plane backward, so
-        `GimbalYawDegree = heading + 180°` for both cameras — that is the
-        compass direction the saved JPEG's top edge points to, which is
-        what AOIService and the FOV-box renderer consume.
-
-        Roll sign differs because the two pods physically tilt to
-        opposite sides. With yaw flipped 180° from heading, the
-        Rodrigues rotation axis used by AOIService is the *backward*
-        direction; `roll = +OUTWARD_ROLL_DEG` about that axis tilts
-        the optical axis to plane right (cam 0), and the negative value
-        tilts to plane left (cam 1). Pitch is fixed at nadir.
+        Roll — the pods physically tilt ±OUTWARD_ROLL_DEG cross-track
+        (cam 0 to plane RIGHT, cam 1 to plane LEFT). As of processor
+        version 6 the roll is expressed about the FLIGHT axis
+        (FlightYawDegree), which stays physically meaningful whatever the
+        stored image orientation is. About the *forward* flight axis a
+        positive Rodrigues roll tilts the optical axis to plane LEFT, so
+        cam 0 (right tilt) takes -OUTWARD_ROLL_DEG and cam 1 takes
+        +OUTWARD_ROLL_DEG — the opposite signs from version 5, which
+        expressed roll about the backward gimbal-yaw axis. Consumers pick
+        the axis by ProcessorVersion. Pitch is fixed at nadir.
         """
         if cam_idx not in (0, 1):
             raise ValueError(f"Invalid WALDO cam_idx {cam_idx}")
-        roll = (+OUTWARD_ROLL_DEG) if cam_idx == 0 else (-OUTWARD_ROLL_DEG)
+        if image_up_deg is not None:
+            yaw = float(image_up_deg) % 360.0
+        else:
+            yaw = (float(heading_deg) + 180.0) % 360.0
+        roll = (-OUTWARD_ROLL_DEG) if cam_idx == 0 else (+OUTWARD_ROLL_DEG)
         return {
             'pitch': -90.0,
-            'yaw': (float(heading_deg) + 180.0) % 360.0,
+            'yaw': yaw,
             'roll': roll,
         }
+
+    # ------------------------------------------------------------------
+    # Image-orientation measurement
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _pair_orientation_sample(path_a: str, path_b: str,
+                                 bearing_deg: float) -> Optional[Tuple[float, int]]:
+        """Measure image-top bearing from one consecutive image pair.
+
+        Feature-matches the two frames, takes the content shift, and derives
+        which compass bearing the image's top edge points to: the camera's
+        world motion (GPS bearing a->b) appears in image coordinates as the
+        negated content shift, and the angle between them is the rotation of
+        the image frame relative to north.
+
+        Returns:
+            (image_up_bearing_deg, inlier_count), or None when the pair
+            cannot be matched confidently.
+        """
+        try:
+            f = ORIENTATION_DOWNSCALE
+            imgs = []
+            for p in (path_a, path_b):
+                img = cv2.imdecode(np.fromfile(p, dtype=np.uint8), cv2.IMREAD_GRAYSCALE)
+                if img is None:
+                    return None
+                imgs.append(cv2.resize(img, (img.shape[1] // f, img.shape[0] // f),
+                                       interpolation=cv2.INTER_AREA))
+            a, b = imgs
+
+            orb = cv2.ORB_create(3000)
+            ka, da = orb.detectAndCompute(a, None)
+            kb, db = orb.detectAndCompute(b, None)
+            if da is None or db is None or len(ka) < ORIENTATION_MIN_INLIERS:
+                return None
+            matcher = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+            matches = sorted(matcher.match(da, db), key=lambda m: m.distance)[:800]
+            if len(matches) < ORIENTATION_MIN_INLIERS:
+                return None
+            src = np.float32([ka[m.queryIdx].pt for m in matches]).reshape(-1, 1, 2)
+            dst = np.float32([kb[m.trainIdx].pt for m in matches]).reshape(-1, 1, 2)
+            M, inliers = cv2.estimateAffinePartial2D(src, dst, ransacReprojThreshold=3.0)
+            if M is None or inliers is None:
+                return None
+            n_inliers = int(inliers.sum())
+            if n_inliers < ORIENTATION_MIN_INLIERS:
+                return None
+            # Consecutive frames share orientation; a big relative rotation
+            # means the affine locked onto repeating texture, not real overlap
+            rel_rot = math.degrees(math.atan2(M[1, 0], M[0, 0]))
+            if abs(rel_rot) > 8.0:
+                return None
+
+            # Ground content at a's centre appears in b displaced by the
+            # camera's motion, negated
+            c = np.array([a.shape[1] / 2.0, a.shape[0] / 2.0, 1.0])
+            mapped = M @ c
+            content_dx, content_dy = mapped[0] - c[0], mapped[1] - c[1]
+            cam_dx, cam_dy = -content_dx, -content_dy
+            if abs(cam_dx) < 1e-6 and abs(cam_dy) < 1e-6:
+                return None
+            # Camera motion direction in image terms, clockwise from image-up
+            motion_img_deg = math.degrees(math.atan2(cam_dx, -cam_dy)) % 360.0
+            image_up = (float(bearing_deg) - motion_img_deg) % 360.0
+            return image_up, n_inliers
+        except Exception:
+            return None
+
+    @staticmethod
+    def _circular_stats(angles_deg: List[float],
+                        weights: List[float]) -> Tuple[float, float]:
+        """Weighted circular mean and spread (degrees) of compass angles."""
+        angles = np.radians(np.asarray(angles_deg, dtype=float))
+        wgt = np.asarray(weights, dtype=float)
+        sin_sum = float((wgt * np.sin(angles)).sum())
+        cos_sum = float((wgt * np.cos(angles)).sum())
+        mean_deg = math.degrees(math.atan2(sin_sum, cos_sum)) % 360.0
+        resultant = math.hypot(sin_sum, cos_sum) / float(wgt.sum())
+        resultant = min(1.0, max(1e-9, resultant))
+        spread_deg = math.degrees(math.sqrt(-2.0 * math.log(resultant)))
+        return mean_deg, spread_deg
+
+    def _pair_motion_bearing(self, group: List["WaldoImageRecord"]) -> Optional[Tuple[float, float, int]]:
+        """Coarse image-top bearing from inter-frame motion vs the GPS track.
+
+        Returns:
+            (mean_deg, spread_deg, sample_count), or None with no usable pairs.
+        """
+        candidates = []
+        for a, b in zip(group, group[1:]):
+            north_m = (b.lat - a.lat) * 111320.0
+            east_m = (b.lon - a.lon) * 111320.0 * math.cos(math.radians(a.lat))
+            dist = math.hypot(north_m, east_m)
+            if dist < ORIENTATION_MIN_BASELINE_M:
+                continue
+            bearing = math.degrees(math.atan2(east_m, north_m)) % 360.0
+            candidates.append((a.path, b.path, bearing))
+        if not candidates:
+            return None
+
+        step = max(1, len(candidates) // ORIENTATION_SAMPLE_PAIRS)
+        samples = []
+        for path_a, path_b, bearing in candidates[::step][:ORIENTATION_SAMPLE_PAIRS]:
+            result = self._pair_orientation_sample(path_a, path_b, bearing)
+            if result is not None:
+                samples.append(result)
+        if len(samples) < 2:
+            return None
+        mean_deg, spread_deg = self._circular_stats(
+            [s[0] for s in samples], [s[1] for s in samples])
+        return mean_deg, spread_deg, len(samples)
+
+    @staticmethod
+    def _tile_shadow_axis(path: str) -> Optional[Tuple[float, int]]:
+        """Dominant dark-streak axis of a frame, degrees CW from image-up mod 180.
+
+        Standing trees and snags cast long thin shadows; their common
+        direction is the solar shadow direction in image coordinates. Uses
+        the elongation-filtered dark connected components of a downscaled
+        central crop.
+
+        Returns:
+            (axis_deg_mod_180, streak_count), or None when the frame has too
+            few usable streaks (overcast, water, uniform terrain).
+        """
+        try:
+            img = cv2.imdecode(np.fromfile(path, dtype=np.uint8), cv2.IMREAD_GRAYSCALE)
+            if img is None:
+                return None
+            h, w = img.shape
+            crop = img[h // 4:3 * h // 4:2, w // 4:3 * w // 4:2]
+            dark = (crop < np.percentile(crop, 8)).astype(np.uint8)
+            dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
+            n, labels, stats, _ = cv2.connectedComponentsWithStats(dark, 8)
+            angles, weights = [], []
+            for i in range(1, n):
+                if stats[i, cv2.CC_STAT_AREA] < 60:
+                    continue
+                ys, xs = np.where(labels == i)
+                xs = xs - xs.mean()
+                ys = ys - ys.mean()
+                cov = np.cov(np.stack([xs, ys]))
+                evals, evecs = np.linalg.eigh(cov)
+                if evals[1] / max(evals[0], 1e-6) < 6:
+                    continue  # keep only long, thin components
+                v = evecs[:, 1]
+                angles.append(math.degrees(math.atan2(v[0], -v[1])) % 180)
+                weights.append(float(stats[i, cv2.CC_STAT_AREA]))
+            if len(angles) < SHADOW_MIN_STREAKS:
+                return None
+            # Circular stats on doubled angles (axes are 180-periodic)
+            doubled = np.radians(np.asarray(angles) * 2.0)
+            wgt = np.asarray(weights)
+            mean2 = math.atan2(float((wgt * np.sin(doubled)).sum()),
+                               float((wgt * np.cos(doubled)).sum()))
+            return (math.degrees(mean2) / 2.0) % 180, len(angles)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _resolve_shadow_world_azimuth(record: "WaldoImageRecord") -> Optional[float]:
+        """Compass direction shadows point at this record's time/place, or None."""
+        try:
+            exif = MetaDataHelper.get_exif_data_piexif(record.path)
+            try:
+                xmp = MetaDataHelper.get_xmp_data(record.path, parse=True)
+            except Exception:
+                xmp = None
+            utc, _source = resolve_capture_utc(exif, xmp, lat=record.lat, lon=record.lon)
+            elev, az = get_solar_position(record.lat, record.lon, utc)
+        except (SolarTimeUnresolvable, Exception):
+            return None
+        if elev is None or elev < SHADOW_MIN_SUN_ELEV_DEG:
+            return None
+        return (az + 180.0) % 360.0
+
+    @staticmethod
+    def _pick_orientation_candidate(shadow_world_deg: float, axis_deg: float,
+                                    disambiguator_deg: float) -> Optional[float]:
+        """Resolve the shadow axis' 180-degree ambiguity.
+
+        The two image-up candidates implied by a shadow axis differ by exactly
+        180 degrees; the coarse disambiguator (inter-frame motion, or the
+        mounting model) only needs to be within 90 degrees of the truth to
+        pick correctly.
+        """
+        c1 = (shadow_world_deg - axis_deg) % 360.0
+        c2 = (c1 + 180.0) % 360.0
+
+        def circ_diff(a, b):
+            return abs((a - b + 180.0) % 360.0 - 180.0)
+
+        d1, d2 = circ_diff(c1, disambiguator_deg), circ_diff(c2, disambiguator_deg)
+        if abs(d1 - d2) < 1.0:
+            return None  # right at the 90-degree tie: cannot disambiguate
+        return c1 if d1 < d2 else c2
+
+    def measure_image_up_bearing(self, records: List["WaldoImageRecord"],
+                                 cam_idx: int) -> Optional[float]:
+        """Measure the stored-image-top compass bearing for one camera group.
+
+        Primary route: solar-shadow axis per sampled frame (precise to a few
+        degrees), disambiguated by the coarse inter-frame-motion bearing (or
+        the mounting model when motion is unavailable). Secondary route: the
+        motion bearing alone, when it is tight enough on its own. Returns
+        None when neither route yields a confident answer (the caller falls
+        back to the mounting model).
+        """
+        group = [r for r in records
+                 if r.cam_idx == cam_idx and r.lat is not None and r.lon is not None]
+        group.sort(key=lambda r: r.name)
+        if not group:
+            return None
+
+        motion = self._pair_motion_bearing(group)
+
+        # Disambiguator for the shadow axis: motion measurement when present,
+        # else the mounting-model prediction
+        if motion is not None:
+            disambiguator = motion[0]
+        else:
+            headings = [r.heading_deg for r in group if r.heading_deg is not None]
+            if headings:
+                mean_heading, _ = self._circular_stats(headings, [1.0] * len(headings))
+                disambiguator = (mean_heading + 180.0) % 360.0
+            else:
+                disambiguator = None
+
+        shadow_samples: List[Tuple[float, float]] = []
+        if disambiguator is not None:
+            step = max(1, len(group) // SHADOW_SAMPLE_IMAGES)
+            for record in group[::step][:SHADOW_SAMPLE_IMAGES]:
+                shadow_world = self._resolve_shadow_world_azimuth(record)
+                if shadow_world is None:
+                    continue
+                axis = self._tile_shadow_axis(record.path)
+                if axis is None:
+                    continue
+                candidate = self._pick_orientation_candidate(
+                    shadow_world, axis[0], disambiguator)
+                if candidate is not None:
+                    shadow_samples.append((candidate, float(axis[1])))
+
+        if len(shadow_samples) >= SHADOW_MIN_SAMPLES:
+            mean_deg, spread_deg = self._circular_stats(
+                [s[0] for s in shadow_samples], [s[1] for s in shadow_samples])
+            stderr_deg = spread_deg / math.sqrt(len(shadow_samples))
+            if spread_deg <= SHADOW_MAX_SPREAD_DEG and stderr_deg <= SHADOW_MAX_STDERR_DEG:
+                self.logger.info(
+                    f"WALDO cam {cam_idx}: measured image-top bearing {mean_deg:.1f} deg "
+                    f"from sun shadows ({len(shadow_samples)} frames, "
+                    f"spread {spread_deg:.1f} deg, stderr {stderr_deg:.1f} deg)"
+                )
+                return mean_deg
+            self.logger.warning(
+                f"WALDO cam {cam_idx}: shadow orientation samples disagree "
+                f"(spread {spread_deg:.1f} deg, stderr {stderr_deg:.1f} deg); "
+                f"trying inter-frame motion"
+            )
+
+        if motion is not None:
+            mean_deg, spread_deg, count = motion
+            if count >= ORIENTATION_MIN_PAIRS and spread_deg <= ORIENTATION_MAX_SPREAD_DEG:
+                self.logger.info(
+                    f"WALDO cam {cam_idx}: measured image-top bearing {mean_deg:.1f} deg "
+                    f"from inter-frame motion ({count} pairs, spread {spread_deg:.1f} deg)"
+                )
+                return mean_deg
+            self.logger.warning(
+                f"WALDO cam {cam_idx}: orientation could not be measured confidently "
+                f"(motion spread {spread_deg:.1f} deg over {count} pairs); "
+                f"falling back to the mounting model"
+            )
+        return None
 
     def compute_relative_altitude_m(
         self, lat: float, lon: float, gps_alt_ellipsoidal_m: float
@@ -440,6 +763,19 @@ class WaldoMetadataService:
         emit(0, 0, "Deriving plane heading from GPS track...")
         self.derive_headings(records)
 
+        # 3b. Measure the stored image orientation per camera by comparing
+        #     inter-frame content motion against the GPS track. Post-flight
+        #     software may normalize frames (field data showed north-up
+        #     imagery ~41 deg away from the mounting model), so measurement
+        #     always wins; the model is only the fallback.
+        image_up_by_cam: Dict[int, Optional[float]] = {}
+        for cam_idx in sorted({r.cam_idx for r in records}):
+            if cancel_cb():
+                result.cancelled = True
+                return result
+            emit(0, 0, f"Measuring image orientation (cam {cam_idx})...")
+            image_up_by_cam[cam_idx] = self.measure_image_up_bearing(records, cam_idx)
+
         # 4. Per-image XMP synthesis
         total = len(records)
         for i, rec in enumerate(records):
@@ -470,7 +806,10 @@ class WaldoMetadataService:
                 result.errors.append((rec.name, f"AGL computation failed: {e}"))
                 continue
 
-            angles = self.compute_optical_axis_angles(rec.heading_deg, rec.cam_idx)
+            angles = self.compute_optical_axis_angles(
+                rec.heading_deg, rec.cam_idx,
+                image_up_deg=image_up_by_cam.get(rec.cam_idx)
+            )
 
             try:
                 self._write_synthesised_xmp(

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -42,12 +42,14 @@ from core.services.shadow.SolarPosition import (
 
 
 WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
-# Version 6: GimbalYawDegree is the *measured* image-top bearing (from
-# inter-frame content motion vs GPS track) rather than the assumed
-# heading+180 mounting model, and GimbalRollDegree is expressed about the
-# FLIGHT axis (FlightYawDegree) rather than the gimbal-yaw axis. Consumers
-# key the roll-axis convention off this version.
-WALDO_PROCESSOR_VERSION = "6"
+# Version 7: GimbalRollDegree is expressed about the FLIGHT axis
+# (FlightYawDegree) rather than the gimbal-yaw axis (consumers key the
+# convention off version >= 6), and GimbalYawDegree comes from the mounting
+# model unless inter-frame motion measurement confidently CONTRADICTS it
+# (catches datasets whose post-flight software re-orients the frames).
+# Version 7 also retires v6's sun-shadow orientation measurement: on steep
+# terrain at low sun, slope shear and charred fallen logs mislead it.
+WALDO_PROCESSOR_VERSION = "7"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 
@@ -59,29 +61,19 @@ OUTWARD_ROLL_DEG = 22.5
 # Orientation-measurement tunables. Field imagery showed the mounting-model
 # yaw assumption off by ~41 degrees (post-flight software had normalized the
 # frames north-up), so orientation is measured from the imagery itself.
-#
-# Two complementary measurements:
-# - Sun-shadow axis: capture time + GPS give the exact solar azimuth, and the
-#   dominant dark-streak direction in the frame gives where that shadow lies
-#   in image coordinates. Precise (a few degrees) but ambiguous by 180.
-# - Inter-frame motion vs GPS track: feature matching between consecutive
-#   frames. Coarse on tilted fixed-wing imagery (tens of degrees of scatter)
-#   but unambiguous - exactly what is needed to pick the shadow's half-plane.
-ORIENTATION_SAMPLE_PAIRS = 8       # consecutive-image pairs sampled per camera
-ORIENTATION_MIN_PAIRS = 3          # accept a measurement only with this many good pairs
-ORIENTATION_MAX_SPREAD_DEG = 12.0  # ...agreeing to within this circular std-dev
+# The measurement: inter-frame content motion vs the GPS track (feature
+# matching between consecutive frames). It carries tens-of-degrees of noise
+# on tilted fixed-wing imagery over relief, so it never fine-tunes the
+# model - it only OVERRIDES the model when it confidently disagrees by more
+# than the override threshold (e.g. frames normalized north-up by post-flight
+# software read ~180 deg away from the model; measurement noise never does).
+ORIENTATION_SAMPLE_PAIRS = 16      # consecutive-image pairs sampled per camera
+ORIENTATION_MIN_PAIRS = 4          # accept a measurement only with this many good pairs
+ORIENTATION_MAX_STDERR_DEG = 8.0   # confidence required of the circular mean
 ORIENTATION_MIN_BASELINE_M = 30.0  # pairs closer than this give unreliable bearings
 ORIENTATION_MIN_INLIERS = 20       # ORB/RANSAC inliers required per pair
 ORIENTATION_DOWNSCALE = 6          # feature matching runs at 1/N resolution
-SHADOW_SAMPLE_IMAGES = 7           # frames sampled per camera for the shadow axis
-SHADOW_MIN_STREAKS = 40            # dark elongated components needed per frame
-SHADOW_MIN_SUN_ELEV_DEG = 5.0      # below this the sun casts no usable shadows
-SHADOW_MIN_SAMPLES = 3             # accept the shadow route with this many frames
-# Terrain slope shears individual frames' shadows by up to ~20 deg, but the
-# shear direction is random across a flight, so the per-frame samples are
-# gated on the standard error of their circular mean rather than raw spread.
-SHADOW_MAX_SPREAD_DEG = 30.0       # raw-spread sanity cap (systematic problem)
-SHADOW_MAX_STDERR_DEG = 6.0        # confidence required of the aggregated mean
+ORIENTATION_OVERRIDE_DEG = 60.0    # measured-vs-model gap that trips the override
 
 # Filename prefix → cam index. 0_* = left, 1_* = right.
 _WALDO_PREFIX_RE = re.compile(r'^(?P<cam>[01])_')
@@ -325,101 +317,17 @@ class WaldoMetadataService:
             [s[0] for s in samples], [s[1] for s in samples])
         return mean_deg, spread_deg, len(samples)
 
-    @staticmethod
-    def _tile_shadow_axis(path: str) -> Optional[Tuple[float, int]]:
-        """Dominant dark-streak axis of a frame, degrees CW from image-up mod 180.
-
-        Standing trees and snags cast long thin shadows; their common
-        direction is the solar shadow direction in image coordinates. Uses
-        the elongation-filtered dark connected components of a downscaled
-        central crop.
-
-        Returns:
-            (axis_deg_mod_180, streak_count), or None when the frame has too
-            few usable streaks (overcast, water, uniform terrain).
-        """
-        try:
-            img = cv2.imdecode(np.fromfile(path, dtype=np.uint8), cv2.IMREAD_GRAYSCALE)
-            if img is None:
-                return None
-            h, w = img.shape
-            crop = img[h // 4:3 * h // 4:2, w // 4:3 * w // 4:2]
-            dark = (crop < np.percentile(crop, 8)).astype(np.uint8)
-            dark = cv2.morphologyEx(dark, cv2.MORPH_OPEN, np.ones((2, 2), np.uint8))
-            n, labels, stats, _ = cv2.connectedComponentsWithStats(dark, 8)
-            angles, weights = [], []
-            for i in range(1, n):
-                if stats[i, cv2.CC_STAT_AREA] < 60:
-                    continue
-                ys, xs = np.where(labels == i)
-                xs = xs - xs.mean()
-                ys = ys - ys.mean()
-                cov = np.cov(np.stack([xs, ys]))
-                evals, evecs = np.linalg.eigh(cov)
-                if evals[1] / max(evals[0], 1e-6) < 6:
-                    continue  # keep only long, thin components
-                v = evecs[:, 1]
-                angles.append(math.degrees(math.atan2(v[0], -v[1])) % 180)
-                weights.append(float(stats[i, cv2.CC_STAT_AREA]))
-            if len(angles) < SHADOW_MIN_STREAKS:
-                return None
-            # Circular stats on doubled angles (axes are 180-periodic)
-            doubled = np.radians(np.asarray(angles) * 2.0)
-            wgt = np.asarray(weights)
-            mean2 = math.atan2(float((wgt * np.sin(doubled)).sum()),
-                               float((wgt * np.cos(doubled)).sum()))
-            return (math.degrees(mean2) / 2.0) % 180, len(angles)
-        except Exception:
-            return None
-
-    @staticmethod
-    def _resolve_shadow_world_azimuth(record: "WaldoImageRecord") -> Optional[float]:
-        """Compass direction shadows point at this record's time/place, or None."""
-        try:
-            exif = MetaDataHelper.get_exif_data_piexif(record.path)
-            try:
-                xmp = MetaDataHelper.get_xmp_data(record.path, parse=True)
-            except Exception:
-                xmp = None
-            utc, _source = resolve_capture_utc(exif, xmp, lat=record.lat, lon=record.lon)
-            elev, az = get_solar_position(record.lat, record.lon, utc)
-        except (SolarTimeUnresolvable, Exception):
-            return None
-        if elev is None or elev < SHADOW_MIN_SUN_ELEV_DEG:
-            return None
-        return (az + 180.0) % 360.0
-
-    @staticmethod
-    def _pick_orientation_candidate(shadow_world_deg: float, axis_deg: float,
-                                    disambiguator_deg: float) -> Optional[float]:
-        """Resolve the shadow axis' 180-degree ambiguity.
-
-        The two image-up candidates implied by a shadow axis differ by exactly
-        180 degrees; the coarse disambiguator (inter-frame motion, or the
-        mounting model) only needs to be within 90 degrees of the truth to
-        pick correctly.
-        """
-        c1 = (shadow_world_deg - axis_deg) % 360.0
-        c2 = (c1 + 180.0) % 360.0
-
-        def circ_diff(a, b):
-            return abs((a - b + 180.0) % 360.0 - 180.0)
-
-        d1, d2 = circ_diff(c1, disambiguator_deg), circ_diff(c2, disambiguator_deg)
-        if abs(d1 - d2) < 1.0:
-            return None  # right at the 90-degree tie: cannot disambiguate
-        return c1 if d1 < d2 else c2
-
     def measure_image_up_bearing(self, records: List["WaldoImageRecord"],
                                  cam_idx: int) -> Optional[float]:
-        """Measure the stored-image-top compass bearing for one camera group.
+        """Return a measured image-top bearing ONLY when it refutes the model.
 
-        Primary route: solar-shadow axis per sampled frame (precise to a few
-        degrees), disambiguated by the coarse inter-frame-motion bearing (or
-        the mounting model when motion is unavailable). Secondary route: the
-        motion bearing alone, when it is tight enough on its own. Returns
-        None when neither route yields a confident answer (the caller falls
-        back to the mounting model).
+        The inter-frame-motion measurement is too noisy on tilted fixed-wing
+        imagery over relief to fine-tune the mounting model, but a dataset
+        whose frames were re-oriented by post-flight software reads far away
+        from the model (typically ~180 deg) - far beyond measurement noise.
+        So: measure, and return the measurement only when it is confident
+        AND disagrees with the model by more than ORIENTATION_OVERRIDE_DEG.
+        Returns None otherwise (caller stamps the mounting model).
         """
         group = [r for r in records
                  if r.cam_idx == cam_idx and r.lat is not None and r.lon is not None]
@@ -428,65 +336,36 @@ class WaldoMetadataService:
             return None
 
         motion = self._pair_motion_bearing(group)
-
-        # Disambiguator for the shadow axis: motion measurement when present,
-        # else the mounting-model prediction
-        if motion is not None:
-            disambiguator = motion[0]
-        else:
-            headings = [r.heading_deg for r in group if r.heading_deg is not None]
-            if headings:
-                mean_heading, _ = self._circular_stats(headings, [1.0] * len(headings))
-                disambiguator = (mean_heading + 180.0) % 360.0
-            else:
-                disambiguator = None
-
-        shadow_samples: List[Tuple[float, float]] = []
-        if disambiguator is not None:
-            step = max(1, len(group) // SHADOW_SAMPLE_IMAGES)
-            for record in group[::step][:SHADOW_SAMPLE_IMAGES]:
-                shadow_world = self._resolve_shadow_world_azimuth(record)
-                if shadow_world is None:
-                    continue
-                axis = self._tile_shadow_axis(record.path)
-                if axis is None:
-                    continue
-                candidate = self._pick_orientation_candidate(
-                    shadow_world, axis[0], disambiguator)
-                if candidate is not None:
-                    shadow_samples.append((candidate, float(axis[1])))
-
-        if len(shadow_samples) >= SHADOW_MIN_SAMPLES:
-            mean_deg, spread_deg = self._circular_stats(
-                [s[0] for s in shadow_samples], [s[1] for s in shadow_samples])
-            stderr_deg = spread_deg / math.sqrt(len(shadow_samples))
-            if spread_deg <= SHADOW_MAX_SPREAD_DEG and stderr_deg <= SHADOW_MAX_STDERR_DEG:
-                self.logger.info(
-                    f"WALDO cam {cam_idx}: measured image-top bearing {mean_deg:.1f} deg "
-                    f"from sun shadows ({len(shadow_samples)} frames, "
-                    f"spread {spread_deg:.1f} deg, stderr {stderr_deg:.1f} deg)"
-                )
-                return mean_deg
-            self.logger.warning(
-                f"WALDO cam {cam_idx}: shadow orientation samples disagree "
-                f"(spread {spread_deg:.1f} deg, stderr {stderr_deg:.1f} deg); "
-                f"trying inter-frame motion"
+        if motion is None:
+            return None
+        mean_deg, spread_deg, count = motion
+        stderr_deg = spread_deg / math.sqrt(count)
+        if count < ORIENTATION_MIN_PAIRS or stderr_deg > ORIENTATION_MAX_STDERR_DEG:
+            self.logger.info(
+                f"WALDO cam {cam_idx}: orientation measurement inconclusive "
+                f"({count} pairs, stderr {stderr_deg:.1f} deg); using the mounting model"
             )
+            return None
 
-        if motion is not None:
-            mean_deg, spread_deg, count = motion
-            if count >= ORIENTATION_MIN_PAIRS and spread_deg <= ORIENTATION_MAX_SPREAD_DEG:
-                self.logger.info(
-                    f"WALDO cam {cam_idx}: measured image-top bearing {mean_deg:.1f} deg "
-                    f"from inter-frame motion ({count} pairs, spread {spread_deg:.1f} deg)"
-                )
-                return mean_deg
-            self.logger.warning(
-                f"WALDO cam {cam_idx}: orientation could not be measured confidently "
-                f"(motion spread {spread_deg:.1f} deg over {count} pairs); "
-                f"falling back to the mounting model"
+        headings = [r.heading_deg for r in group if r.heading_deg is not None]
+        if not headings:
+            return None
+        mean_heading, _ = self._circular_stats(headings, [1.0] * len(headings))
+        model_deg = (mean_heading + 180.0) % 360.0
+        gap = abs((mean_deg - model_deg + 180.0) % 360.0 - 180.0)
+        if gap <= ORIENTATION_OVERRIDE_DEG:
+            self.logger.info(
+                f"WALDO cam {cam_idx}: measured orientation {mean_deg:.1f} deg agrees "
+                f"with the mounting model {model_deg:.1f} deg (gap {gap:.1f} deg); "
+                f"stamping the model"
             )
-        return None
+            return None
+        self.logger.warning(
+            f"WALDO cam {cam_idx}: measured orientation {mean_deg:.1f} deg "
+            f"({count} pairs, stderr {stderr_deg:.1f} deg) contradicts the mounting "
+            f"model {model_deg:.1f} deg (gap {gap:.1f} deg); stamping the measurement"
+        )
+        return mean_deg
 
     def compute_relative_altitude_m(
         self, lat: float, lon: float, gps_alt_ellipsoidal_m: float

--- a/app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py
+++ b/app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py
@@ -155,6 +155,12 @@ class WaldoPrePassDialog(TranslationMixin, QDialog):
         lines.append(self.tr("Already up-to-date: {n}").format(n=result.already_current))
         lines.append(self.tr("Skipped (non-WALDO): {n}").format(n=result.skipped))
         lines.append(self.tr("Errors:           {n}").format(n=len(result.errors)))
+        warnings = getattr(result, 'warnings', None) or []
+        if warnings:
+            lines.append("")
+            lines.append(self.tr("⚠ Capture-time warnings (camera clock is suspect):"))
+            for msg in warnings:
+                lines.append(f"  {msg}")
         if result.errors:
             lines.append("")
             lines.append(self.tr("Per-image errors:"))

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -314,24 +314,42 @@ def test_pair_orientation_sample_recovers_known_rotation(tmp_path):
     assert abs(result[0] - 90.0) < 6.0
 
 
-def test_measure_image_up_bearing_aggregates_pairs(tmp_path):
-    """Full-group measurement over several synthetic pairs."""
-    service = WaldoMetadataService()
+def _motion_records(tmp_path, heading_deg):
+    """Synthetic north-up frames moving north, with the given model heading."""
     records = []
     lat = 41.0
-    for i in range(4):
+    for i in range(5):
         pa, pb = _write_shifted_frames(tmp_path / f'p{i}', (0, -280 - 10 * i), seed=i)
         # GPS: successive frames move north by ~200m
         records.append(WaldoImageRecord(path=pa, name=f'0_000_00_{2*i:03d}.jpg',
-                                        cam_idx=0, lat=lat, lon=-122.0))
+                                        cam_idx=0, lat=lat, lon=-122.0,
+                                        heading_deg=heading_deg))
         lat += 0.0018
         records.append(WaldoImageRecord(path=pb, name=f'0_000_00_{2*i+1:03d}.jpg',
-                                        cam_idx=0, lat=lat, lon=-122.0))
+                                        cam_idx=0, lat=lat, lon=-122.0,
+                                        heading_deg=heading_deg))
         lat += 0.0018
+    return records
+
+
+def test_measurement_overrides_model_only_on_clear_contradiction(tmp_path):
+    """North-up frames with a model saying 'south-up' trip the override."""
+    service = WaldoMetadataService()
+    # heading 0 -> model image-top = 180; measurement reads ~0 -> gap ~180
+    records = _motion_records(tmp_path, heading_deg=0.0)
 
     measured = service.measure_image_up_bearing(records, cam_idx=0)
     assert measured is not None
     assert min(measured, 360.0 - measured) < 8.0
+
+
+def test_measurement_agreeing_with_model_defers_to_it(tmp_path):
+    """When measurement and model roughly agree, the model is stamped."""
+    service = WaldoMetadataService()
+    # heading 180 -> model image-top = 0; measurement reads ~0 -> gap ~0
+    records = _motion_records(tmp_path, heading_deg=180.0)
+
+    assert service.measure_image_up_bearing(records, cam_idx=0) is None
 
 
 def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
@@ -348,37 +366,3 @@ def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
         lat += 0.0018
 
     assert service.measure_image_up_bearing(records, cam_idx=0) is None
-
-
-def test_tile_shadow_axis_recovers_streak_direction(tmp_path):
-    """Synthetic parallel dark streaks at a known angle are measured mod 180."""
-    rng = np.random.default_rng(3)
-    img = rng.integers(140, 220, (2400, 3200), dtype=np.uint8)
-    # Streaks at 30 deg CW from image-up: direction vector (sin30, -cos30).
-    # Placed densely enough that the method's central crop still sees plenty.
-    for i in range(280):
-        x0 = int(rng.integers(200, 3000))
-        y0 = int(rng.integers(200, 2200))
-        x1 = int(x0 + math.sin(math.radians(30.0)) * 160)
-        y1 = int(y0 - math.cos(math.radians(30.0)) * 160)
-        cv2.line(img, (x0, y0), (x1, y1), 10, 6)
-    p = str(tmp_path / 'streaks.jpg')
-    cv2.imwrite(p, img)
-
-    result = WaldoMetadataService._tile_shadow_axis(p)
-    assert result is not None
-    axis, count = result
-    assert count >= 40
-    assert min(abs(axis - 30.0), abs(axis - 210.0), 180.0 - abs(axis - 30.0)) < 5.0
-
-
-def test_pick_orientation_candidate_uses_coarse_half_plane():
-    # Shadow points 100 deg (world); axis measured at 100 deg CW from up
-    # => candidates 0 and 180. A coarse hint of 41 picks north.
-    picked = WaldoMetadataService._pick_orientation_candidate(100.0, 100.0, 41.0)
-    assert picked == 0.0
-    # A coarse hint near the opposite half picks the flipped candidate
-    picked = WaldoMetadataService._pick_orientation_candidate(100.0, 100.0, 200.0)
-    assert picked == 180.0
-    # Exactly at the 90-degree tie: refuse to guess
-    assert WaldoMetadataService._pick_orientation_candidate(100.0, 100.0, 90.0) is None

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -1,5 +1,6 @@
 """Unit tests for WaldoMetadataService."""
 
+import importlib
 import math
 from datetime import datetime, timedelta
 
@@ -366,3 +367,85 @@ def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
         lat += 0.0018
 
     assert service.measure_image_up_bearing(records, cam_idx=0) is None
+
+
+# --------------------------------------------------------------------------
+# Capture-time audit
+# --------------------------------------------------------------------------
+
+def test_parse_offset_hours():
+    assert WaldoMetadataService._parse_offset_hours(b'-06:00') == -6.0
+    assert WaldoMetadataService._parse_offset_hours('+05:30') == 5.5
+    assert WaldoMetadataService._parse_offset_hours(None) is None
+    assert WaldoMetadataService._parse_offset_hours(b'garbage') is None
+
+
+def _audit_exif(dt_bytes, offset_bytes):
+    import piexif
+    return {
+        'Exif': {
+            piexif.ExifIFD.DateTimeOriginal: dt_bytes,
+            piexif.ExifIFD.OffsetTimeOriginal: offset_bytes,
+        },
+        'GPS': {},
+    }
+
+
+def test_audit_flags_timezone_longitude_mismatch(tmp_path, monkeypatch):
+    """A camera set to -06:00 at longitude -122.9 must be flagged."""
+    waldo_module = importlib.import_module('core.services.waldo.WaldoMetadataService')
+    p = str(tmp_path / '0_000_00_000.jpg')
+    open(p, 'wb').write(b'x')
+
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        lambda path: _audit_exif(b'2026:07:25 09:00:00', b'-06:00'))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        lambda exif_data: {'latitude': 41.3, 'longitude': -122.9})
+
+    warnings = WaldoMetadataService().audit_capture_times([p])
+    assert any('timezone' in w for w in warnings)
+
+
+def test_audit_flags_capture_after_file_write(tmp_path, monkeypatch):
+    """A claimed capture hours after the file's mtime means the clock is ahead."""
+    import os as _os
+    waldo_module = importlib.import_module('core.services.waldo.WaldoMetadataService')
+    from datetime import datetime, timedelta, timezone as tz
+
+    p = str(tmp_path / '0_000_00_000.jpg')
+    open(p, 'wb').write(b'x')
+    # Claimed capture: 10 hours after the file's mtime
+    claimed_local = datetime.fromtimestamp(
+        _os.path.getmtime(p), tz=tz.utc) + timedelta(hours=10) - timedelta(hours=8)
+    dt_bytes = claimed_local.strftime('%Y:%m:%d %H:%M:%S').encode()
+
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        lambda path: _audit_exif(dt_bytes, b'-08:00'))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        lambda exif_data: {'latitude': 41.3, 'longitude': -122.9})
+
+    warnings = WaldoMetadataService().audit_capture_times([p])
+    assert any('AFTER' in w for w in warnings)
+
+
+def test_audit_quiet_on_healthy_metadata(tmp_path, monkeypatch):
+    """Correct offset, past capture time, sun up: no warnings."""
+    import os as _os
+    waldo_module = importlib.import_module('core.services.waldo.WaldoMetadataService')
+    from datetime import datetime, timedelta, timezone as tz
+
+    p = str(tmp_path / '0_000_00_000.jpg')
+    open(p, 'wb').write(b'x')
+    # Claimed capture: two hours before the file was written, offset -08:00
+    claimed_local = datetime.fromtimestamp(
+        _os.path.getmtime(p), tz=tz.utc) - timedelta(hours=2) - timedelta(hours=8)
+    dt_bytes = claimed_local.strftime('%Y:%m:%d %H:%M:%S').encode()
+
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        lambda path: _audit_exif(dt_bytes, b'-08:00'))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        lambda exif_data: {'latitude': 41.3, 'longitude': -122.9})
+    # Force the solar check to a sun-up answer so no daylight warning can fire
+    monkeypatch.setattr(waldo_module, 'get_solar_position', lambda lat, lon, utc: (30.0, 120.0))
+
+    assert WaldoMetadataService().audit_capture_times([p]) == []

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -1,8 +1,13 @@
 """Unit tests for WaldoMetadataService."""
 
+import math
 from datetime import datetime, timedelta
 
+import cv2
+import numpy as np
 import pytest
+
+from core.services.image.AOIService import AOIService
 
 from core.services.waldo.WaldoMetadataService import (
     WaldoMetadataService,
@@ -35,25 +40,36 @@ def test_is_waldo_image(name, expected):
 # compute_optical_axis_angles
 # --------------------------------------------------------------------------
 
-def test_optical_axis_cam_0_right_pod_image_flipped_180():
-    # `0_*` = RIGHT pod, body top forward, but WALDO software rotates the
-    # saved JPEG 180° so stored image-top = plane backward. GimbalYaw
-    # therefore points backward (heading + 180°). Positive roll about
-    # that flipped heading axis tilts the optical axis to plane RIGHT.
+def test_optical_axis_cam_0_fallback_yaw_and_flight_axis_roll():
+    # No measured orientation: yaw falls back to the mounting model
+    # (image-top = plane backward = heading + 180). As of v6 the roll is
+    # expressed about the FLIGHT axis: about the forward axis a positive
+    # Rodrigues roll tilts LEFT, so cam 0 (right tilt) is negative.
     angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 0)
     assert angles['pitch'] == -90.0
     assert angles['yaw'] == 225.0  # 45 + 180
-    assert angles['roll'] == +OUTWARD_ROLL_DEG
+    assert angles['roll'] == -OUTWARD_ROLL_DEG
 
 
-def test_optical_axis_cam_1_left_pod_top_backward():
-    # `1_*` = LEFT pod, body top backward, no software rotation. Stored
-    # image-top = plane backward as well, so GimbalYaw = heading + 180°.
-    # Negative roll about the flipped heading axis tilts west (LEFT).
+def test_optical_axis_cam_1_fallback_yaw_and_flight_axis_roll():
+    # `1_*` = LEFT pod: tilt to plane LEFT = positive roll about the
+    # forward flight axis.
     angles = WaldoMetadataService.compute_optical_axis_angles(0.0, 1)
     assert angles['pitch'] == -90.0
     assert angles['yaw'] == 180.0
+    assert angles['roll'] == +OUTWARD_ROLL_DEG
+
+
+def test_optical_axis_measured_orientation_wins_over_model():
+    # A measured image-top bearing overrides the mounting model entirely;
+    # the roll stays anchored to the flight axis so the physical tilt is
+    # unchanged by whatever orientation the frames are stored in.
+    angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 0, image_up_deg=1.5)
+    assert angles['yaw'] == 1.5
     assert angles['roll'] == -OUTWARD_ROLL_DEG
+    angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 1, image_up_deg=359.0)
+    assert angles['yaw'] == 359.0
+    assert angles['roll'] == +OUTWARD_ROLL_DEG
 
 
 def test_optical_axis_cam_1_yaw_wraps_past_360():
@@ -195,3 +211,174 @@ def test_process_folder_emits_indeterminate_phases_before_per_image(tmp_path):
     # And at least one of the early events should advertise reading metadata.
     assert any("metadata" in e[2].lower() for e in events[:3]), \
         f"Expected an early 'metadata' phase status, got {events[:3]}"
+
+# --------------------------------------------------------------------------
+# v5 -> v6 tilt equivalence and orientation measurement
+# --------------------------------------------------------------------------
+
+
+def _ground_offset_m(lat0, lon0, lat, lon):
+    north = (lat - lat0) * 111320.0
+    east = (lon - lon0) * 111320.0 * math.cos(math.radians(lat0))
+    return north, east
+
+
+def test_flight_axis_roll_reproduces_v5_tilt_direction():
+    """The v6 stamping (flight-axis roll) must tilt the footprint the same
+    way the v5 stamping (backward gimbal-yaw-axis roll) did.
+
+    Projects the image-centre pixel with both parameterizations through the
+    real ray-casting code: the ground point must land cross-track on the
+    same side of the aircraft, in the same place.
+    """
+    heading = 45.0
+    lat0, lon0 = 41.0, -122.0
+    kwargs = dict(cx=2000.0, cy=1500.0, img_width=4000, img_height=3000,
+                  focal_mm=50.0, sensor_w_mm=36.0, sensor_h_mm=24.0)
+
+    for cam_idx, side_sign in ((0, +1), (1, -1)):  # cam0 tilts plane-RIGHT
+        # v5: yaw = heading+180, roll about the (default) yaw axis
+        v5_roll = (+OUTWARD_ROLL_DEG) if cam_idx == 0 else (-OUTWARD_ROLL_DEG)
+        v5 = AOIService._calculate_ground_position(
+            lat0, lon0, 2000.0, 1500.0,
+            altitude_m=1000.0, pitch_deg=-90.0,
+            yaw_deg=(heading + 180.0) % 360.0, roll_deg=v5_roll,
+            **kwargs)
+
+        # v6: measured yaw (north-up here), roll about the flight axis
+        angles = WaldoMetadataService.compute_optical_axis_angles(
+            heading, cam_idx, image_up_deg=0.0)
+        v6 = AOIService._calculate_ground_position(
+            lat0, lon0, 2000.0, 1500.0,
+            altitude_m=1000.0, pitch_deg=angles['pitch'],
+            yaw_deg=angles['yaw'], roll_deg=angles['roll'],
+            roll_axis_azimuth_deg=heading,
+            **kwargs)
+
+        assert v5 is not None and v6 is not None
+        n5, e5 = _ground_offset_m(lat0, lon0, *v5)
+        n6, e6 = _ground_offset_m(lat0, lon0, *v6)
+        # Same physical point: the centre-pixel footprint is tilt-driven and
+        # identical regardless of how the stored pixels are rotated
+        assert abs(n5 - n6) < 1.0 and abs(e5 - e6) < 1.0
+
+        # And it lies cross-track on the correct side of the flight axis
+        h = math.radians(heading)
+        cross = -math.sin(h) * n5 + math.cos(h) * e5  # +ve = plane right
+        assert cross * side_sign > 100.0  # 22.5 deg at 1000m AGL: ~414m
+
+
+def _write_shifted_frames(out_dir, shift_xy, size=(1800, 2400), seed=5):
+    """Two JPEG 'frames' of one texture, the second shifted by shift_xy.
+
+    The texture uses blurred blobs large enough to survive the service's
+    ORIENTATION_DOWNSCALE before feature matching.
+    """
+    import os as _os
+    _os.makedirs(str(out_dir), exist_ok=True)
+    rng = np.random.default_rng(seed)
+    h, w = size
+    dx, dy = shift_xy
+    margin = max(abs(dx), abs(dy)) + 50
+    canvas = rng.integers(0, 255, (h + 2 * margin, w + 2 * margin), dtype=np.uint8)
+    canvas = cv2.GaussianBlur(canvas, (0, 0), 5.0)
+    canvas = cv2.normalize(canvas, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
+    oy, ox = margin, margin
+    a = canvas[oy:oy + h, ox:ox + w]
+    b = canvas[oy + dy:oy + dy + h, ox + dx:ox + dx + w]
+    pa = str(out_dir) + _os.sep + '0_000_00_000.jpg'
+    pb = str(out_dir) + _os.sep + '0_000_00_001.jpg'
+    cv2.imwrite(pa, a)
+    cv2.imwrite(pb, b)
+    return pa, pb
+
+
+def test_pair_orientation_sample_recovers_known_rotation(tmp_path):
+    """Content shifted 'up' while GPS says 'moving north' => north-up frames."""
+    # Frame b crops a region 300px higher on the shared texture: the camera
+    # moved 'up' in image terms between the frames.
+    pa, pb = _write_shifted_frames(tmp_path, (0, -300))
+
+    # Camera moved up in image; GPS bearing says due north
+    result = WaldoMetadataService._pair_orientation_sample(pa, pb, 0.0)
+    assert result is not None
+    image_up, inliers = result
+    assert inliers >= 20
+    # image-up should be ~north (0 deg)
+    assert min(image_up, 360.0 - image_up) < 6.0
+
+    # Same imagery, but GPS says the motion was due east: the image's top
+    # must then be pointing west (270)
+    result = WaldoMetadataService._pair_orientation_sample(pa, pb, 90.0)
+    assert result is not None
+    assert abs(result[0] - 90.0) < 6.0
+
+
+def test_measure_image_up_bearing_aggregates_pairs(tmp_path):
+    """Full-group measurement over several synthetic pairs."""
+    service = WaldoMetadataService()
+    records = []
+    lat = 41.0
+    for i in range(4):
+        pa, pb = _write_shifted_frames(tmp_path / f'p{i}', (0, -280 - 10 * i), seed=i)
+        # GPS: successive frames move north by ~200m
+        records.append(WaldoImageRecord(path=pa, name=f'0_000_00_{2*i:03d}.jpg',
+                                        cam_idx=0, lat=lat, lon=-122.0))
+        lat += 0.0018
+        records.append(WaldoImageRecord(path=pb, name=f'0_000_00_{2*i+1:03d}.jpg',
+                                        cam_idx=0, lat=lat, lon=-122.0))
+        lat += 0.0018
+
+    measured = service.measure_image_up_bearing(records, cam_idx=0)
+    assert measured is not None
+    assert min(measured, 360.0 - measured) < 8.0
+
+
+def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
+    """Unrelated noise frames must fail closed (fall back to the model)."""
+    service = WaldoMetadataService()
+    rng = np.random.default_rng(9)
+    records = []
+    lat = 41.0
+    for i in range(5):
+        p = str(tmp_path / f'0_000_00_{i:03d}.jpg')
+        cv2.imwrite(p, rng.integers(0, 255, (400, 500), dtype=np.uint8))
+        records.append(WaldoImageRecord(path=p, name=f'0_000_00_{i:03d}.jpg',
+                                        cam_idx=0, lat=lat, lon=-122.0))
+        lat += 0.0018
+
+    assert service.measure_image_up_bearing(records, cam_idx=0) is None
+
+
+def test_tile_shadow_axis_recovers_streak_direction(tmp_path):
+    """Synthetic parallel dark streaks at a known angle are measured mod 180."""
+    rng = np.random.default_rng(3)
+    img = rng.integers(140, 220, (2400, 3200), dtype=np.uint8)
+    # Streaks at 30 deg CW from image-up: direction vector (sin30, -cos30).
+    # Placed densely enough that the method's central crop still sees plenty.
+    for i in range(280):
+        x0 = int(rng.integers(200, 3000))
+        y0 = int(rng.integers(200, 2200))
+        x1 = int(x0 + math.sin(math.radians(30.0)) * 160)
+        y1 = int(y0 - math.cos(math.radians(30.0)) * 160)
+        cv2.line(img, (x0, y0), (x1, y1), 10, 6)
+    p = str(tmp_path / 'streaks.jpg')
+    cv2.imwrite(p, img)
+
+    result = WaldoMetadataService._tile_shadow_axis(p)
+    assert result is not None
+    axis, count = result
+    assert count >= 40
+    assert min(abs(axis - 30.0), abs(axis - 210.0), 180.0 - abs(axis - 30.0)) < 5.0
+
+
+def test_pick_orientation_candidate_uses_coarse_half_plane():
+    # Shadow points 100 deg (world); axis measured at 100 deg CW from up
+    # => candidates 0 and 180. A coarse hint of 41 picks north.
+    picked = WaldoMetadataService._pick_orientation_candidate(100.0, 100.0, 41.0)
+    assert picked == 0.0
+    # A coarse hint near the opposite half picks the flipped candidate
+    picked = WaldoMetadataService._pick_orientation_candidate(100.0, 100.0, 200.0)
+    assert picked == 180.0
+    # Exactly at the 90-degree tie: refuse to guess
+    assert WaldoMetadataService._pick_orientation_candidate(100.0, 100.0, 90.0) is None

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -15794,17 +15794,22 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Errors:           {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="160"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
+        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
         <source>Per-image errors:</source>
         <translation>Per-image errors:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="174"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
         <source>Cancelling...</source>
         <translation>Cancelling...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
         <source>Cancellation requested...</source>
         <translation>Cancellation requested...</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -15794,17 +15794,22 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Errores:          {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="160"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
+        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
         <source>Per-image errors:</source>
         <translation>Errores por imagen:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="174"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
         <source>Cancelling...</source>
         <translation>Cancelando...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
         <source>Cancellation requested...</source>
         <translation>Cancelación solicitada...</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -15794,17 +15794,22 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Errori:           {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="160"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
+        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
         <source>Per-image errors:</source>
         <translation>Errori per immagine:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="174"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
         <source>Cancelling...</source>
         <translation>Annullamento...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
         <source>Cancellation requested...</source>
         <translation>Annullamento richiesto...</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -15794,17 +15794,22 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Fouten:          {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="160"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
+        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
         <source>Per-image errors:</source>
         <translation>Fouten per afbeelding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="174"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
         <source>Cancelling...</source>
         <translation>Annuleren...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
         <source>Cancellation requested...</source>
         <translation>Annulering aangevraagd...</translation>
     </message>


### PR DESCRIPTION
## The report

The Person Size Reference shadow pointed visibly the wrong way relative to tree shadows on WALDO imagery.

## Root cause — bigger than the shadow

Ground-truthing the reported frame against the sun (capture time + GPS give the exact solar azimuth; the tree shadows in the frame show where that azimuth lies in pixel space) proved the stored frames are **north-aligned** — image-top bearing 0–4° across four flight lines, independently confirmed by inter-frame feature motion vs the GPS track. The pre-pass, however, stamps `GimbalYawDegree` from the pod-mounting model (image-top = plane backward = heading + 180°), which was **~41° off** for this flight. The operator confirms the post-flight software rotates at least some frames, so the model cannot be trusted per dataset.

That stamped yaw feeds every direction-dependent computation on WALDO imagery: **AOI GPS estimates (up to ~350 m of error at frame edges at 1,500 m AGL)**, FOV footprints on the map, neighbor tracking — and the reported shadow.

## The fix: measure, don't assume

Per camera group, the pre-pass now measures the stored orientation:

- **Primary — solar-shadow axis:** the dominant dark-streak direction per sampled frame (elongation-filtered connected components) vs the computed shadow azimuth. Precise to a few degrees, 180°-ambiguous — so the coarse inter-frame-motion bearing (or the mounting model) picks the half-plane; the coarse source only needs to be within 90°, which it always is. Terrain slope shears individual frames' shadows randomly, so acceptance is gated on the **standard error of the circular mean** (≤6° over up to 7 frames) with a 30° raw-spread sanity cap.
- **Secondary:** inter-frame motion alone when tight enough on its own.
- **Fallback:** the existing mounting model, unchanged.

Because a measured yaw decouples image orientation from the aircraft, the ±22.5° pod-tilt roll is now expressed about the **flight axis** (`FlightYawDegree`); the Rodrigues signs flip accordingly, `AOIService` gains a `roll_axis_azimuth_deg` pass-through, and new `ImageService` accessors select the axis **only for WALDO v6-stamped imagery** — v5 stamps and DJI imagery behave exactly as before. An equivalence test proves the v6 parameterization lands the centre-pixel footprint on the same ground point as v5 through the real ray-caster.

`WALDO_PROCESSOR_VERSION` bumps 5 → 6, so already-stamped datasets self-correct on their next open.

## Field validation

On the reported flight: measured image-top bearing **4.3°** from sun shadows (7 frames, stderr 5.7°) where the model stamped 40.75° — matching the hand-measured tree shadows within a few degrees.

## Tests

27 WALDO tests pass (9 new: measured-yaw stamping, flight-axis roll signs, v5/v6 tilt equivalence through the ray-caster, synthetic orientation measurement plus fail-closed cases, shadow-axis recovery at a known angle, half-plane disambiguation including the 90° tie), plus the AOI/image service suites. `flake8` clean.