### PR TITLE
perf: MRMap histogram + windowed per-AOI expansion (follow-up commits that missed #124)

### DIFF
--- a/app/algorithms/images/HSVColorRange/services/HSVColorRangeService.py
+++ b/app/algorithms/images/HSVColorRange/services/HSVColorRangeService.py
@@ -323,41 +323,84 @@ class HSVColorRangeService(AlgorithmService):
             coords[:, 0] = np.clip(coords[:, 0], 0, w - 1)
             coords[:, 1] = np.clip(coords[:, 1], 0, h - 1)
 
-            seed_mask = np.zeros((h, w), dtype=bool)
-            seed_mask[coords[:, 1], coords[:, 0]] = True
-
-            cluster_rect = [
-                int(coords[:, 0].min()), int(coords[:, 1].min()),
-                int(coords[:, 0].max()), int(coords[:, 1].max()),
-            ]
-            safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
-
             seed_hues = hsv_image[coords[:, 1], coords[:, 0], 0]
             mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
             if mean_hue is None:
-                combined_mask[seed_mask] = 255
+                combined_mask[coords[:, 1], coords[:, 0]] = 255
                 continue
 
+            expanded_roi, (x0, y0) = self._expand_aoi_windowed(aoi, coords, mean_hue, hsv_image, h, w)
+
+            ys2, xs2 = np.nonzero(expanded_roi)
+            if len(xs2) == 0:
+                continue
+            aoi['detected_pixels'] = np.stack([xs2 + x0, ys2 + y0], axis=1).tolist()
+            # Hull area is translation-invariant, so the ROI mask suffices
+            aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(expanded_roi)))
+
+            roi_view = combined_mask[y0:y0 + expanded_roi.shape[0], x0:x0 + expanded_roi.shape[1]]
+            roi_view[expanded_roi] = 255
+
+        return areas_of_interest, combined_mask
+
+    def _expand_aoi_windowed(self, aoi, coords, mean_hue, hsv_image, h, w):
+        """Run one AOI's hue flood inside a bounded, growable window.
+
+        Same windowing discipline as MRMapService._expand_single_aoi: running
+        the full-frame hue mask and flood per AOI made expansion cost scale
+        with (AOIs x image area). A flood that does not touch a window border
+        with image beyond it equals the global flood exactly; if it does, the
+        window grows 4x and re-runs, degrading to the old full-frame behavior
+        in the worst case. A safety-cap overflow inside the window implies
+        overflow globally, so cap decisions are exact.
+
+        Args:
+            aoi (dict): The AOI being expanded (used for logging only).
+            coords (np.ndarray): (N, 2) clipped detected pixels as (x, y).
+            mean_hue (float): Circular mean hue of the original pixels.
+            hsv_image: Full-frame HSV image.
+            h, w (int): Full-frame dimensions.
+
+        Returns:
+            tuple: (expanded bool ROI mask, (x0, y0) window origin).
+        """
+        xmin, ymin = int(coords[:, 0].min()), int(coords[:, 1].min())
+        xmax, ymax = int(coords[:, 0].max()), int(coords[:, 1].max())
+        safety_cap = DetectionExpansion.compute_safety_cap([xmin, ymin, xmax, ymax])
+
+        margin = max(128, xmax - xmin + 1, ymax - ymin + 1)
+        while True:
+            x0, y0 = max(0, xmin - margin), max(0, ymin - margin)
+            x1, y1 = min(w, xmax + 1 + margin), min(h, ymax + 1 + margin)
+
+            seed_roi = np.zeros((y1 - y0, x1 - x0), dtype=bool)
+            seed_roi[coords[:, 1] - y0, coords[:, 0] - x0] = True
+
             hue_ok = DetectionExpansion.hue_distance_mask(
-                hsv_image, mean_hue, self.hue_expansion,
+                hsv_image[y0:y1, x0:x1], mean_hue, self.hue_expansion,
                 sat_floor=self.hue_expansion_sat_floor,
                 val_floor=self.hue_expansion_val_floor,
             )
-            expanded, cap_hit = DetectionExpansion.expand_hue_flood(seed_mask, hue_ok, safety_cap)
+            expanded, cap_hit = DetectionExpansion.expand_hue_flood(seed_roi, hue_ok, safety_cap)
             if cap_hit:
                 self.logger.warning(
                     f"HSV hue expansion cap hit for AOI at {aoi.get('center')}; keeping original selection."
                 )
-                expanded = seed_mask
+                # Seeds never touch an open border (the window wraps their
+                # bounding rect with margin), so this result is final
+                return seed_roi, (x0, y0)
 
