### PR TITLE
feat(waldo): authoritative per-image headings from the WALDO trigger-log KML

### DIFF
--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -39,6 +39,10 @@ from core.services.shadow.SolarPosition import (
     get_solar_position,
     resolve_capture_utc,
 )
+from core.services.waldo.WaldoTriggerLog import (
+    TRIGGER_MIN_CHRONOLOGY_FRACTION,
+    WaldoTriggerLogService,
+)
 
 
 WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
@@ -49,7 +53,14 @@ WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
 # (catches datasets whose post-flight software re-orients the frames).
 # Version 7 also retires v6's sun-shadow orientation measurement: on steep
 # terrain at low sun, slope shear and charred fallen logs mislead it.
-WALDO_PROCESSOR_VERSION = "7"
+# Version 8: per-image headings come from the WALDO *_Triggers.kml capture
+# log when one is found near the images. Timestamp-derived headings flip
+# ~180 deg on the first image of each serpentine lane (the >30 s turn gap
+# starves the bearing pass and the fill then copies the OPPOSITE lane's
+# heading - 15 of 1464 images on field data), and cannot handle frames
+# re-flown in the opposite direction. The bump restamps existing datasets
+# so those images get corrected on their next open.
+WALDO_PROCESSOR_VERSION = "8"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 
@@ -113,6 +124,7 @@ class WaldoProcessResult:
     skipped: int = 0  # non-WALDO files
     errors: List[Tuple[str, str]] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)  # informational, non-warning
     cancelled: bool = False
 
 
@@ -689,6 +701,68 @@ class WaldoMetadataService:
                     r.heading_deg = heading
 
     # ------------------------------------------------------------------
+    # Trigger-log heading override
+    # ------------------------------------------------------------------
+
+    def _apply_trigger_log_headings(self, records: List[WaldoImageRecord],
+                                    result: WaldoProcessResult):
+        """Replace GPS/timestamp-derived headings with trigger-log headings.
+
+        Runs AFTER derive_headings so the comparison can report how many
+        images the log corrected; the log wins wherever it matches. A log
+        whose document order contradicts the EXIF timestamps is rejected
+        (it would flip serpentine lanes instead of fixing them). Failures
+        never abort the pass - the timestamp-derived headings remain.
+        """
+        try:
+            trigger_service = WaldoTriggerLogService()
+            found = trigger_service.discover(records)
+            if found is None:
+                return
+            kml_path, triggers = found
+            kml_name = os.path.basename(kml_path)
+
+            chrono = WaldoTriggerLogService.chronology_fraction(triggers, records)
+            if chrono is not None and chrono < TRIGGER_MIN_CHRONOLOGY_FRACTION:
+                result.warnings.append(
+                    f"{kml_name}: trigger order disagrees with image timestamps "
+                    f"({chrono:.0%} consistent) - the log was ignored for headings."
+                )
+                return
+
+            headings = WaldoTriggerLogService.headings_by_name(triggers)
+            applied = 0
+            corrected = 0
+            for rec in records:
+                tname = WaldoTriggerLogService.image_trigger_name(rec.name)
+                heading = headings.get(tname) if tname else None
+                if heading is None:
+                    continue
+                if rec.heading_deg is not None:
+                    diff = abs((rec.heading_deg - heading + 180.0) % 360.0 - 180.0)
+                    if diff > 90.0:
+                        corrected += 1
+                        self.logger.info(
+                            f"WALDO trigger log corrected {rec.name}: "
+                            f"{rec.heading_deg:.1f} -> {heading:.1f} deg")
+                rec.heading_deg = heading
+                applied += 1
+
+            result.notes.append(
+                f"Trigger log {kml_name}: flight direction applied to "
+                f"{applied} of {len(records)} image(s)."
+            )
+            if corrected:
+                result.warnings.append(
+                    f"{kml_name}: corrected the flight direction of {corrected} "
+                    f"image(s) by more than 90 degrees (serpentine lane starts / "
+                    f"re-flown frames). AOI positions on those images were "
+                    f"unreliable in analyses run before this pass."
+                )
+        except Exception as e:
+            self.logger.warning(f"WALDO trigger-log pass failed: {e}")
+
+    # ------------------------------------------------------------------
     # Public folder pipeline
     # ------------------------------------------------------------------
 
@@ -771,6 +845,13 @@ class WaldoMetadataService:
         #    runs in milliseconds even for thousands of records).
         emit(0, 0, "Deriving plane heading from GPS track...")
         self.derive_headings(records)
+
+        # 3a. Trigger-log override: WALDO's *_Triggers.kml lists every
+        #     trigger in CAPTURE order with its position - authoritative for
+        #     flight direction where timestamp sorting fails (serpentine
+        #     lane starts, frames re-flown the opposite way, clock faults).
+        emit(0, 0, "Looking for WALDO trigger log (*_Triggers.kml)...")
+        self._apply_trigger_log_headings(records, result)
 
         # 3b. Measure the stored image orientation per camera by comparing
         #     inter-frame content motion against the GPS track. Post-flight

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -663,17 +663,35 @@ class WaldoMetadataService:
                 j += direction
             return None
 
-        # Pass 1: bearing(prev → next) for interior images.
+        # Pass 1: bearing(prev → next) for interior images; edge images (a
+        # lane start/end whose other neighbour sits beyond the turn window)
+        # use the one in-window side. One-sided bearings are noisier but a
+        # fill would copy the PREVIOUS lane's heading, which on a serpentine
+        # flight is ~180 deg wrong (observed on field data at lane starts).
         for i in range(n):
             prev_idx = neighbour_search(i, -1)
             next_idx = neighbour_search(i, +1)
             if prev_idx is not None and next_idx is not None:
-                group[i].heading_deg = LocationInfo.bearing(
+                heading = LocationInfo.bearing(
                     group[prev_idx].lat, group[prev_idx].lon,
                     group[next_idx].lat, group[next_idx].lon
                 )
+            elif prev_idx is not None:
+                heading = LocationInfo.bearing(
+                    group[prev_idx].lat, group[prev_idx].lon,
+                    group[i].lat, group[i].lon
+                )
+            elif next_idx is not None:
+                heading = LocationInfo.bearing(
+                    group[i].lat, group[i].lon,
+                    group[next_idx].lat, group[next_idx].lon
+                )
+            else:
+                continue
+            if not math.isnan(heading):
+                group[i].heading_deg = heading
 
-        # Pass 2: forward fill (first images inherit from the next valid).
+        # Pass 2: forward fill (stationary clusters inherit the last valid).
         last_seen: Optional[float] = None
         for r in group:
             if r.heading_deg is None and last_seen is not None:

--- a/app/core/services/waldo/WaldoTriggerLog.py
+++ b/app/core/services/waldo/WaldoTriggerLog.py
@@ -1,0 +1,297 @@
+"""
+WaldoTriggerLog - Authoritative per-image heading from the WALDO trigger KML.
+
+WALDO ground software writes a ``<flight>_Triggers.kml`` next to the flight's
+image folders: one ``<Placemark>`` per camera trigger, named after the image
+(``000_12_035`` for images ``0_000_12_035.jpg`` / ``1_000_12_035.jpg``) and
+positioned where the trigger fired. Crucially the placemarks appear in
+CAPTURE ORDER, not filename order: WALDO flights are flown serpentine
+(alternating lanes flown in opposite directions while frame numbers ascend
+in a fixed geographic direction) and any skipped frames may be re-flown at
+the end of the flight travelling the other way. Filename order therefore
+does NOT recover the flight direction, and EXIF timestamps do so only when
+the camera clock behaved. The trigger log is the ground truth for both the
+capture sequence and the trigger positions.
+
+This module parses that log and derives a per-image plane heading from the
+document-order neighbours of each trigger, giving every image a heading
+accurate to a few degrees regardless of serpentine lanes, recapture passes,
+or camera-clock faults.
+
+Real-world tolerances baked in:
+- files may be truncated mid-coordinates (the logger does not always close
+  its tags) - parsing reads to EOF;
+- placemark names carry trailing whitespace;
+- trigger names are NOT globally unique across flights (every flight numbers
+  lanes from zero), so discovery validates candidates by GPS proximity, not
+  by name alone.
+"""
+
+import glob
+import math
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from helpers.LocationInfo import LocationInfo
+
+from core.services.LoggerService import LoggerService
+
+# Consecutive triggers in a lane are ~150-250 m apart; anything beyond this is
+# a lane-change turn or a jump to a recapture site and must not contribute to
+# a bearing.
+TRIGGER_NEIGHBOR_MAX_M = 600.0
+
+# Consecutive segment bearings turning harder than this split the capture
+# sequence into separate runs. Distance alone cannot detect a tight
+# serpentine turn: adjacent lanes can sit closer together than
+# TRIGGER_NEIGHBOR_MAX_M, making the turn segment look like lane spacing.
+TRIGGER_TURN_BREAK_DEG = 60.0
+
+# An image matches a trigger only when its EXIF GPS lies within this distance
+# of the trigger position (observed misfit on field data: ~12 m median).
+TRIGGER_MATCH_MAX_M = 300.0
+
+# A candidate KML must position-match at least this fraction of the images
+# before it is trusted as the flight's trigger log.
+TRIGGER_MIN_MATCH_FRACTION = 0.5
+
+# Doc order is trusted as capture order only when the EXIF timestamps of
+# matched images agree with it at least this often (constant clock offsets do
+# not affect the comparison; it only checks monotonicity).
+TRIGGER_MIN_CHRONOLOGY_FRACTION = 0.8
+
+# How many directory levels above the images to search for candidate KMLs
+# (field layout: <root>/<flight>_Triggers.kml with images in
+# <root>/<flight>/batch<N>/).
+TRIGGER_SEARCH_LEVELS = 3
+
+
+@dataclass
+class TriggerPoint:
+    """One camera trigger from the log, in document (= capture) order."""
+    name: str
+    lat: float
+    lon: float
+    alt: Optional[float]
+
+
+class WaldoTriggerLogService:
+    """Parse WALDO trigger KMLs and derive per-image headings from them."""
+
+    def __init__(self):
+        self.logger = LoggerService()
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def parse_triggers_kml(path: str) -> List[TriggerPoint]:
+        """Return the trigger points of a KML in document order.
+
+        Tolerates truncated files and malformed placemarks (skipped).
+        Returns [] when the file is unreadable or contains no point placemarks.
+        """
+        try:
+            with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                text = f.read()
+        except OSError:
+            return []
+
+        points: List[TriggerPoint] = []
+        pattern = re.compile(
+            r'<Placemark>\s*<name>([^<]+)</name>.*?'
+            r'<Point>.*?<coordinates>([^<]*)',
+            re.S)
+        for m in pattern.finditer(text):
+            name = m.group(1).strip()
+            coords = m.group(2).strip().split(',')
+            try:
+                lon = float(coords[0])
+                lat = float(coords[1])
+                alt = float(coords[2]) if len(coords) > 2 else None
+            except (ValueError, IndexError):
+                continue
+            points.append(TriggerPoint(name=name, lat=lat, lon=lon, alt=alt))
+        return points
+
+    @staticmethod
+    def image_trigger_name(image_name: str) -> Optional[str]:
+        """Map a WALDO image filename to its trigger placemark name.
+
+        ``0_000_12_035.jpg`` -> ``000_12_035`` (cam prefix stripped; both
+        cameras share one trigger). Returns None for non-WALDO names.
+        """
+        base = os.path.splitext(os.path.basename(image_name))[0]
+        m = re.match(r'^[01]_(.+)$', base)
+        if not m:
+            return None
+        return m.group(1)
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def discover(self, records: Sequence) -> Optional[Tuple[str, List[TriggerPoint]]]:
+        """Find the trigger KML for a set of WaldoImageRecords, if any.
+
+        Searches the image directories and up to TRIGGER_SEARCH_LEVELS parent
+        levels for ``*.kml`` files, and scores each candidate by the fraction
+        of records it matches BY NAME AND GPS POSITION. Position matching is
+        essential: every flight numbers its lanes from zero, so a sibling
+        flight's log can contain the same trigger names at different places.
+
+        Returns (kml_path, triggers) for the best candidate above
+        TRIGGER_MIN_MATCH_FRACTION, or None.
+        """
+        usable = [r for r in records if r.lat is not None and r.lon is not None]
+        if not usable:
+            return None
+
+        candidates: List[str] = []
+        seen_dirs = set()
+        for rec in usable:
+            d = os.path.dirname(os.path.abspath(rec.path))
+            for _ in range(TRIGGER_SEARCH_LEVELS + 1):
+                if d in seen_dirs:
+                    break
+                seen_dirs.add(d)
+                candidates.extend(sorted(glob.glob(os.path.join(d, '*.kml'))))
+                parent = os.path.dirname(d)
+                if parent == d:
+                    break
+                d = parent
+
+        best: Optional[Tuple[str, List[TriggerPoint]]] = None
+        best_score = 0.0
+        for kml_path in dict.fromkeys(candidates):  # dedupe, keep order
+            triggers = self.parse_triggers_kml(kml_path)
+            if not triggers:
+                continue
+            by_name = {t.name: t for t in triggers}
+            matched = 0
+            for rec in usable:
+                tname = self.image_trigger_name(rec.name)
+                trig = by_name.get(tname) if tname else None
+                if trig is None:
+                    continue
+                dist = LocationInfo.haversine_m(rec.lat, rec.lon, trig.lat, trig.lon)
+                if dist <= TRIGGER_MATCH_MAX_M:
+                    matched += 1
+            score = matched / len(usable)
+            if score > best_score:
+                best_score = score
+                best = (kml_path, triggers)
+
+        if best is None or best_score < TRIGGER_MIN_MATCH_FRACTION:
+            return None
+        self.logger.info(
+            f"WALDO trigger log: {best[0]} matched "
+            f"{best_score:.0%} of {len(usable)} images")
+        return best
+
+    # ------------------------------------------------------------------
+    # Heading derivation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def headings_by_name(triggers: List[TriggerPoint]) -> Dict[str, float]:
+        """Per-trigger plane heading from document-order neighbours.
+
+        The capture sequence is first split into straight RUNS. A run break
+        occurs at any segment that is too long / too short to be in-lane
+        spacing, or that turns harder than TRIGGER_TURN_BREAK_DEG relative
+        to the run's direction (a tight serpentine turn can bring the next
+        lane closer than the distance guard alone would catch). Headings
+        never cross a run boundary: interior triggers use the chord
+        bearing(prev -> next), run-edge triggers the one in-run segment,
+        and singleton runs (an isolated recapture) get no heading - the
+        caller keeps its timestamp-derived fallback there.
+        """
+        n = len(triggers)
+        if n == 0:
+            return {}
+
+        # Segment i connects trigger i to trigger i+1. None = unusable.
+        seg_bearing: List[Optional[float]] = [None] * (n - 1)
+        for i in range(n - 1):
+            a, b = triggers[i], triggers[i + 1]
+            dist = LocationInfo.haversine_m(a.lat, a.lon, b.lat, b.lon)
+            if not (1.0 < dist < TRIGGER_NEIGHBOR_MAX_M):
+                continue
+            brg = LocationInfo.bearing(a.lat, a.lon, b.lat, b.lon)
+            if not math.isnan(brg):
+                seg_bearing[i] = brg % 360.0
+
+        # Assign run ids. After a break the new run's direction is unknown
+        # (the breaking segment belongs to the turn, not to either lane),
+        # so it seeds from the first good segment inside the new run.
+        run_id = [0] * n
+        current = 0
+        run_dir: Optional[float] = None
+        for i in range(1, n):
+            sb = seg_bearing[i - 1]
+            turned = (
+                sb is not None and run_dir is not None
+                and abs((sb - run_dir + 180.0) % 360.0 - 180.0) > TRIGGER_TURN_BREAK_DEG
+            )
+            if sb is None or turned:
+                current += 1
+                run_dir = None
+            else:
+                run_dir = sb
+            run_id[i] = current
+
+        headings: Dict[str, float] = {}
+        for i, trig in enumerate(triggers):
+            # Adjacent same-run triggers always have a usable segment between
+            # them (an unusable segment forces a run break).
+            prev_in_run = i > 0 and run_id[i - 1] == run_id[i]
+            next_in_run = i < n - 1 and run_id[i + 1] == run_id[i]
+            if prev_in_run and next_in_run:
+                heading = LocationInfo.bearing(
+                    triggers[i - 1].lat, triggers[i - 1].lon,
+                    triggers[i + 1].lat, triggers[i + 1].lon)
+            elif prev_in_run:
+                heading = seg_bearing[i - 1]
+            elif next_in_run:
+                heading = seg_bearing[i]
+            else:
+                continue
+            if heading is not None and not math.isnan(heading):
+                headings[trig.name] = heading % 360.0
+        return headings
+
+    @staticmethod
+    def chronology_fraction(triggers: List[TriggerPoint],
+                            records: Sequence) -> Optional[float]:
+        """Fraction of doc-adjacent trigger pairs whose EXIF timestamps
+        are non-decreasing.
+
+        Guards against a hypothetical log written in name order rather than
+        capture order: a serpentine flight would then get half its lanes
+        flipped, which is worse than the timestamp-based fallback. Constant
+        camera-clock offsets (the known WALDO AM/PM + timezone faults) shift
+        every timestamp equally and do not affect the check.
+
+        Returns None when fewer than 3 comparable pairs exist.
+        """
+        ts_by_trigger: Dict[str, object] = {}
+        for rec in records:
+            if rec.timestamp is None:
+                continue
+            tname = WaldoTriggerLogService.image_trigger_name(rec.name)
+            if tname is None:
+                continue
+            # Prefer cam 0's clock; either cam alone is self-consistent.
+            if tname not in ts_by_trigger or rec.cam_idx == 0:
+                ts_by_trigger[tname] = rec.timestamp
+
+        ordered = [ts_by_trigger[t.name] for t in triggers if t.name in ts_by_trigger]
+        if len(ordered) < 4:
+            return None
+        pairs = len(ordered) - 1
+        good = sum(1 for a, b in zip(ordered, ordered[1:]) if b >= a)
+        return good / pairs

--- a/app/core/services/waldo/__init__.py
+++ b/app/core/services/waldo/__init__.py
@@ -17,6 +17,10 @@ from .WaldoMetadataService import (
     WALDO_NAMESPACE_URI,
     WALDO_PROCESSOR_VERSION,
 )
+from .WaldoTriggerLog import (
+    WaldoTriggerLogService,
+    TriggerPoint,
+)
 
 __all__ = [
     'WaldoMetadataService',
@@ -27,4 +31,6 @@ __all__ = [
     'WaldoMissingGPSError',
     'WALDO_NAMESPACE_URI',
     'WALDO_PROCESSOR_VERSION',
+    'WaldoTriggerLogService',
+    'TriggerPoint',
 ]

--- a/app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py
+++ b/app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py
@@ -155,10 +155,13 @@ class WaldoPrePassDialog(TranslationMixin, QDialog):
         lines.append(self.tr("Already up-to-date: {n}").format(n=result.already_current))
         lines.append(self.tr("Skipped (non-WALDO): {n}").format(n=result.skipped))
         lines.append(self.tr("Errors:           {n}").format(n=len(result.errors)))
+        notes = getattr(result, 'notes', None) or []
+        for msg in notes:
+            lines.append(f"  {msg}")
         warnings = getattr(result, 'warnings', None) or []
         if warnings:
             lines.append("")
-            lines.append(self.tr("⚠ Capture-time warnings (camera clock is suspect):"))
+            lines.append(self.tr("⚠ Metadata warnings:"))
             for msg in warnings:
                 lines.append(f"  {msg}")
         if result.errors:

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -179,6 +179,36 @@ def test_heading_cross_cam_fallback():
     assert cam1.heading_deg is not None  # filled from cam 0
 
 
+def test_heading_serpentine_lane_edges_use_one_sided_bearing():
+    """Lane-edge images must derive from their OWN lane, never inherit the
+    previous lane's heading across the turn gap.
+
+    Serpentine field flights showed the first image of each lane stamped
+    ~180 deg flipped: the >30 s turn starved the two-sided bearing pass and
+    the forward fill copied the opposite lane's heading.
+    """
+    t0 = datetime(2026, 1, 1, 12, 0, 0)
+    records = []
+    # Lane A: northbound, captures every 2 s.
+    for i in range(4):
+        records.append(_make_record(0, i, 37.000 + i * 0.001, -120.000,
+                                    t0 + timedelta(seconds=i * 2)))
+    # 90 s turn gap (beyond MAX_NEIGHBOR_DT_S), then lane B: SOUTHBOUND.
+    for i in range(4):
+        records.append(_make_record(0, 10 + i, 37.003 - i * 0.001, -120.002,
+                                    t0 + timedelta(seconds=90 + i * 2)))
+    svc = WaldoMetadataService(terrain_service=None)
+    svc.derive_headings(records)
+    lane_a = records[:4]
+    lane_b = records[4:]
+    for r in lane_a:
+        diff = min(abs(r.heading_deg), abs(360.0 - r.heading_deg))
+        assert diff < 5.0, f"lane A image {r.name} heading {r.heading_deg}"
+    for r in lane_b:
+        assert abs(r.heading_deg - 180.0) < 5.0, \
+            f"lane B image {r.name} heading {r.heading_deg} (flip regression)"
+
+
 # --------------------------------------------------------------------------
 # process_folder progress phasing
 # --------------------------------------------------------------------------

--- a/app/tests/core/services/waldo/test_waldo_trigger_log.py
+++ b/app/tests/core/services/waldo/test_waldo_trigger_log.py
@@ -1,0 +1,332 @@
+"""Unit tests for WaldoTriggerLogService and its WaldoMetadataService hookup."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from core.services.waldo.WaldoMetadataService import (
+    WaldoMetadataService,
+    WaldoImageRecord,
+    WaldoProcessResult,
+)
+from core.services.waldo.WaldoTriggerLog import (
+    TriggerPoint,
+    WaldoTriggerLogService,
+)
+
+
+# --------------------------------------------------------------------------
+# KML synthesis helpers
+# --------------------------------------------------------------------------
+
+KML_HEADER = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<kml xmlns="http://www.opengis.net/kml/2.2">\n'
+    '<Document> <name>Test_Triggers</name>\n'
+)
+
+
+def _placemark(name, lat, lon, alt=2400.0):
+    # Real files carry a trailing space inside <name> — reproduce it.
+    return (
+        f'<Placemark> <name>{name} </name> <styleUrl>#whiteDot</styleUrl> '
+        f'<Point> <coordinates>{lon:.6f},{lat:.6f},{alt:.2f}</coordinates> '
+        f'</Point> </Placemark>\n'
+    )
+
+
+def _write_kml(path, placemarks, close=True):
+    text = KML_HEADER + "".join(placemarks)
+    if close:
+        text += "</Document>\n</kml>\n"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+# Lane geometry: 0.002 deg latitude ~= 222 m spacing (inside the 600 m
+# neighbour guard); 0.02 deg ~= 2.2 km (outside it).
+def _lane(lane_idx, frames, lat0, lon, ascending=True):
+    marks = []
+    for j, frame in enumerate(frames):
+        lat = lat0 + (j if ascending else -j) * 0.002
+        marks.append((f"000_{lane_idx:02d}_{frame:03d}", lat, lon))
+    return marks
+
+
+# --------------------------------------------------------------------------
+# parse_triggers_kml
+# --------------------------------------------------------------------------
+
+def test_parse_reads_names_and_coords_in_document_order(tmp_path):
+    marks = [_placemark("000_12_000", 41.0, -122.0),
+             _placemark("000_12_001", 41.002, -122.0)]
+    path = _write_kml(tmp_path / "t.kml", marks)
+    points = WaldoTriggerLogService.parse_triggers_kml(path)
+    assert [p.name for p in points] == ["000_12_000", "000_12_001"]
+    assert points[0].lat == pytest.approx(41.0)
+    assert points[0].lon == pytest.approx(-122.0)
+    assert points[0].alt == pytest.approx(2400.0)
+
+
+def test_parse_tolerates_truncated_file(tmp_path):
+    # Field Position/Trigger KMLs can end mid-stream with no closing tags.
+    marks = [_placemark("000_12_000", 41.0, -122.0)]
+    text = KML_HEADER + "".join(marks) + \
+        '<Placemark> <name>000_12_001 </name> <Point> <coordinates>-122.000000,41.002'
+    path = tmp_path / "trunc.kml"
+    path.write_text(text, encoding="utf-8")
+    points = WaldoTriggerLogService.parse_triggers_kml(str(path))
+    assert len(points) == 2
+    assert points[1].lat == pytest.approx(41.002)
+    assert points[1].alt is None
+
+
+def test_parse_skips_linestring_placemarks(tmp_path):
+    # Position KMLs hold a LineString track — must not parse as triggers.
+    text = KML_HEADER + (
+        '<Placemark id="X"> <name>Track</name> <LineString> <coordinates>\n'
+        '-122.0,41.0,3000\n-122.0,41.1,3000\n</coordinates> </LineString> </Placemark>\n'
+    )
+    path = tmp_path / "pos.kml"
+    path.write_text(text, encoding="utf-8")
+    assert WaldoTriggerLogService.parse_triggers_kml(str(path)) == []
+
+
+def test_parse_skips_malformed_coordinates(tmp_path):
+    marks = [
+        _placemark("000_12_000", 41.0, -122.0),
+        '<Placemark> <name>bad </name> <Point> <coordinates>not,numbers</coordinates> </Point> </Placemark>\n',
+        _placemark("000_12_001", 41.002, -122.0),
+    ]
+    path = _write_kml(tmp_path / "t.kml", marks)
+    points = WaldoTriggerLogService.parse_triggers_kml(path)
+    assert [p.name for p in points] == ["000_12_000", "000_12_001"]
+
+
+def test_parse_unreadable_path_returns_empty(tmp_path):
+    assert WaldoTriggerLogService.parse_triggers_kml(str(tmp_path / "nope.kml")) == []
+
+
+# --------------------------------------------------------------------------
+# image_trigger_name
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("image,expected", [
+    ("0_000_12_035.jpg", "000_12_035"),
+    ("1_000_00_002.JPG", "000_00_002"),
+    (r"E:\somewhere\1_000_04_019.jpg", "000_04_019"),
+    ("DJI_0001.JPG", None),
+    ("2_000_00_000.jpg", None),
+])
+def test_image_trigger_name(image, expected):
+    assert WaldoTriggerLogService.image_trigger_name(image) == expected
+
+
+# --------------------------------------------------------------------------
+# headings_by_name
+# --------------------------------------------------------------------------
+
+def _points(marks):
+    return [TriggerPoint(name=n, lat=lat, lon=lon, alt=None) for n, lat, lon in marks]
+
+
+def test_headings_serpentine_lanes_get_opposite_directions():
+    # Lane 01 flown north (frames ascending), lane 00 flown SOUTH while its
+    # frame numbers still ascend geographically north — the serpentine trap.
+    lane_a = _lane(1, range(5), 41.0, -122.0, ascending=True)
+    lane_b = _lane(0, [4, 3, 2, 1, 0], 41.008, -122.003, ascending=False)
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane_a + lane_b))
+    for j in range(5):
+        assert headings[f"000_01_{j:03d}"] == pytest.approx(0.0, abs=3.0) or \
+            headings[f"000_01_{j:03d}"] == pytest.approx(360.0, abs=3.0)
+    for j in range(5):
+        assert headings[f"000_00_{j:03d}"] == pytest.approx(180.0, abs=3.0)
+
+
+def test_headings_recaptured_frames_get_recapture_direction():
+    # Frames 1-2 of lane 00 were missed on the northbound pass and re-flown
+    # SOUTHBOUND at the end of the flight. Their headings must come from the
+    # recapture pass, not from where their names sit in the lane.
+    lane = _lane(0, [0, 3, 4], 41.0, -122.0, ascending=True)   # 41.000/002/004
+    recapture = [("000_00_002", 41.004, -122.0),               # flying south now
+                 ("000_00_001", 41.002, -122.0)]
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane + recapture))
+    assert headings["000_00_000"] == pytest.approx(0.0, abs=3.0)
+    assert headings["000_00_002"] == pytest.approx(180.0, abs=3.0)
+    assert headings["000_00_001"] == pytest.approx(180.0, abs=3.0)
+
+
+def test_headings_lane_ends_use_one_sided_bearing():
+    # A jump >600 m (0.02 deg) separates two lanes; the triggers flanking the
+    # jump must not derive a bearing across it.
+    lane_a = _lane(1, range(3), 41.0, -122.0, ascending=True)
+    lane_b = _lane(0, range(3), 41.1, -122.003, ascending=True)
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane_a + lane_b))
+    # Last of lane A and first of lane B still get their own lane's direction.
+    assert headings["000_01_002"] == pytest.approx(0.0, abs=3.0)
+    assert headings["000_00_000"] == pytest.approx(0.0, abs=3.0)
+
+
+def test_headings_isolated_trigger_gets_none():
+    lane = _lane(1, range(3), 41.0, -122.0, ascending=True)
+    isolated = [("000_09_050", 41.5, -122.5)]
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane + isolated))
+    assert "000_09_050" not in headings
+    assert "000_01_001" in headings
+
+
+def test_headings_stationary_duplicate_neighbour_ignored():
+    # A duplicate point (<1 m away) must not produce a degenerate bearing.
+    marks = [("000_00_000", 41.0, -122.0),
+             ("000_00_001", 41.0, -122.0),
+             ("000_00_002", 41.002, -122.0)]
+    headings = WaldoTriggerLogService.headings_by_name(_points(marks))
+    assert headings["000_00_001"] == pytest.approx(0.0, abs=3.0)
+
+
+# --------------------------------------------------------------------------
+# chronology_fraction
+# --------------------------------------------------------------------------
+
+def _rec(name, lat, lon, ts, cam=0, path=None):
+    return WaldoImageRecord(path=path or name, name=name, cam_idx=cam,
+                            lat=lat, lon=lon, timestamp=ts)
+
+
+def test_chronology_consistent_timestamps_score_high():
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    records = [_rec(f"0_{n}.jpg", lat, lon, t0 + timedelta(seconds=4 * j))
+               for j, (n, lat, lon) in enumerate(marks)]
+    frac = WaldoTriggerLogService.chronology_fraction(_points(marks), records)
+    assert frac == pytest.approx(1.0)
+
+
+def test_chronology_reversed_timestamps_score_low():
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    records = [_rec(f"0_{n}.jpg", lat, lon, t0 - timedelta(seconds=4 * j))
+               for j, (n, lat, lon) in enumerate(marks)]
+    frac = WaldoTriggerLogService.chronology_fraction(_points(marks), records)
+    assert frac == pytest.approx(0.0)
+
+
+def test_chronology_too_few_matches_returns_none():
+    marks = _lane(0, range(2), 41.0, -122.0, ascending=True)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    records = [_rec(f"0_{n}.jpg", lat, lon, t0)
+               for n, lat, lon in marks]
+    assert WaldoTriggerLogService.chronology_fraction(_points(marks), records) is None
+
+
+# --------------------------------------------------------------------------
+# discover
+# --------------------------------------------------------------------------
+
+def _flight_layout(tmp_path, marks, kml_name="20260723_65561_Triggers.kml"):
+    """Field layout: <root>/<kml> with images two levels down in batch dirs."""
+    batch_dir = tmp_path / "20260723_65561" / "batch1"
+    batch_dir.mkdir(parents=True)
+    kml = _write_kml(tmp_path / kml_name, [_placemark(n, lat, lon) for n, lat, lon in marks])
+    records = [_rec(f"0_{n}.jpg", lat, lon, None, path=str(batch_dir / f"0_{n}.jpg"))
+               for n, lat, lon in marks]
+    return kml, records
+
+
+def test_discover_finds_kml_levels_above_images(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    kml, records = _flight_layout(tmp_path, marks)
+    found = WaldoTriggerLogService().discover(records)
+    assert found is not None
+    assert found[0] == kml
+    assert len(found[1]) == 5
+
+
+def test_discover_rejects_name_collision_from_other_flight(tmp_path):
+    # A sibling flight's log contains the SAME trigger names at different
+    # positions (every flight numbers lanes from zero). GPS proximity must
+    # pick the right log.
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    decoy_marks = [(n, lat + 1.0, lon + 1.0) for n, lat, lon in marks]
+    kml, records = _flight_layout(tmp_path, marks)
+    _write_kml(tmp_path / "20260723_99999_Triggers.kml",
+               [_placemark(n, lat, lon) for n, lat, lon in decoy_marks])
+    found = WaldoTriggerLogService().discover(records)
+    assert found is not None
+    assert found[0] == kml
+
+
+def test_discover_returns_none_without_positional_match(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    _, records = _flight_layout(tmp_path, marks)
+    # Re-write the KML with every trigger displaced ~111 km: names all match
+    # but no position does, so the log must be rejected.
+    far_marks = [(n, lat + 1.0, lon) for n, lat, lon in marks]
+    _write_kml(tmp_path / "20260723_65561_Triggers.kml",
+               [_placemark(n, lat, lon) for n, lat, lon in far_marks])
+    assert WaldoTriggerLogService().discover(records) is None
+
+
+def test_discover_returns_none_when_no_kml_exists(tmp_path):
+    batch_dir = tmp_path / "flight" / "batch1"
+    batch_dir.mkdir(parents=True)
+    records = [_rec("0_000_00_000.jpg", 41.0, -122.0, None,
+                    path=str(batch_dir / "0_000_00_000.jpg"))]
+    assert WaldoTriggerLogService().discover(records) is None
+
+
+# --------------------------------------------------------------------------
+# WaldoMetadataService._apply_trigger_log_headings integration
+# --------------------------------------------------------------------------
+
+def test_apply_corrects_flipped_headings_and_warns(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)  # truth: north
+    _, records = _flight_layout(tmp_path, marks)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    for j, rec in enumerate(records):
+        rec.timestamp = t0 + timedelta(seconds=4 * j)
+        rec.heading_deg = 180.0  # timestamp derivation got these flipped
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = WaldoProcessResult()
+    svc._apply_trigger_log_headings(records, result)
+
+    for rec in records:
+        assert rec.heading_deg == pytest.approx(0.0, abs=3.0) or \
+            rec.heading_deg == pytest.approx(360.0, abs=3.0)
+    assert any("corrected the flight direction of 5" in w for w in result.warnings)
+    assert any("Trigger log" in n and "5 of 5" in n for n in result.notes)
+
+
+def test_apply_rejects_log_contradicting_timestamps(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    _, records = _flight_layout(tmp_path, marks)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    for j, rec in enumerate(records):
+        rec.timestamp = t0 - timedelta(seconds=4 * j)  # doc order backwards
+        rec.heading_deg = 123.0
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = WaldoProcessResult()
+    svc._apply_trigger_log_headings(records, result)
+
+    assert all(rec.heading_deg == 123.0 for rec in records)
+    assert any("ignored" in w for w in result.warnings)
+    assert result.notes == []
+
+
+def test_apply_no_kml_is_a_quiet_noop(tmp_path):
+    batch_dir = tmp_path / "flight" / "batch1"
+    batch_dir.mkdir(parents=True)
+    records = [_rec("0_000_00_000.jpg", 41.0, -122.0,
+                    datetime(2026, 7, 23, 6, 30, 0),
+                    path=str(batch_dir / "0_000_00_000.jpg"))]
+    records[0].heading_deg = 77.0
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = WaldoProcessResult()
+    svc._apply_trigger_log_headings(records, result)
+
+    assert records[0].heading_deg == 77.0
+    assert result.warnings == []
+    assert result.notes == []

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -1679,70 +1679,70 @@ Please check your credentials and try again.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>CalTopo Login &amp; Map Selection</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Current map: Not selected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>I&apos;m Logged In - Export Data</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Click this after logging in and navigating to your map</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Initialization Error</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Failed to initialize CalTopo browser:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Failed to Load</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Failed to load CalTopo. Please check your internet connection and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Current map: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>No Map Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Browser Not Ready</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>The CalTopo browser is still loading. Please wait a moment and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Starting export...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Authentication Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser not initialized. Please try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Please check:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Offline Mode Enabled</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Turn off Offline Only to export to CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Nothing Selected</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Please ensure your images have GPS coordinates and are nadir shots.</translation
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>No Map Selected</translation>
     </message>
@@ -2137,7 +2137,7 @@ The map URL should look like:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 The reason was written to the log (adiat_logs.txt) and the console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Photos uploaded: {uploaded} of {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 The items should now be visible on your map.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Export Successful</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Partial Success</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Export Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Export Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Exporting to CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Logged Out</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Successfully logged out from CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>Loading CalTopo Maps</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Connecting to CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Fetching account data and maps...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Connection Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Number of corners: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Authentication Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>No CalTopo session cookies were captured. Please log in and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Number of corners: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ The reason was written to the log (adiat_logs.txt) and the console.
 Would you like to re-enter your Team ID, Credential ID and Credential Secret?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exporting to CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparing data and exporting...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Errors:           {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Per-image errors:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Cancelling...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Cancellation requested...</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -1679,70 +1679,70 @@ Compruebe sus credenciales e inténtelo de nuevo.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>Inicio de sesión y selección de mapa de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Mapa actual: No seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Inicie sesión → Vaya a su mapa → Haga clic en &apos;He iniciado sesión&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>He iniciado sesión - Exportar datos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Haga clic en esto tras iniciar sesión y navegar hasta su mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Error de inicialización</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Error al inicializar el navegador de CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Error al cargar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Error al cargar CalTopo. Compruebe su conexión a Internet e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Mapa actual: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>Ningún mapa seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 La URL del mapa debe contener un ID de mapa (p. ej., /m/ABC123 o #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Navegador no listo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>El navegador de CalTopo aún se está cargando. Espere un momento e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Iniciando exportación...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Error de autenticación</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Navegador no inicializado. Inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Compruebe:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Modo sin conexión habilitado</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Desactive Solo sin conexión para exportar a CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Nada seleccionado</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Seleccione al menos un tipo de datos (AOI marcados, ubicaciones de dron/imagen o área de cobertura) para exportar.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Asegúrese de que sus imágenes tengan coordenadas GPS y sean tomas nadir.</tran
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>Ningún mapa seleccionado</translation>
     </message>
@@ -2137,7 +2137,7 @@ La URL del mapa debería verse así:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Abra su mapa en la ventana de CalTopo antes de hacer clic en &apos;He iniciado sesión - Exportar datos&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consola.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Fotos subidas: {uploaded} de {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 Los elementos ya deberían aparecer en su mapa.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Los detalles de lo que falló se registraron en el archivo de registro (adiat_logs.txt) y en la consola.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Exportación exitosa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Éxito parcial</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Exportación fallida</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Error de exportación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ Los detalles de lo que falló se registraron en el archivo de registro (adiat_lo
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Number of corners: {count}</source>
 Número de esquinas: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Exportando a CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Sesión cerrada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Sesión cerrada correctamente en CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>Cargando mapas de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Conectando a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Obteniendo datos de la cuenta y mapas...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Error de conexión</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Número de esquinas: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Error de autenticación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>No se capturaron cookies de sesión de CalTopo. Inicie sesión e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Número de esquinas: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consol
 ¿Desea volver a introducir su ID de equipo, ID de credencial y secreto de credencial?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exportando a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparando datos y exportando...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Errores:          {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Errores por imagen:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Cancelando...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Cancelación solicitada...</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -1679,70 +1679,70 @@ Controlla le tue credenziali e riprova.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>Accesso CalTopo &amp; Selezione Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Mappa corrente: Non selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Accedi → Naviga verso la tua mappa → Clicca &apos;Sono connesso&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>Sono connesso - Esporta Dati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Clicca qui dopo aver effettuato l&apos;accesso e aver navigato verso la tua mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Errore di Inizializzazione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Impossibile inizializzare il browser CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Caricamento Fallito</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Impossibile caricare CalTopo. Controlla la tua connessione internet e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Mappa corrente: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 L&apos;URL della mappa deve contenere un ID mappa (es., /m/ABC123 o #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Browser non pronto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>Il browser CalTopo è ancora in fase di caricamento. Attendi un momento e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Inizio esportazione...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Autenticazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser non inizializzato. Riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Controlla:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Modalità Offline Abilitata</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Disattiva Solo Offline per esportare su CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Nessuna Selezione</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Seleziona almeno un tipo di dati (AOI contrassegnate, posizioni drone/immagini o area di copertura) da esportare.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Assicurati che le tue immagini abbiano le coordinate GPS e siano scatti nadirali
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
@@ -2137,7 +2137,7 @@ L&apos;URL della mappa dovrebbe essere simile a:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Apri la mappa nella finestra CalTopo prima di fare clic su &apos;Sono connesso - Esporta Dati&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 Il motivo è stato scritto nel registro (adiat_logs.txt) e nella console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Foto caricate: {uploaded} di {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 Gli elementi dovrebbero ora essere visibili sulla mappa.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 I dettagli di eventuali errori sono stati scritti nel registro (adiat_logs.txt) e nella console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Esportazione Riuscita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Successo Parziale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Esportazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Errore di Esportazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ I dettagli di eventuali errori sono stati scritti nel registro (adiat_logs.txt) 
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Area in metri quadrati: {sqm:.0f} m²
 Numero di angoli: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Esportazione su CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Disconnessione da CalTopo riuscita.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>Caricamento Mappe CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Connessione a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Recupero dati account e mappe...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Errore di Connessione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Numero di angoli: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Autenticazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>Nessun cookie di sessione CalTopo acquisito. Effettua l&apos;accesso e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Numero di angoli: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ Il motivo è stato scritto nel registro (adiat_logs.txt) e nella console.
 Vuoi reinserire ID team, ID credenziale e segreto credenziale?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Esportazione su CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparazione dati ed esportazione...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Errori:           {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Errori per immagine:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Annullamento...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Annullamento richiesto...</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -1679,70 +1679,70 @@ Controleer uw inloggegevens en probeer het opnieuw.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>CalTopo aanmelden &amp; kaartselectie</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Huidige kaart: niet geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Aanmelden → navigeer naar uw kaart → klik op &apos;Ik ben aangemeld&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>Ik ben aangemeld - Gegevens exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Klik hierop na het aanmelden en navigeren naar uw kaart</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Initialisatiefout</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Kan CalTopo-browser niet initialiseren:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Laden mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Kan CalTopo niet laden. Controleer uw internetverbinding en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Huidige kaart: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>Geen kaart geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 De kaart-URL moet een kaart-ID bevatten (bijv. /m/ABC123 of #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Browser niet gereed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>De CalTopo-browser laadt nog. Wacht even en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Export starten...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Authenticatie mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser niet geïnitialiseerd. Probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Controleer:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Offline-modus ingeschakeld</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Schakel Alleen offline uit om naar CalTopo te exporteren.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Niets geselecteerd</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Selecteer ten minste één gegevenstype (gemarkeerde AOI&apos;s, drone-/afbeeldingslocaties of dekkingsgebied) om te exporteren.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Zorg dat uw afbeeldingen GPS-coördinaten hebben en nadirale opnamen zijn.</tran
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>Geen kaart geselecteerd</translation>
     </message>
@@ -2137,7 +2137,7 @@ De kaart-URL moet er zo uitzien:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Open uw kaart in het CalTopo-venster voordat u op &apos;Ik ben aangemeld - Gegevens exporteren&apos; klikt.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 De reden is vastgelegd in het logbestand (adiat_logs.txt) en de console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Geüploade foto&apos;s: {uploaded} van {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 De items zouden nu op uw kaart zichtbaar moeten zijn.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Details over wat is mislukt, staan in het logbestand (adiat_logs.txt) en de console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Export geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Gedeeltelijk geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Export mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Exportfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ Details over wat is mislukt, staan in het logbestand (adiat_logs.txt) en de cons
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Gebied in vierkante meter: {sqm:.0f} m²
 Aantal hoeken: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Exporteren naar CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Afgemeld</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Succesvol afgemeld bij CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>CalTopo-kaarten laden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Verbinden met CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Accountgegevens en kaarten ophalen...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Verbindingsfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Aantal hoeken: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Authenticatie mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>Er zijn geen CalTopo-sessiecookies vastgelegd. Meld u aan en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Aantal hoeken: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ De reden is vastgelegd in het logbestand (adiat_logs.txt) en de console.
 Wilt u uw team-ID, referentie-ID en referentiegeheim opnieuw invoeren?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exporteren naar CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Gegevens voorbereiden en exporteren...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Fouten:          {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Fouten per afbeelding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Annuleren...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Annulering aangevraagd...</translation>
     </message>


### PR DESCRIPTION
## Problem

WALDO fixed-wing flights are flown serpentine: lanes alternate direction while frame numbers ascend in a fixed geographic direction, and frames missed mid-lane may be re-flown at the end of the flight travelling the opposite way. Neither filename order nor EXIF timestamps reliably recover each image's flight direction — and the stamped heading drives both AOI ground projection and the person-reference shadow.

Field measurement of the current v7 timestamp-based derivation (Siskiyou, 3 flights, 2132 images): **21 images were stamped ~180° flipped.** Each is the first image of a serpentine lane inside a processing batch — the >30 s turn gap starves the two-sided bearing pass, and the forward fill then copies the *previous, opposite-direction* lane's heading. Those images had rotated AOI positions and reversed shadow rendering.

## Fix

WALDO's ground software writes a `<flight>_Triggers.kml` beside the flight folders: one placemark per trigger, named after the image (`000_12_035` ↔ `0_000_12_035.jpg`), **in capture order**. That log is the ground truth for both sequence and position, so the pre-pass now uses it as the authoritative heading source:

- **New `WaldoTriggerLogService`** (`app/core/services/waldo/WaldoTriggerLog.py`):
  - Tolerant KML parsing — field files arrive truncated with unclosed tags, names carry trailing whitespace, Position-track LineStrings are ignored.
  - Discovery walks up to 3 levels above the images and validates candidates by **name + GPS proximity** — trigger names collide across flights (every flight numbers lanes from zero), so a name match alone is never trusted.
  - Headings come from document-order neighbours, segmented into straight **runs**: a run breaks on out-of-range spacing *or* a >60° direction change, so bearings never cross a lane turn or a recapture repositioning jump. Interior triggers use the chord; run edges the one in-run segment; isolated triggers keep the timestamp-derived fallback.
- **`WaldoMetadataService`** applies log headings after the existing derivation, logs and reports corrections >90°, and rejects a log whose document order contradicts the image timestamps (guards a hypothetical name-ordered log, which would flip lanes instead of fixing them). Absence of a KML is a silent no-op — the v7 behaviour is unchanged.
- **Processor version 7 → 8** so previously stamped datasets restamp (and self-correct) on next open.
- Pre-pass dialog lists the trigger log used and any corrections; warnings header generalised (translations updated).

## Validation

- 25 new unit tests (parsing, discovery incl. cross-flight name collisions, serpentine/recapture/turn/isolated heading cases, chronology gate, service integration); full waldo suite 55 passed; flake8 clean.
- Field run of the production pipeline per batch over all three Siskiyou flights: the right KML was discovered from every batch folder (100% GPS match), exactly the 21 flipped images were corrected, and **every one of 2132 images landed within a few degrees of independently computed ground truth** (0 residuals >20°).