-            ys2, xs2 = np.where(expanded)
-            if len(xs2) == 0:
-                continue
-            aoi['detected_pixels'] = np.stack([xs2, ys2], axis=1).tolist()
-            aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(expanded)))
-            combined_mask[expanded] = 255
-
-        return areas_of_interest, combined_mask
+            touches_open_border = (
+                (y0 > 0 and expanded[0, :].any())
+                or (y1 < h and expanded[-1, :].any())
+                or (x0 > 0 and expanded[:, 0].any())
+                or (x1 < w and expanded[:, -1].any())
+            )
+            if not touches_open_border:
+                return expanded, (x0, y0)
+            if x0 == 0 and y0 == 0 and x1 == w and y1 == h:
+                return expanded, (x0, y0)
+            margin *= 4
 
     def _calculate_hsv_distances(self, hsv_image, target_hsv, mask):
         """

--- a/app/algorithms/images/MRMap/services/MRMapService.py
+++ b/app/algorithms/images/MRMap/services/MRMapService.py
@@ -88,11 +88,9 @@ class MRMapService(AlgorithmService):
 
             hist = Histogram(img_converted, self.colorspace)
 
-            # Extract channels (order depends on colorspace)
-            # For all colorspaces, channels are in order [0, 1, 2]
-            ch0, ch1, ch2 = img_converted[:, :, 0], img_converted[:, :, 1], img_converted[:, :, 2]
-            # Compute bin counts for each pixel
-            bin_counts = hist.bin_count(ch0, ch1, ch2)
+            # Bin counts for the histogram's own image: reuses the quantization
+            # computed while the histogram was built
+            bin_counts = hist.bin_count_for_image()
             bin_counts = bin_counts * ((8000 * 6000) / (width * height))
             # Adjust counts based on image size
             # adjusted_counts = bin_counts * (STANDARD_IMAGE_SIZE / (width * height))
@@ -578,6 +576,17 @@ class Histogram:
         # Create color-space-aware quantization mappings
         self.mapping_ch0, self.mapping_ch1, self.mapping_ch2 = self._create_mappings()
 
+        # Premultiplied lookup tables: value -> its term of the fused flat bin
+        # index. B^3 = 17576 fits in uint16, so the whole fused index is three
+        # table lookups and two uint16 adds per pixel - no wide temporaries.
+        bins = NUMBER_OF_QUANTIZED_HISTOGRAM_BINS
+        self._fused_ch0 = self.mapping_ch0.astype(np.uint16) * (bins * bins)
+        self._fused_ch1 = self.mapping_ch1.astype(np.uint16) * bins
+        self._fused_ch2 = self.mapping_ch2.astype(np.uint16)
+
+        # Fused index of this image's own pixels, kept for bin_count_for_image
+        self._own_fused = None
+
         self.q_histogram = None
         self.create_histogram()
 
@@ -655,23 +664,49 @@ class Histogram:
             mapping = np.clip(mapping, 0, NUMBER_OF_QUANTIZED_HISTOGRAM_BINS - 1)
             return mapping, mapping, mapping
 
+    def _fused_bin_index(self, ch0, ch1, ch2):
+        """Map channel values to a single flat index into the 3D histogram.
+
+        Args:
+            ch0, ch1, ch2: Channel value arrays (0-255 / 0-179 raw values).
+
+        Returns:
+            numpy.ndarray: uint16 flat indices into the B*B*B histogram.
+        """
+        fused = self._fused_ch0[ch0]
+        fused += self._fused_ch1[ch1]
+        fused += self._fused_ch2[ch2]
+        return fused
+
     def create_histogram(self):
         """Create quantized 3D histogram from image.
 
-        Maps pixel values to quantized bins using color-space-aware mappings
-        and computes histogram for efficient bin count lookups.
+        The channels are quantized to integer bin indices by the mapping
+        tables, so the counts come from np.bincount on a fused index.
+        np.histogramdd computed the identical result here, but through
+        generic float bin-edge searches (searchsorted) over every pixel -
+        the single largest cost of an MRMap pass on 48MP imagery.
         """
-        # Use channel-specific mappings for better quantization
-        ch0_mapped = self.mapping_ch0[self.image_array[:, :, 0]]
-        ch1_mapped = self.mapping_ch1[self.image_array[:, :, 1]]
-        ch2_mapped = self.mapping_ch2[self.image_array[:, :, 2]]
-
-        # Compute histogram directly without storing a large intermediate array
-        self.q_histogram, _ = np.histogramdd(
-            (ch0_mapped.ravel(), ch1_mapped.ravel(), ch2_mapped.ravel()),  # Direct ravel to avoid memory overhead
-            bins=(NUMBER_OF_QUANTIZED_HISTOGRAM_BINS,) * 3,
-            range=((0, NUMBER_OF_QUANTIZED_HISTOGRAM_BINS),) * 3
+        bins = NUMBER_OF_QUANTIZED_HISTOGRAM_BINS
+        self._own_fused = self._fused_bin_index(
+            self.image_array[:, :, 0],
+            self.image_array[:, :, 1],
+            self.image_array[:, :, 2]
         )
+        counts = np.bincount(self._own_fused.ravel(), minlength=bins ** 3)
+        # float64 to match np.histogramdd's output dtype for downstream math
+        self.q_histogram = counts.reshape(bins, bins, bins).astype(np.float64)
+
+    def bin_count_for_image(self):
+        """Bin counts for every pixel of the image this histogram was built on.
+
+        Reuses the fused index computed while building the histogram, so the
+        per-pixel quantization is not paid a second time.
+
+        Returns:
+            numpy.ndarray: Bin counts, shaped like the image's first two dims.
+        """
+        return self.q_histogram.ravel()[self._own_fused]
 
     def bin_count(self, ch0, ch1, ch2):
         """
@@ -683,9 +718,5 @@ class Histogram:
         Returns:
             numpy.ndarray: Bin counts for each pixel
         """
-        # Use channel-specific mappings
-        q0 = self.mapping_ch0[ch0]
-        q1 = self.mapping_ch1[ch1]
-        q2 = self.mapping_ch2[ch2]
-
-        return self.q_histogram[q0, q1, q2]
+        # Single flat gather instead of broadcast 3-array fancy indexing
+        return self.q_histogram.ravel()[self._fused_bin_index(ch0, ch1, ch2)]

--- a/app/algorithms/images/MRMap/services/MRMapService.py
+++ b/app/algorithms/images/MRMap/services/MRMapService.py
@@ -426,10 +426,7 @@ class MRMapService(AlgorithmService):
             if not original_pixels:
                 continue
 
-            # Seed mask from original detected pixels.
             coords = np.asarray(original_pixels, dtype=np.int32)
-            seed_mask = np.zeros((h, w), dtype=bool)
-            seed_mask[coords[:, 1], coords[:, 0]] = True
 
             # Derive cluster rect from the stored contour corners. MRMap stores
             # the axis-aligned cluster rectangle as 4 corner points.
@@ -444,45 +441,117 @@ class MRMapService(AlgorithmService):
                     int(coords[:, 0].max()), int(coords[:, 1].max()),
                 ]
 
-            safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
+            selected_roi, origin = self._expand_single_aoi(
+                aoi, coords, cluster_rect, expanded_bin_mask, hsv_img, h, w
+            )
+            if selected_roi is None:
+                continue
+            x0, y0 = origin
+
+            # Commit expanded selection back to AOI (ROI coords -> image coords).
+            ys2, xs2 = np.nonzero(selected_roi)
+            if len(xs2) == 0:
+                continue
+            aoi['detected_pixels'] = np.stack([xs2 + x0, ys2 + y0], axis=1).tolist()
+            # Hull area is translation-invariant, so the ROI mask suffices
+            aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(selected_roi)))
+
+            roi_view = combined_mask[y0:y0 + selected_roi.shape[0], x0:x0 + selected_roi.shape[1]]
+            roi_view[selected_roi] = 255
+
+        return areas_of_interest, combined_mask
+
+    def _expand_single_aoi(self, aoi, coords, cluster_rect, expanded_bin_mask, hsv_img, h, w):
+        """Run both expansion stages for one AOI inside a bounded window.
+
+        Every stage used to run on full-frame arrays per AOI (a full-frame hue
+        mask, two full-frame connected-component floods, full-frame commits),
+        which made expansion cost ~1.4s per AOI on 48MP imagery - the dominant
+        cost of an MRMap batch with many small detections.
+
+        The flood is computed inside a window around the cluster rect instead.
+        A flood confined to the window (not touching a border that has more
+        image beyond it) is exactly the global flood, because any pixel
+        connected from the seed must be reached through the border. If the
+        result does touch such a border, the window grows and the stages
+        re-run; the pathological worst case degrades to the old full-frame
+        behavior. A safety-cap overflow inside the window implies overflow
+        globally (the window flood is a subset of the global flood), so cap
+        decisions are exact too.
+
+        Args:
+            aoi (dict): The AOI being expanded (used for logging only).
+            coords (np.ndarray): (N, 2) original detected pixels as (x, y).
+            cluster_rect (list): [xmin, ymin, xmax, ymax] cluster rectangle.
+            expanded_bin_mask: Full-frame bool mask for threshold expansion, or None.
+            hsv_img: Full-frame HSV image for hue expansion, or None.
+            h, w (int): Full-frame dimensions.
+
+        Returns:
+            tuple: (selected_roi bool mask, (x0, y0) window origin), or
+            (None, None) when there is nothing to expand.
+        """
+        xmin, ymin, xmax, ymax = (int(v) for v in cluster_rect)
+        safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
+
+        # Precompute the hue reference once; it depends only on the seeds.
+        mean_hue = None
+        if hsv_img is not None and self.hue_expansion > 0:
+            seed_hues = hsv_img[coords[:, 1], coords[:, 0], 0]
+            mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
+
+        # Window sized so the safety cap usually resolves without regrowth
+        margin = max(128, xmax - xmin + 1, ymax - ymin + 1)
+        while True:
+            x0, y0 = max(0, xmin - margin), max(0, ymin - margin)
+            x1, y1 = min(w, xmax + 1 + margin), min(h, ymax + 1 + margin)
+            roi_shape = (y1 - y0, x1 - x0)
+
+            seed_roi = np.zeros(roi_shape, dtype=bool)
+            seed_roi[coords[:, 1] - y0, coords[:, 0] - x0] = True
 
             # Stage 1: threshold expansion (MRMap only).
-            selected = seed_mask
+            selected = seed_roi
             if expanded_bin_mask is not None:
+                rect_roi = [xmin - x0, ymin - y0, xmax - x0, ymax - y0]
                 threshold_selected = DetectionExpansion.expand_threshold_mrmap(
-                    expanded_bin_mask, cluster_rect, (h, w)
+                    expanded_bin_mask[y0:y1, x0:x1], rect_roi, roi_shape
                 )
-                selected = seed_mask | threshold_selected
+                selected = seed_roi | threshold_selected
 
             # Stage 2: hue expansion. Reference = circular mean of *original*
             # detected pixel hues.
-            if hsv_img is not None and self.hue_expansion > 0:
-                seed_hues = hsv_img[coords[:, 1], coords[:, 0], 0]
-                mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
-                if mean_hue is not None:
-                    hue_ok = DetectionExpansion.hue_distance_mask(
-                        hsv_img, mean_hue, self.hue_expansion,
-                        sat_floor=self.hue_expansion_sat_floor,
-                        val_floor=self.hue_expansion_val_floor,
+            if mean_hue is not None:
+                hue_ok = DetectionExpansion.hue_distance_mask(
+                    hsv_img[y0:y1, x0:x1], mean_hue, self.hue_expansion,
+                    sat_floor=self.hue_expansion_sat_floor,
+                    val_floor=self.hue_expansion_val_floor,
+                )
+                flooded, cap_hit = DetectionExpansion.expand_hue_flood(selected, hue_ok, safety_cap)
+                if cap_hit:
+                    # Exceeding the cap inside the window means the global
+                    # flood exceeds it too; keep the pre-hue selection, but it
+                    # must still be window-exact before we accept it
+                    self.logger.warning(
+                        f"MRMap hue expansion cap hit for AOI at {aoi.get('center')}; keeping pre-hue selection."
                     )
-                    flooded, cap_hit = DetectionExpansion.expand_hue_flood(selected, hue_ok, safety_cap)
-                    if cap_hit:
-                        self.logger.warning(
-                            f"MRMap hue expansion cap hit for AOI at {aoi.get('center')}; keeping pre-hue selection."
-                        )
-                    else:
-                        selected = flooded
+                else:
+                    selected = flooded
 
-            # Commit expanded selection back to AOI.
-            ys2, xs2 = np.where(selected)
-            if len(xs2) == 0:
-                continue
-            aoi['detected_pixels'] = np.stack([xs2, ys2], axis=1).tolist()
-            aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(selected)))
-
-            combined_mask[selected] = 255
-
-        return areas_of_interest, combined_mask
+            # The result is exact unless it touches a window border with more
+            # image beyond it - then connectivity may continue outside
+            touches_open_border = (
+                (y0 > 0 and selected[0, :].any())
+                or (y1 < h and selected[-1, :].any())
+                or (x0 > 0 and selected[:, 0].any())
+                or (x1 < w and selected[:, -1].any())
+            )
+            if not touches_open_border:
+                return selected, (x0, y0)
+            if x0 == 0 and y0 == 0 and x1 == w and y1 == h:
+                # Full frame: nothing beyond the border, result is final
+                return selected, (x0, y0)
+            margin *= 4
 
     def _add_confidence_scores(self, areas_of_interest, bin_counts, mask):
         """Add confidence scores to AOIs based on histogram bin counts (rarity scores).

--- a/app/tests/algorithms/images/HSVColorRange/test_hsv_color_range_service.py
+++ b/app/tests/algorithms/images/HSVColorRange/test_hsv_color_range_service.py
@@ -531,3 +531,136 @@ def test_add_confidence_scores_scale_factor_transforms_coords(hsv_color_range_se
     result = hsv_color_range_service._add_confidence_scores(aois, distances, mask)
     assert 'confidence' in result[0]
     assert result[0]['raw_score'] > 0
+
+
+# ---------------------------------------------------------------------------
+# Windowed hue expansion equivalence vs the old full-frame implementation
+# ---------------------------------------------------------------------------
+
+from algorithms import DetectionExpansion
+
+
+def _reference_hue_expansion(service, areas_of_interest, img_shape, hsv_image):
+    """The pre-windowing full-frame implementation, kept as the oracle."""
+    h, w = int(img_shape[0]), int(img_shape[1])
+    combined_mask = np.zeros((h, w), dtype=np.uint8)
+
+    for aoi in areas_of_interest:
+        original_pixels = aoi.get('detected_pixels') or []
+        if not original_pixels:
+            continue
+        coords = np.asarray(original_pixels, dtype=np.int32)
+        coords[:, 0] = np.clip(coords[:, 0], 0, w - 1)
+        coords[:, 1] = np.clip(coords[:, 1], 0, h - 1)
+
+        seed_mask = np.zeros((h, w), dtype=bool)
+        seed_mask[coords[:, 1], coords[:, 0]] = True
+        cluster_rect = [int(coords[:, 0].min()), int(coords[:, 1].min()),
+                        int(coords[:, 0].max()), int(coords[:, 1].max())]
+        safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
+
+        seed_hues = hsv_image[coords[:, 1], coords[:, 0], 0]
+        mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
+        if mean_hue is None:
+            combined_mask[seed_mask] = 255
+            continue
+
+        hue_ok = DetectionExpansion.hue_distance_mask(
+            hsv_image, mean_hue, service.hue_expansion,
+            sat_floor=service.hue_expansion_sat_floor,
+            val_floor=service.hue_expansion_val_floor)
+        expanded, cap_hit = DetectionExpansion.expand_hue_flood(seed_mask, hue_ok, safety_cap)
+        if cap_hit:
+            expanded = seed_mask
+
+        ys2, xs2 = np.where(expanded)
+        if len(xs2) == 0:
+            continue
+        aoi['detected_pixels'] = np.stack([xs2, ys2], axis=1).tolist()
+        aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(expanded)))
+        combined_mask[expanded] = 255
+
+    return areas_of_interest, combined_mask
+
+
+def _hue_expansion_service():
+    options = {
+        'hsv_configs': [{'selected_color': (200, 30, 30),
+                         'hsv_ranges': {'h_minus': 0.05, 'h_plus': 0.05,
+                                        's_minus': 0.1, 's_plus': 0.1,
+                                        'v_minus': 0.1, 'v_plus': 0.1}}],
+        'hue_expansion': 5,
+        'hue_expansion_sat_floor': 35,
+        'hue_expansion_val_floor': 20,
+    }
+    return HSVColorRangeService(
+        identifier=(255, 255, 0), min_area=1, max_area=0,
+        aoi_radius=10, combine_aois=True, options=options
+    )
+
+
+def _hue_aoi(pixels):
+    return {'center': (int(pixels[0][0]), int(pixels[0][1])), 'radius': 10,
+            'area': len(pixels), 'detected_pixels': [list(p) for p in pixels]}
+
+
+def _assert_hue_expansion_equivalent(aois, hsv):
+    import copy
+    service = _hue_expansion_service()
+    actual, actual_mask = service._apply_hue_expansion_aois(
+        copy.deepcopy(aois), hsv.shape, hsv)
+    expected, expected_mask = _reference_hue_expansion(
+        service, copy.deepcopy(aois), hsv.shape, hsv)
+
+    assert np.array_equal(actual_mask, expected_mask)
+    for got, want in zip(actual, expected):
+        assert sorted(map(tuple, got['detected_pixels'])) == sorted(map(tuple, want['detected_pixels']))
+        assert got['area'] == want['area']
+
+
+def test_windowed_hue_expansion_matches_full_frame_locally():
+    hsv = np.zeros((400, 600, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 120
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    hsv[190:214, 290:330, 0] = 2  # matching patch around the seeds
+    aois = [_hue_aoi([(300, 200), (301, 200), (300, 201)])]
+
+    _assert_hue_expansion_equivalent(aois, hsv)
+
+
+def test_windowed_hue_expansion_follows_ribbon_across_windows():
+    hsv = np.zeros((300, 2400, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 120
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    hsv[149:152, 80:2300, 0] = 3
+    aois = [_hue_aoi([(100, 150), (101, 150)])]
+
+    _assert_hue_expansion_equivalent(aois, hsv)
+
+    service = _hue_expansion_service()
+    expanded, _ = service._apply_hue_expansion_aois(
+        [_hue_aoi([(100, 150), (101, 150)])], hsv.shape, hsv)
+    assert max(p[0] for p in expanded[0]['detected_pixels']) >= 2290
+
+
+def test_windowed_hue_expansion_cap_hit_matches_full_frame():
+    hsv = np.zeros((500, 800, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 3       # entire frame matches the seed hue
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    aois = [_hue_aoi([(400, 250), (401, 250)])]
+
+    _assert_hue_expansion_equivalent(aois, hsv)
+
+
+def test_windowed_hue_expansion_seed_at_corner():
+    hsv = np.zeros((200, 200, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 120
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    hsv[0:6, 0:6, 0] = 3
+    aois = [_hue_aoi([(1, 1), (1, 2)])]
+
+    _assert_hue_expansion_equivalent(aois, hsv)

--- a/app/tests/algorithms/images/MRMap/test_mrmap_service.py
+++ b/app/tests/algorithms/images/MRMap/test_mrmap_service.py
@@ -527,3 +527,63 @@ def test_process_image_with_threshold_expansion_and_hue():
         full_path = os.path.join(tmpdir, "test.jpg")
         result = service.process_image(img, full_path, tmpdir, tmpdir)
     assert isinstance(result, AnalysisResult)
+
+
+# ---------------------------------------------------------------------------
+# Histogram equivalence: bincount fast path must reproduce np.histogramdd
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('colorspace', ['RGB', 'HSV', 'LAB'])
+def test_histogram_matches_histogramdd(colorspace):
+    """The fused-index bincount must equal the histogramdd it replaced."""
+    rng = np.random.default_rng(42)
+    img = rng.integers(0, 256, (120, 160, 3), dtype=np.uint8)
+    if colorspace == 'HSV':
+        img[:, :, 0] = rng.integers(0, 180, (120, 160), dtype=np.uint8)
+
+    hist = Histogram(img, colorspace=colorspace)
+
+    ch0_mapped = hist.mapping_ch0[img[:, :, 0]]
+    ch1_mapped = hist.mapping_ch1[img[:, :, 1]]
+    ch2_mapped = hist.mapping_ch2[img[:, :, 2]]
+    from algorithms.images.MRMap.services.MRMapService import NUMBER_OF_QUANTIZED_HISTOGRAM_BINS as B
+    reference, _ = np.histogramdd(
+        (ch0_mapped.ravel(), ch1_mapped.ravel(), ch2_mapped.ravel()),
+        bins=(B,) * 3, range=((0, B),) * 3
+    )
+
+    assert hist.q_histogram.dtype == reference.dtype
+    assert np.array_equal(hist.q_histogram, reference)
+
+
+def test_bin_count_matches_direct_indexing():
+    """The flat-gather lookup must equal 3D fancy indexing of the histogram."""
+    rng = np.random.default_rng(7)
+    img = rng.integers(0, 256, (80, 100, 3), dtype=np.uint8)
+    hist = Histogram(img, colorspace='LAB')
+
+    ch0, ch1, ch2 = img[:, :, 0], img[:, :, 1], img[:, :, 2]
+    counts = hist.bin_count(ch0, ch1, ch2)
+
+    q0 = hist.mapping_ch0[ch0]
+    q1 = hist.mapping_ch1[ch1]
+    q2 = hist.mapping_ch2[ch2]
+    reference = hist.q_histogram[q0, q1, q2]
+
+    assert counts.shape == reference.shape
+    assert np.array_equal(counts, reference)
+    # Every pixel's own bin contains at least itself
+    assert (hist.bin_count(ch0, ch1, ch2) >= 1).all()
+
+
+def test_bin_count_for_image_matches_bin_count():
+    """The cached-index fast path must equal the general lookup."""
+    rng = np.random.default_rng(9)
+    img = rng.integers(0, 256, (60, 90, 3), dtype=np.uint8)
+    hist = Histogram(img, colorspace='LAB')
+
+    fast = hist.bin_count_for_image()
+    general = hist.bin_count(img[:, :, 0], img[:, :, 1], img[:, :, 2])
+
+    assert fast.shape == (60, 90)
+    assert np.array_equal(fast, general)

--- a/app/tests/algorithms/images/MRMap/test_mrmap_service.py
+++ b/app/tests/algorithms/images/MRMap/test_mrmap_service.py
@@ -3,6 +3,7 @@ import numpy as np
 import tempfile
 import os
 from algorithms.images.MRMap.services.MRMapService import MRMapService, Histogram, _percent_to_u8
+from algorithms import DetectionExpansion
 from algorithms.AlgorithmService import AnalysisResult
 
 
@@ -587,3 +588,179 @@ def test_bin_count_for_image_matches_bin_count():
 
     assert fast.shape == (60, 90)
     assert np.array_equal(fast, general)
+
+# ---------------------------------------------------------------------------
+# Windowed expansion equivalence: _apply_expansion must reproduce the old
+# full-frame implementation exactly, including window-regrowth and cap cases.
+# ---------------------------------------------------------------------------
+
+
+def _reference_apply_expansion(service, areas_of_interest, img_shape, expanded_bin_mask, hsv_img):
+    """The pre-windowing full-frame implementation, kept as the oracle."""
+    h, w = int(img_shape[0]), int(img_shape[1])
+    combined_mask = np.zeros((h, w), dtype=np.uint8)
+
+    for aoi in areas_of_interest:
+        original_pixels = aoi.get('detected_pixels') or []
+        if not original_pixels:
+            continue
+        coords = np.asarray(original_pixels, dtype=np.int32)
+        seed_mask = np.zeros((h, w), dtype=bool)
+        seed_mask[coords[:, 1], coords[:, 0]] = True
+
+        contour = aoi.get('contour') or []
+        if contour:
+            xs = [int(p[0]) for p in contour]
+            ys = [int(p[1]) for p in contour]
+            cluster_rect = [min(xs), min(ys), max(xs), max(ys)]
+        else:
+            cluster_rect = [int(coords[:, 0].min()), int(coords[:, 1].min()),
+                            int(coords[:, 0].max()), int(coords[:, 1].max())]
+
+        safety_cap = DetectionExpansion.compute_safety_cap(cluster_rect)
+
+        selected = seed_mask
+        if expanded_bin_mask is not None:
+            threshold_selected = DetectionExpansion.expand_threshold_mrmap(
+                expanded_bin_mask, cluster_rect, (h, w))
+            selected = seed_mask | threshold_selected
+
+        if hsv_img is not None and service.hue_expansion > 0:
+            seed_hues = hsv_img[coords[:, 1], coords[:, 0], 0]
+            mean_hue = DetectionExpansion.circular_mean_hue(seed_hues)
+            if mean_hue is not None:
+                hue_ok = DetectionExpansion.hue_distance_mask(
+                    hsv_img, mean_hue, service.hue_expansion,
+                    sat_floor=service.hue_expansion_sat_floor,
+                    val_floor=service.hue_expansion_val_floor)
+                flooded, cap_hit = DetectionExpansion.expand_hue_flood(selected, hue_ok, safety_cap)
+                if not cap_hit:
+                    selected = flooded
+
+        ys2, xs2 = np.where(selected)
+        if len(xs2) == 0:
+            continue
+        aoi['detected_pixels'] = np.stack([xs2, ys2], axis=1).tolist()
+        aoi['area'] = int(round(DetectionExpansion.convex_hull_area_from_mask(selected)))
+        combined_mask[selected] = 255
+
+    return areas_of_interest, combined_mask
+
+
+def _expansion_service(**overrides):
+    options = {'threshold': 4, 'segments': 1, 'window': 5, 'colorspace': 'HSV',
+               'threshold_expansion': 400, 'hue_expansion': 5,
+               'hue_expansion_sat_floor': 35, 'hue_expansion_val_floor': 20}
+    options.update(overrides)
+    return MRMapService((255, 255, 0), 1, 0, 15, True, options)
+
+
+def _aoi_from_pixels(pixels):
+    coords = np.asarray(pixels, dtype=np.int32)
+    xmin, ymin = int(coords[:, 0].min()), int(coords[:, 1].min())
+    xmax, ymax = int(coords[:, 0].max()), int(coords[:, 1].max())
+    return {
+        'center': (int(coords[:, 0].mean()), int(coords[:, 1].mean())),
+        'radius': 10,
+        'area': len(pixels),
+        'contour': [[xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]],
+        'detected_pixels': [list(p) for p in pixels],
+    }
+
+
+def _assert_expansion_equivalent(service, aois, shape, expanded_bin_mask, hsv_img):
+    import copy
+    actual_aois = copy.deepcopy(aois)
+    expected_aois = copy.deepcopy(aois)
+
+    actual, actual_mask = service._apply_expansion(actual_aois, shape, expanded_bin_mask, hsv_img)
+    expected, expected_mask = _reference_apply_expansion(
+        service, expected_aois, shape, expanded_bin_mask, hsv_img)
+
+    assert np.array_equal(actual_mask, expected_mask)
+    for got, want in zip(actual, expected):
+        assert sorted(map(tuple, got['detected_pixels'])) == sorted(map(tuple, want['detected_pixels']))
+        assert got['area'] == want['area']
+
+
+def test_windowed_expansion_matches_full_frame_locally():
+    """A flood contained near the AOI must match the old full-frame result."""
+    rng = np.random.default_rng(21)
+    hsv = np.zeros((500, 700, 3), dtype=np.uint8)
+    hsv[:, :, 0] = rng.integers(90, 140, (500, 700))  # background hues far from red
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    # A red-ish patch around the seed for the hue flood to grab
+    hsv[240:260, 340:365, 0] = 2
+    seeds = [(350, 250), (351, 250), (350, 251)]
+    aois = [_aoi_from_pixels(seeds)]
+
+    bin_mask = np.zeros((500, 700), dtype=bool)
+    bin_mask[245:255, 345:360] = True  # threshold expansion inside the rect area
+
+    service = _expansion_service()
+    _assert_expansion_equivalent(service, aois, hsv.shape, bin_mask, hsv)
+
+
+def test_windowed_expansion_follows_long_ribbon_across_windows():
+    """A hue-matching ribbon far longer than the initial window must be fully
+    followed - the window regrows until the flood is contained."""
+    hsv = np.zeros((400, 3000, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 120
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    # Ribbon of seed-matching hue from x=100 to x=2900 at y=200
+    hsv[199:202, 100:2900, 0] = 3
+    seeds = [(150, 200), (151, 200)]
+    aois = [_aoi_from_pixels(seeds)]
+
+    service = _expansion_service()
+    _assert_expansion_equivalent(service, aois, hsv.shape, None, hsv)
+
+    # And the ribbon really was followed beyond the first window
+    xs = [p[0] for p in aois and service._apply_expansion(
+        [_aoi_from_pixels(seeds)], hsv.shape, None, hsv)[0][0]['detected_pixels']]
+    assert max(xs) >= 2890
+
+
+def test_windowed_expansion_cap_hit_matches_full_frame():
+    """A hue region larger than the safety cap must trigger the cap in both
+    implementations and keep the pre-hue selection."""
+    hsv = np.zeros((600, 900, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 3       # the WHOLE image matches the seed hue
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    seeds = [(450, 300), (451, 300)]
+    aois = [_aoi_from_pixels(seeds)]
+
+    service = _expansion_service()
+    _assert_expansion_equivalent(service, aois, hsv.shape, None, hsv)
+
+
+def test_windowed_expansion_at_image_corner():
+    """Seeds at the frame corner: clamped windows must not distort results."""
+    hsv = np.zeros((300, 300, 3), dtype=np.uint8)
+    hsv[:, :, 0] = 120
+    hsv[:, :, 1] = 200
+    hsv[:, :, 2] = 200
+    hsv[0:8, 0:8, 0] = 3
+    seeds = [(1, 1), (2, 1)]
+    aois = [_aoi_from_pixels(seeds)]
+
+    service = _expansion_service()
+    _assert_expansion_equivalent(service, aois, hsv.shape, None, hsv)
+
+
+def test_windowed_threshold_expansion_connectivity_across_window_border():
+    """Phase-B threshold connectivity that extends past the initial window
+    must be followed via window regrowth."""
+    shape = (400, 2600)
+    bin_mask = np.zeros(shape, dtype=bool)
+    # Rect area with expanded-threshold pixels, connected to a long tail
+    bin_mask[195:206, 95:110] = True
+    bin_mask[199:202, 110:2500] = True
+    seeds = [(100, 200), (101, 200)]
+    aois = [_aoi_from_pixels(seeds)]
+
+    service = _expansion_service(hue_expansion=0)
+    _assert_expansion_equivalent(service, aois, shape, bin_mask, None)


### PR DESCRIPTION
## Why this PR

PR #124 was merged after its first commit; three follow-up commits pushed to the same branch during continued field profiling landed after the merge and never reached `dev`. This PR carries exactly those three commits, cherry-picked onto current `dev`. They account for most of the field-measured batch speedup.

## The three commits

1. **MRMap histogram → fused-index bincount.** `np.histogramdd` ran generic float bin-edge searches over every pixel even though the channels were already quantized to integer bin indices, and the per-pixel quantization was computed twice. Now a single `np.bincount` over a fused flat index built from premultiplied uint16 tables, with the index reused for the image's own lookup. Exact-equivalence tests against `histogramdd` for RGB/HSV/LAB. ~2.1× on MRMap process_image.

2. **MRMap per-AOI expansion in bounded windows.** With small min-area settings (field-realistic: 1,700+ AOIs across 150 images), expansion ran a full-frame hue-distance mask and two full-frame connected-component floods **per AOI** — ~1.4 s/AOI on 48 MP imagery, ~85% of total batch time. Each AOI now runs in a window around its cluster that grows 4× and re-runs whenever the flood touches a border with image beyond it (worst case = old behavior). Exactness argument and oracle tests against the old implementation (contained floods, a hue ribbon longer than the window, safety-cap overflow, corner seeds, threshold-phase connectivity across the border). Field result: **17.2 s → 3.75 s per image (~4.6×), identical AOI counts**.

3. **HSV hue expansion windowed the same way** — identical pattern, same exactness argument, same oracle-test approach.

## Field validation

A real 150-image 48 MP MRMap batch (min area 3, 1,718 AOIs, threshold + hue expansion): **1,120 s → 156 s end-to-end (~7.2×), byte-identical detections** — with commit 1 contributing the first step and commit 2 the bulk.

## Tests

114 pass across MRMap, HSVColorRange, and the base algorithm-service suites (equivalence oracles included). `flake8` clean.