### PR TITLE
feat(waldo): operator-confirmed camera clock correction (non-destructive)

### DIFF
--- a/app/core/controllers/images/viewer/WaldoPrePassController.py
+++ b/app/core/controllers/images/viewer/WaldoPrePassController.py
@@ -6,14 +6,24 @@ prefix, builds a TerrainService configured against the user's preferred DEM
 provider, opens a modal WaldoPrePassDialog and blocks until the synthesis
 finishes (or the user cancels). After this returns, the standard ImageService
 metadata path will read the synthesised drone-dji XMP fields written to disk.
+
+Also drives the operator-confirmed camera clock correction: when the pre-pass
+audit detects the known clock-fault signature, a confirmation dialog offers a
+non-destructive corrected capture time (stamped in the waldo XMP namespace).
+The per-folder decision is remembered in settings.
 """
 
-from typing import List
+import json
+import os
+from typing import List, Optional
 
 from core.services.LoggerService import LoggerService
 from core.services.SettingsService import SettingsService
 from core.services.waldo import WaldoMetadataService
 from core.views.images.viewer.dialogs.WaldoPrePassDialog import WaldoPrePassDialog
+from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import WaldoClockCorrectionDialog
+
+CLOCK_DECISIONS_SETTING = 'WaldoClockCorrections'
 
 
 class WaldoPrePassController:
@@ -55,8 +65,19 @@ class WaldoPrePassController:
             if not any_pending and not WaldoMetadataService.is_already_processed(path):
                 any_pending = True
 
+        # Detect the clock fault BEFORE any stamping: the pre-pass rewrites
+        # the files, which resets their mtime and destroys the file-time
+        # evidence the detection relies on.
+        detect_service = WaldoMetadataService(terrain_service=None)
+        proposal = None
+        try:
+            proposal = detect_service.propose_clock_correction(waldo_paths)
+        except Exception as e:
+            self.logger.error(f"WaldoPrePassController: clock-fault detection failed - {e}")
+
         if not any_pending:
             self.logger.info("WaldoPrePassController: all WALDO images already processed.")
+            self._offer_clock_correction(waldo_paths, proposal, service=detect_service)
             return
 
         # Build a TerrainService that respects the configured provider preference.
@@ -75,3 +96,89 @@ class WaldoPrePassController:
             "WaldoPrePassController: processed=%d already_current=%d errors=%d cancelled=%s"
             % (result.processed, result.already_current, len(result.errors), result.cancelled)
         )
+        if not result.cancelled:
+            self._offer_clock_correction(waldo_paths, proposal, service=service)
+
+    # ------------------------------------------------------------------
+    # Clock correction
+    # ------------------------------------------------------------------
+
+    def _clock_decisions(self) -> dict:
+        raw = self.settings_service.get_setting(CLOCK_DECISIONS_SETTING)
+        if not raw:
+            return {}
+        try:
+            decisions = json.loads(raw)
+            return decisions if isinstance(decisions, dict) else {}
+        except (TypeError, ValueError):
+            return {}
+
+    def _store_clock_decision(self, folder_key: str, decision: dict):
+        decisions = self._clock_decisions()
+        decisions[folder_key] = decision
+        self.settings_service.set_setting(CLOCK_DECISIONS_SETTING, json.dumps(decisions))
+
+    def _offer_clock_correction(self, waldo_paths: List[str], proposal,
+                                service: Optional[WaldoMetadataService] = None):
+        """Drive the confirmation dialog for a pre-computed clock proposal.
+
+        The proposal is detected by the caller BEFORE the pre-pass stamps
+        anything (stamping resets mtimes and weakens detection). A remembered
+        'declined' suppresses the offer; a remembered acceptance re-applies
+        silently (progress only) so images added to the folder later get
+        corrected without re-asking.
+        """
+        if not waldo_paths or proposal is None:
+            return
+        try:
+            if service is None:
+                service = WaldoMetadataService(terrain_service=None)
+
+            folder_key = os.path.normcase(os.path.abspath(os.path.dirname(waldo_paths[0])))
+            decision = self._clock_decisions().get(folder_key)
+            if decision and decision.get('decision') == 'declined':
+                self.logger.info(
+                    "WaldoPrePassController: clock fault detected but correction "
+                    "was previously declined for this folder.")
+                return
+
+            auto = bool(decision and decision.get('decision') == 'accepted')
+            if auto:
+                proposal.face_shift_h = int(decision.get('face_shift_h', proposal.face_shift_h))
+                tz_text = decision.get('tz_text')
+                if tz_text:
+                    proposal.tz_name = None
+                    proposal.fixed_offset_h = None
+                    # Reuse the dialog's parser by seeding its editable field.
+                    try:
+                        from zoneinfo import ZoneInfo
+                        ZoneInfo(tz_text)
+                        proposal.tz_name = tz_text
+                    except Exception:
+                        try:
+                            proposal.fixed_offset_h = float(tz_text)
+                        except ValueError:
+                            proposal.tz_name = None
+
+            dialog = WaldoClockCorrectionDialog(
+                self.parent, service, waldo_paths, proposal, auto_apply=auto)
+            dialog.exec()
+
+            if dialog.applied and dialog.remember_choice and not auto:
+                self._store_clock_decision(folder_key, {
+                    'decision': 'accepted',
+                    'face_shift_h': dialog.accepted_face_shift_h,
+                    'tz_text': dialog.accepted_tz_text,
+                })
+            elif dialog.declined and dialog.remember_choice:
+                self._store_clock_decision(folder_key, {'decision': 'declined'})
+
+            result = dialog.result_data
+            self.logger.info(
+                "WaldoPrePassController: clock correction corrected=%d current=%d "
+                "errors=%d declined=%s"
+                % (result.processed, result.already_current, len(result.errors),
+                   dialog.declined)
+            )
+        except Exception as e:
+            self.logger.error(f"WaldoPrePassController: clock correction failed - {e}")

--- a/app/core/services/shadow/SolarPosition.py
+++ b/app/core/services/shadow/SolarPosition.py
@@ -56,6 +56,10 @@ def resolve_capture_utc(
     """Resolve image capture time to a tz-aware UTC datetime.
 
     Resolution order (first match wins, most authoritative first):
+        0. XMP waldo:CaptureUtcCorrected — an operator-confirmed repair of a
+           known-faulty camera clock (see WaldoMetadataService clock
+           correction). When present it outranks everything: the EXIF fields
+           below are exactly what the repair was confirmed against.
         1. EXIF GPSDateStamp + GPSTimeStamp — already UTC, preferred.
         2. EXIF DateTimeOriginal + OffsetTimeOriginal — canonical local+offset.
         3. XMP xmp:CreateDate / xmp:ModifyDate — ISO 8601 with offset.
@@ -83,12 +87,24 @@ def resolve_capture_utc(
 
     Returns:
         (utc_datetime, source_tag) where source_tag is one of
-        'gps', 'exif_with_offset', 'xmp_create_date', 'xmp_modify_date',
-        'exif_local_tz_from_gps'.
+        'waldo_corrected', 'gps', 'exif_with_offset', 'xmp_create_date',
+        'xmp_modify_date', 'exif_local_tz_from_gps'.
 
     Raises:
         SolarTimeUnresolvable: no resolvable timestamp present.
     """
+    if xmp_data:
+        # Key shape depends on the XMP reader: bare when parsed per-namespace,
+        # prefixed when merged across namespaces.
+        for key in ('CaptureUtcCorrected', 'waldo:CaptureUtcCorrected',
+                    'XMP-waldo:CaptureUtcCorrected'):
+            value = xmp_data.get(key)
+            if value:
+                try:
+                    return _from_iso8601(value), 'waldo_corrected'
+                except ValueError:
+                    break
+
     gps = exif_data.get('GPS') or {}
     gps_date = gps.get(piexif.GPSIFD.GPSDateStamp)
     gps_time = gps.get(piexif.GPSIFD.GPSTimeStamp)
@@ -192,6 +208,18 @@ def _get_timezone_finder():
         from timezonefinder import TimezoneFinder
         _TZ_FINDER = TimezoneFinder()
     return _TZ_FINDER
+
+
+def timezone_name_for_position(lat: float, lon: float) -> Optional[str]:
+    """IANA timezone name covering lat/lon, or None when undeterminable.
+
+    Wraps the optional timezonefinder dependency: returns None instead of
+    raising when the package is missing or the position has no zone.
+    """
+    try:
+        return _get_timezone_finder().timezone_at(lat=lat, lng=lon)
+    except Exception:
+        return None
 
 
 def _from_local_via_gps_timezone(dt_orig, lat: float, lon: float) -> datetime:

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -39,6 +39,10 @@ from core.services.shadow.SolarPosition import (
     get_solar_position,
     resolve_capture_utc,
 )
+from core.services.waldo.WaldoTriggerLog import (
+    TRIGGER_MIN_CHRONOLOGY_FRACTION,
+    WaldoTriggerLogService,
+)
 
 
 WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
@@ -49,7 +53,14 @@ WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
 # (catches datasets whose post-flight software re-orients the frames).
 # Version 7 also retires v6's sun-shadow orientation measurement: on steep
 # terrain at low sun, slope shear and charred fallen logs mislead it.
-WALDO_PROCESSOR_VERSION = "7"
+# Version 8: per-image headings come from the WALDO *_Triggers.kml capture
+# log when one is found near the images. Timestamp-derived headings flip
+# ~180 deg on the first image of each serpentine lane (the >30 s turn gap
+# starves the bearing pass and the fill then copies the OPPOSITE lane's
+# heading - 15 of 1464 images on field data), and cannot handle frames
+# re-flown in the opposite direction. The bump restamps existing datasets
+# so those images get corrected on their next open.
+WALDO_PROCESSOR_VERSION = "8"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 
@@ -113,6 +124,7 @@ class WaldoProcessResult:
     skipped: int = 0  # non-WALDO files
     errors: List[Tuple[str, str]] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)  # informational, non-warning
     cancelled: bool = False
 
 
@@ -689,6 +701,68 @@ class WaldoMetadataService:
                     r.heading_deg = heading
 
     # ------------------------------------------------------------------
+    # Trigger-log heading override
+    # ------------------------------------------------------------------
+
+    def _apply_trigger_log_headings(self, records: List[WaldoImageRecord],
+                                    result: WaldoProcessResult):
+        """Replace GPS/timestamp-derived headings with trigger-log headings.
+
+        Runs AFTER derive_headings so the comparison can report how many
+        images the log corrected; the log wins wherever it matches. A log
+        whose document order contradicts the EXIF timestamps is rejected
+        (it would flip serpentine lanes instead of fixing them). Failures
+        never abort the pass - the timestamp-derived headings remain.
+        """
+        try:
+            trigger_service = WaldoTriggerLogService()
+            found = trigger_service.discover(records)
+            if found is None:
+                return
+            kml_path, triggers = found
+            kml_name = os.path.basename(kml_path)
+
+            chrono = WaldoTriggerLogService.chronology_fraction(triggers, records)
+            if chrono is not None and chrono < TRIGGER_MIN_CHRONOLOGY_FRACTION:
+                result.warnings.append(
+                    f"{kml_name}: trigger order disagrees with image timestamps "
+                    f"({chrono:.0%} consistent) - the log was ignored for headings."
+                )
+                return
+
+            headings = WaldoTriggerLogService.headings_by_name(triggers)
+            applied = 0
+            corrected = 0
+            for rec in records:
+                tname = WaldoTriggerLogService.image_trigger_name(rec.name)
+                heading = headings.get(tname) if tname else None
+                if heading is None:
+                    continue
+                if rec.heading_deg is not None:
+                    diff = abs((rec.heading_deg - heading + 180.0) % 360.0 - 180.0)
+                    if diff > 90.0:
+                        corrected += 1
+                        self.logger.info(
+                            f"WALDO trigger log corrected {rec.name}: "
+                            f"{rec.heading_deg:.1f} -> {heading:.1f} deg")
+                rec.heading_deg = heading
+                applied += 1
+
+            result.notes.append(
+                f"Trigger log {kml_name}: flight direction applied to "
+                f"{applied} of {len(records)} image(s)."
+            )
+            if corrected:
+                result.warnings.append(
+                    f"{kml_name}: corrected the flight direction of {corrected} "
+                    f"image(s) by more than 90 degrees (serpentine lane starts / "
+                    f"re-flown frames). AOI positions on those images were "
+                    f"unreliable in analyses run before this pass."
+                )
+        except Exception as e:
+            self.logger.warning(f"WALDO trigger-log pass failed: {e}")
+
+    # ------------------------------------------------------------------
     # Public folder pipeline
     # ------------------------------------------------------------------
 
@@ -771,6 +845,13 @@ class WaldoMetadataService:
         #    runs in milliseconds even for thousands of records).
         emit(0, 0, "Deriving plane heading from GPS track...")
         self.derive_headings(records)
+
+        # 3a. Trigger-log override: WALDO's *_Triggers.kml lists every
+        #     trigger in CAPTURE order with its position - authoritative for
+        #     flight direction where timestamp sorting fails (serpentine
+        #     lane starts, frames re-flown the opposite way, clock faults).
+        emit(0, 0, "Looking for WALDO trigger log (*_Triggers.kml)...")
+        self._apply_trigger_log_headings(records, result)
 
         # 3b. Measure the stored image orientation per camera by comparing
         #     inter-frame content motion against the GPS track. Post-flight

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -27,6 +27,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Callable, Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo
 
 import cv2
 import numpy as np
@@ -38,6 +39,7 @@ from core.services.shadow.SolarPosition import (
     SolarTimeUnresolvable,
     get_solar_position,
     resolve_capture_utc,
+    timezone_name_for_position,
 )
 from core.services.waldo.WaldoTriggerLog import (
     TRIGGER_MIN_CHRONOLOGY_FRACTION,
@@ -63,6 +65,13 @@ WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
 WALDO_PROCESSOR_VERSION = "8"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
+
+# Clock-correction XMP fields (waldo namespace). The EXIF timestamps are
+# never modified: the corrected UTC lives alongside them, and consumers
+# (SolarPosition.resolve_capture_utc) prefer it when present.
+CLOCK_CORRECTED_UTC_XMP = "CaptureUtcCorrected"
+CLOCK_FACE_SHIFT_XMP = "ClockFaceShiftHours"
+CLOCK_TIMEZONE_XMP = "ClockTimeZone"
 
 # Heading-derivation tunables
 STATIONARY_THRESHOLD_M = 5.0
@@ -126,6 +135,22 @@ class WaldoProcessResult:
     warnings: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)  # informational, non-warning
     cancelled: bool = False
+
+
+@dataclass
+class ClockCorrectionProposal:
+    """A detected camera-clock fault plus the correction offered to the user.
+
+    Built by propose_clock_correction; the operator confirms (and may edit)
+    the values before apply_clock_correction stamps anything.
+    """
+    face_shift_h: int                 # hours to ADD to the clock face (e.g. -12)
+    tz_name: Optional[str]            # IANA zone from GPS (DST-correct), if known
+    fixed_offset_h: Optional[float]   # fallback UTC offset when no zone found
+    evidence: List[str]               # human-readable findings behind the proposal
+    sample_name: str                  # image the preview line is built from
+    sample_face: str                  # its raw EXIF DateTimeOriginal
+    sample_corrected_utc: str         # its corrected time, ISO 8601 UTC
 
 
 class WaldoMetadataService:
@@ -395,6 +420,16 @@ class WaldoMetadataService:
     AUDIT_MTIME_SLACK_S = 3600.0    # claimed capture this far after file-write is impossible
     AUDIT_DAYLIGHT_BRIGHTNESS = 45  # mean pixel value that cannot be a night exposure
 
+    # A file can never be written BEFORE it was captured, so any claimed
+    # capture time ahead of the file's mtime proves the clock runs ahead
+    # (mtime survives Windows copies). The margin only needs to clear copy
+    # jitter: the flip MAGNITUDE cannot be read from mtime because the
+    # post-flight download delay offsets it (field data: a 12 h flip showed
+    # as just 28 min ahead after a ~10 h download delay). The 12-hour AM/PM
+    # flip is proposed as the known-fault default and the operator confirms
+    # it against the preview.
+    CLOCK_AHEAD_MIN_H = 0.1
+
     @staticmethod
     def _parse_offset_hours(raw) -> Optional[float]:
         """Parse an EXIF OffsetTime like '-06:00' into hours, or None."""
@@ -432,6 +467,10 @@ class WaldoMetadataService:
         sampled = paths[:self.AUDIT_SAMPLE_FILES]
         for path in sampled:
             name = os.path.basename(path)
+            if self.get_corrected_utc_stamp(path):
+                # An operator-confirmed clock correction is stamped on this
+                # image: the EXIF faults below are known and already repaired.
+                continue
             try:
                 exif = MetaDataHelper.get_exif_data_piexif(path)
                 exif_ifd = exif.get('Exif', {})
@@ -498,6 +537,213 @@ class WaldoMetadataService:
                 seen_kinds.add(kind)
                 deduped.append(w)
         return deduped
+
+    # ------------------------------------------------------------------
+    # Clock correction (operator-confirmed, non-destructive)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_corrected_utc_stamp(image_path: str) -> Optional[str]:
+        """Return the stamped corrected-UTC string for an image, or None."""
+        try:
+            xmp = MetaDataHelper.get_xmp_data_merged(image_path) or {}
+        except Exception:
+            return None
+        for key in (f'waldo:{CLOCK_CORRECTED_UTC_XMP}', CLOCK_CORRECTED_UTC_XMP,
+                    f'XMP-waldo:{CLOCK_CORRECTED_UTC_XMP}'):
+            value = xmp.get(key)
+            if value:
+                return str(value)
+        return None
+
+    @staticmethod
+    def _parse_exif_face_time(exif: dict) -> Optional[datetime]:
+        """Raw DateTimeOriginal (+ subseconds) as a NAIVE datetime.
+
+        Unlike _parse_exif_timestamp this deliberately ignores OffsetTime:
+        the clock correction reinterprets the face reading from scratch, and
+        the stamped offset is part of what is broken.
+        """
+        exif_ifd = exif.get('Exif') or {}
+        dt_raw = exif_ifd.get(piexif.ExifIFD.DateTimeOriginal)
+        if dt_raw is None:
+            return None
+        try:
+            dt_str = dt_raw.decode('utf-8') if isinstance(dt_raw, bytes) else str(dt_raw)
+            dt = datetime.strptime(dt_str.strip(), "%Y:%m:%d %H:%M:%S")
+        except Exception:
+            return None
+        sub_raw = exif_ifd.get(piexif.ExifIFD.SubSecTimeOriginal)
+        if sub_raw is not None:
+            try:
+                sub_str = (sub_raw.decode('utf-8') if isinstance(sub_raw, bytes)
+                           else str(sub_raw)).strip()
+                if sub_str:
+                    dt = dt.replace(microsecond=int(round(float("0." + sub_str) * 1_000_000)))
+            except Exception:
+                pass
+        return dt
+
+    @staticmethod
+    def compute_corrected_utc(face_dt: datetime, face_shift_h: float,
+                              tz_name: Optional[str],
+                              fixed_offset_h: Optional[float]) -> datetime:
+        """Corrected capture time: shift the clock face, then localise.
+
+        The shifted face reading is interpreted in the TRUE timezone (IANA
+        zone when known - DST-correct for the date - else a fixed offset)
+        and converted to UTC. Raises ValueError when neither timezone form
+        is usable.
+        """
+        shifted = face_dt + timedelta(hours=face_shift_h)
+        if tz_name:
+            try:
+                return shifted.replace(tzinfo=ZoneInfo(tz_name)).astimezone(timezone.utc)
+            except Exception:
+                pass  # unknown zone / no tzdata: fall through to fixed offset
+        if fixed_offset_h is not None:
+            tz = timezone(timedelta(hours=fixed_offset_h))
+            return shifted.replace(tzinfo=tz).astimezone(timezone.utc)
+        raise ValueError("No usable timezone for clock correction")
+
+    def propose_clock_correction(self, paths: List[str]) -> Optional[ClockCorrectionProposal]:
+        """Detect the known clock-fault signature and build a correction offer.
+
+        Fires when a sampled image shows a PROVABLE clock symptom:
+        - the stamped timezone disagrees with the GPS longitude, and/or
+        - the claimed capture time is AFTER the file was written (a file
+          cannot predate its capture; mtime survives Windows copies).
+
+        The proposed face shift is the 12-hour AM/PM flip only when the
+        ahead-proof exists; a timezone mismatch alone proposes a pure zone
+        fix (face shift 0) and the operator adds the flip after checking
+        the preview against the real flight window - the flip magnitude is
+        not measurable from a zone mismatch. NOTE: any XMP write (including
+        the pre-pass itself) resets mtime and destroys the ahead-proof, so
+        detection must run on a folder BEFORE it is first stamped.
+
+        Images already carrying a corrected stamp never fire. Returns None
+        when no provable symptom is present (correcting an unknown fault
+        would be guessing).
+        """
+        for path in paths[:self.AUDIT_SAMPLE_FILES]:
+            name = os.path.basename(path)
+            try:
+                if self.get_corrected_utc_stamp(path):
+                    continue
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                face_dt = self._parse_exif_face_time(exif)
+                gps = LocationInfo.get_gps(exif_data=exif)
+                offset_h = self._parse_offset_hours(
+                    exif.get('Exif', {}).get(piexif.ExifIFD.OffsetTimeOriginal)
+                    or exif.get('Exif', {}).get(piexif.ExifIFD.OffsetTime))
+                if face_dt is None or gps is None or offset_h is None:
+                    continue
+
+                solar_offset = gps['longitude'] / 15.0
+                tz_mismatch = abs(offset_h - solar_offset) > self.AUDIT_TZ_TOLERANCE_H
+
+                claimed_utc = (face_dt.replace(tzinfo=timezone.utc)
+                               - timedelta(hours=offset_h))
+                mtime_utc = datetime.fromtimestamp(os.path.getmtime(path), tz=timezone.utc)
+                ahead_h = (claimed_utc - mtime_utc).total_seconds() / 3600.0
+                clock_ahead = ahead_h > self.CLOCK_AHEAD_MIN_H
+
+                if not (tz_mismatch or clock_ahead):
+                    continue
+
+                tz_name = timezone_name_for_position(gps['latitude'], gps['longitude'])
+                fixed_offset_h = round(solar_offset)
+                face_shift_h = -12 if clock_ahead else 0
+
+                evidence = []
+                if tz_mismatch:
+                    evidence.append(
+                        f"Stamped timezone is UTC{offset_h:+.0f} but the GPS "
+                        f"longitude implies about UTC{solar_offset:+.1f}.")
+                if clock_ahead:
+                    evidence.append(
+                        f"Claimed capture time is {ahead_h * 60.0:.0f} min AFTER the "
+                        f"file was written - impossible, so the clock runs ahead. A "
+                        f"12-hour AM/PM flip offset by the post-flight download delay "
+                        f"produces exactly this.")
+                else:
+                    evidence.append(
+                        "The clock face itself may additionally carry a 12-hour AM/PM "
+                        "error that cannot be proven from these files - check the "
+                        "corrected time below against when the flight actually flew "
+                        "and adjust the face error if needed.")
+
+                corrected = self.compute_corrected_utc(
+                    face_dt, face_shift_h, tz_name, fixed_offset_h)
+                return ClockCorrectionProposal(
+                    face_shift_h=face_shift_h,
+                    tz_name=tz_name,
+                    fixed_offset_h=fixed_offset_h,
+                    evidence=evidence,
+                    sample_name=name,
+                    sample_face=face_dt.strftime("%Y:%m:%d %H:%M:%S"),
+                    sample_corrected_utc=corrected.strftime("%Y-%m-%d %H:%M:%S UTC"),
+                )
+            except Exception as e:
+                self.logger.warning(f"Clock-correction detection failed for {name}: {e}")
+        return None
+
+    def apply_clock_correction(
+        self,
+        image_paths: List[str],
+        face_shift_h: float,
+        tz_name: Optional[str] = None,
+        fixed_offset_h: Optional[float] = None,
+        progress_cb: Optional[Callable[[int, int, str], None]] = None,
+        cancel_cb: Optional[Callable[[], bool]] = None,
+    ) -> WaldoProcessResult:
+        """Stamp a corrected capture UTC on every WALDO image.
+
+        Non-destructive: EXIF stays untouched; the correction lives in the
+        waldo XMP namespace and is preferred by resolve_capture_utc. Images
+        whose stamp already matches are skipped, so re-running is cheap and
+        idempotent.
+        """
+        result = WaldoProcessResult()
+        cancel_cb = cancel_cb or (lambda: False)
+        total = len(image_paths)
+        for i, path in enumerate(image_paths):
+            if cancel_cb():
+                result.cancelled = True
+                break
+            name = os.path.basename(path)
+            if progress_cb is not None:
+                try:
+                    progress_cb(i + 1, total, f"Correcting capture time {i + 1}/{total}: {name}")
+                except Exception:
+                    pass
+            if self.is_waldo_image(path) is None:
+                result.skipped += 1
+                continue
+            try:
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                face_dt = self._parse_exif_face_time(exif)
+                if face_dt is None:
+                    result.errors.append((name, "No DateTimeOriginal to correct"))
+                    continue
+                corrected = self.compute_corrected_utc(
+                    face_dt, face_shift_h, tz_name, fixed_offset_h)
+                corrected_str = corrected.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+                existing = self.get_corrected_utc_stamp(path)
+                if existing == corrected_str:
+                    result.already_current += 1
+                    continue
+                MetaDataHelper.add_xmp_fields(path, [
+                    (WALDO_NAMESPACE_URI, CLOCK_CORRECTED_UTC_XMP, corrected_str),
+                    (WALDO_NAMESPACE_URI, CLOCK_FACE_SHIFT_XMP, f"{face_shift_h:+.0f}"),
+                    (WALDO_NAMESPACE_URI, CLOCK_TIMEZONE_XMP,
+                     tz_name or f"UTC{fixed_offset_h:+.1f}"),
+                ])
+                result.processed += 1
+            except Exception as e:
+                result.errors.append((name, f"Clock correction failed: {e}"))
+        return result
 
     def compute_relative_altitude_m(
         self, lat: float, lon: float, gps_alt_ellipsoidal_m: float

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -663,17 +663,35 @@ class WaldoMetadataService:
                 j += direction
             return None
 
-        # Pass 1: bearing(prev → next) for interior images.
+        # Pass 1: bearing(prev → next) for interior images; edge images (a
+        # lane start/end whose other neighbour sits beyond the turn window)
+        # use the one in-window side. One-sided bearings are noisier but a
+        # fill would copy the PREVIOUS lane's heading, which on a serpentine
+        # flight is ~180 deg wrong (observed on field data at lane starts).
         for i in range(n):
             prev_idx = neighbour_search(i, -1)
             next_idx = neighbour_search(i, +1)
             if prev_idx is not None and next_idx is not None:
-                group[i].heading_deg = LocationInfo.bearing(
+                heading = LocationInfo.bearing(
                     group[prev_idx].lat, group[prev_idx].lon,
                     group[next_idx].lat, group[next_idx].lon
                 )
+            elif prev_idx is not None:
+                heading = LocationInfo.bearing(
+                    group[prev_idx].lat, group[prev_idx].lon,
+                    group[i].lat, group[i].lon
+                )
+            elif next_idx is not None:
+                heading = LocationInfo.bearing(
+                    group[i].lat, group[i].lon,
+                    group[next_idx].lat, group[next_idx].lon
+                )
+            else:
+                continue
+            if not math.isnan(heading):
+                group[i].heading_deg = heading
 
-        # Pass 2: forward fill (first images inherit from the next valid).
+        # Pass 2: forward fill (stationary clusters inherit the last valid).
         last_seen: Optional[float] = None
         for r in group:
             if r.heading_deg is None and last_seen is not None:

--- a/app/core/services/waldo/WaldoTriggerLog.py
+++ b/app/core/services/waldo/WaldoTriggerLog.py
@@ -1,0 +1,297 @@
+"""
+WaldoTriggerLog - Authoritative per-image heading from the WALDO trigger KML.
+
+WALDO ground software writes a ``<flight>_Triggers.kml`` next to the flight's
+image folders: one ``<Placemark>`` per camera trigger, named after the image
+(``000_12_035`` for images ``0_000_12_035.jpg`` / ``1_000_12_035.jpg``) and
+positioned where the trigger fired. Crucially the placemarks appear in
+CAPTURE ORDER, not filename order: WALDO flights are flown serpentine
+(alternating lanes flown in opposite directions while frame numbers ascend
+in a fixed geographic direction) and any skipped frames may be re-flown at
+the end of the flight travelling the other way. Filename order therefore
+does NOT recover the flight direction, and EXIF timestamps do so only when
+the camera clock behaved. The trigger log is the ground truth for both the
+capture sequence and the trigger positions.
+
+This module parses that log and derives a per-image plane heading from the
+document-order neighbours of each trigger, giving every image a heading
+accurate to a few degrees regardless of serpentine lanes, recapture passes,
+or camera-clock faults.
+
+Real-world tolerances baked in:
+- files may be truncated mid-coordinates (the logger does not always close
+  its tags) - parsing reads to EOF;
+- placemark names carry trailing whitespace;
+- trigger names are NOT globally unique across flights (every flight numbers
+  lanes from zero), so discovery validates candidates by GPS proximity, not
+  by name alone.
+"""
+
+import glob
+import math
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from helpers.LocationInfo import LocationInfo
+
+from core.services.LoggerService import LoggerService
+
+# Consecutive triggers in a lane are ~150-250 m apart; anything beyond this is
+# a lane-change turn or a jump to a recapture site and must not contribute to
+# a bearing.
+TRIGGER_NEIGHBOR_MAX_M = 600.0
+
+# Consecutive segment bearings turning harder than this split the capture
+# sequence into separate runs. Distance alone cannot detect a tight
+# serpentine turn: adjacent lanes can sit closer together than
+# TRIGGER_NEIGHBOR_MAX_M, making the turn segment look like lane spacing.
+TRIGGER_TURN_BREAK_DEG = 60.0
+
+# An image matches a trigger only when its EXIF GPS lies within this distance
+# of the trigger position (observed misfit on field data: ~12 m median).
+TRIGGER_MATCH_MAX_M = 300.0
+
+# A candidate KML must position-match at least this fraction of the images
+# before it is trusted as the flight's trigger log.
+TRIGGER_MIN_MATCH_FRACTION = 0.5
+
+# Doc order is trusted as capture order only when the EXIF timestamps of
+# matched images agree with it at least this often (constant clock offsets do
+# not affect the comparison; it only checks monotonicity).
+TRIGGER_MIN_CHRONOLOGY_FRACTION = 0.8
+
+# How many directory levels above the images to search for candidate KMLs
+# (field layout: <root>/<flight>_Triggers.kml with images in
+# <root>/<flight>/batch<N>/).
+TRIGGER_SEARCH_LEVELS = 3
+
+
+@dataclass
+class TriggerPoint:
+    """One camera trigger from the log, in document (= capture) order."""
+    name: str
+    lat: float
+    lon: float
+    alt: Optional[float]
+
+
+class WaldoTriggerLogService:
+    """Parse WALDO trigger KMLs and derive per-image headings from them."""
+
+    def __init__(self):
+        self.logger = LoggerService()
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def parse_triggers_kml(path: str) -> List[TriggerPoint]:
+        """Return the trigger points of a KML in document order.
+
+        Tolerates truncated files and malformed placemarks (skipped).
+        Returns [] when the file is unreadable or contains no point placemarks.
+        """
+        try:
+            with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                text = f.read()
+        except OSError:
+            return []
+
+        points: List[TriggerPoint] = []
+        pattern = re.compile(
+            r'<Placemark>\s*<name>([^<]+)</name>.*?'
+            r'<Point>.*?<coordinates>([^<]*)',
+            re.S)
+        for m in pattern.finditer(text):
+            name = m.group(1).strip()
+            coords = m.group(2).strip().split(',')
+            try:
+                lon = float(coords[0])
+                lat = float(coords[1])
+                alt = float(coords[2]) if len(coords) > 2 else None
+            except (ValueError, IndexError):
+                continue
+            points.append(TriggerPoint(name=name, lat=lat, lon=lon, alt=alt))
+        return points
+
+    @staticmethod
+    def image_trigger_name(image_name: str) -> Optional[str]:
+        """Map a WALDO image filename to its trigger placemark name.
+
+        ``0_000_12_035.jpg`` -> ``000_12_035`` (cam prefix stripped; both
+        cameras share one trigger). Returns None for non-WALDO names.
+        """
+        base = os.path.splitext(os.path.basename(image_name))[0]
+        m = re.match(r'^[01]_(.+)$', base)
+        if not m:
+            return None
+        return m.group(1)
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def discover(self, records: Sequence) -> Optional[Tuple[str, List[TriggerPoint]]]:
+        """Find the trigger KML for a set of WaldoImageRecords, if any.
+
+        Searches the image directories and up to TRIGGER_SEARCH_LEVELS parent
+        levels for ``*.kml`` files, and scores each candidate by the fraction
+        of records it matches BY NAME AND GPS POSITION. Position matching is
+        essential: every flight numbers its lanes from zero, so a sibling
+        flight's log can contain the same trigger names at different places.
+
+        Returns (kml_path, triggers) for the best candidate above
+        TRIGGER_MIN_MATCH_FRACTION, or None.
+        """
+        usable = [r for r in records if r.lat is not None and r.lon is not None]
+        if not usable:
+            return None
+
+        candidates: List[str] = []
+        seen_dirs = set()
+        for rec in usable:
+            d = os.path.dirname(os.path.abspath(rec.path))
+            for _ in range(TRIGGER_SEARCH_LEVELS + 1):
+                if d in seen_dirs:
+                    break
+                seen_dirs.add(d)
+                candidates.extend(sorted(glob.glob(os.path.join(d, '*.kml'))))
+                parent = os.path.dirname(d)
+                if parent == d:
+                    break
+                d = parent
+
+        best: Optional[Tuple[str, List[TriggerPoint]]] = None
+        best_score = 0.0
+        for kml_path in dict.fromkeys(candidates):  # dedupe, keep order
+            triggers = self.parse_triggers_kml(kml_path)
+            if not triggers:
+                continue
+            by_name = {t.name: t for t in triggers}
+            matched = 0
+            for rec in usable:
+                tname = self.image_trigger_name(rec.name)
+                trig = by_name.get(tname) if tname else None
+                if trig is None:
+                    continue
+                dist = LocationInfo.haversine_m(rec.lat, rec.lon, trig.lat, trig.lon)
+                if dist <= TRIGGER_MATCH_MAX_M:
+                    matched += 1
+            score = matched / len(usable)
+            if score > best_score:
+                best_score = score
+                best = (kml_path, triggers)
+
+        if best is None or best_score < TRIGGER_MIN_MATCH_FRACTION:
+            return None
+        self.logger.info(
+            f"WALDO trigger log: {best[0]} matched "
+            f"{best_score:.0%} of {len(usable)} images")
+        return best
+
+    # ------------------------------------------------------------------
+    # Heading derivation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def headings_by_name(triggers: List[TriggerPoint]) -> Dict[str, float]:
+        """Per-trigger plane heading from document-order neighbours.
+
+        The capture sequence is first split into straight RUNS. A run break
+        occurs at any segment that is too long / too short to be in-lane
+        spacing, or that turns harder than TRIGGER_TURN_BREAK_DEG relative
+        to the run's direction (a tight serpentine turn can bring the next
+        lane closer than the distance guard alone would catch). Headings
+        never cross a run boundary: interior triggers use the chord
+        bearing(prev -> next), run-edge triggers the one in-run segment,
+        and singleton runs (an isolated recapture) get no heading - the
+        caller keeps its timestamp-derived fallback there.
+        """
+        n = len(triggers)
+        if n == 0:
+            return {}
+
+        # Segment i connects trigger i to trigger i+1. None = unusable.
+        seg_bearing: List[Optional[float]] = [None] * (n - 1)
+        for i in range(n - 1):
+            a, b = triggers[i], triggers[i + 1]
+            dist = LocationInfo.haversine_m(a.lat, a.lon, b.lat, b.lon)
+            if not (1.0 < dist < TRIGGER_NEIGHBOR_MAX_M):
+                continue
+            brg = LocationInfo.bearing(a.lat, a.lon, b.lat, b.lon)
+            if not math.isnan(brg):
+                seg_bearing[i] = brg % 360.0
+
+        # Assign run ids. After a break the new run's direction is unknown
+        # (the breaking segment belongs to the turn, not to either lane),
+        # so it seeds from the first good segment inside the new run.
+        run_id = [0] * n
+        current = 0
+        run_dir: Optional[float] = None
+        for i in range(1, n):
+            sb = seg_bearing[i - 1]
+            turned = (
+                sb is not None and run_dir is not None
+                and abs((sb - run_dir + 180.0) % 360.0 - 180.0) > TRIGGER_TURN_BREAK_DEG
+            )
+            if sb is None or turned:
+                current += 1
+                run_dir = None
+            else:
+                run_dir = sb
+            run_id[i] = current
+
+        headings: Dict[str, float] = {}
+        for i, trig in enumerate(triggers):
+            # Adjacent same-run triggers always have a usable segment between
+            # them (an unusable segment forces a run break).
+            prev_in_run = i > 0 and run_id[i - 1] == run_id[i]
+            next_in_run = i < n - 1 and run_id[i + 1] == run_id[i]
+            if prev_in_run and next_in_run:
+                heading = LocationInfo.bearing(
+                    triggers[i - 1].lat, triggers[i - 1].lon,
+                    triggers[i + 1].lat, triggers[i + 1].lon)
+            elif prev_in_run:
+                heading = seg_bearing[i - 1]
+            elif next_in_run:
+                heading = seg_bearing[i]
+            else:
+                continue
+            if heading is not None and not math.isnan(heading):
+                headings[trig.name] = heading % 360.0
+        return headings
+
+    @staticmethod
+    def chronology_fraction(triggers: List[TriggerPoint],
+                            records: Sequence) -> Optional[float]:
+        """Fraction of doc-adjacent trigger pairs whose EXIF timestamps
+        are non-decreasing.
+
+        Guards against a hypothetical log written in name order rather than
+        capture order: a serpentine flight would then get half its lanes
+        flipped, which is worse than the timestamp-based fallback. Constant
+        camera-clock offsets (the known WALDO AM/PM + timezone faults) shift
+        every timestamp equally and do not affect the check.
+
+        Returns None when fewer than 3 comparable pairs exist.
+        """
+        ts_by_trigger: Dict[str, object] = {}
+        for rec in records:
+            if rec.timestamp is None:
+                continue
+            tname = WaldoTriggerLogService.image_trigger_name(rec.name)
+            if tname is None:
+                continue
+            # Prefer cam 0's clock; either cam alone is self-consistent.
+            if tname not in ts_by_trigger or rec.cam_idx == 0:
+                ts_by_trigger[tname] = rec.timestamp
+
+        ordered = [ts_by_trigger[t.name] for t in triggers if t.name in ts_by_trigger]
+        if len(ordered) < 4:
+            return None
+        pairs = len(ordered) - 1
+        good = sum(1 for a, b in zip(ordered, ordered[1:]) if b >= a)
+        return good / pairs

--- a/app/core/services/waldo/__init__.py
+++ b/app/core/services/waldo/__init__.py
@@ -17,6 +17,10 @@ from .WaldoMetadataService import (
     WALDO_NAMESPACE_URI,
     WALDO_PROCESSOR_VERSION,
 )
+from .WaldoTriggerLog import (
+    WaldoTriggerLogService,
+    TriggerPoint,
+)
 
 __all__ = [
     'WaldoMetadataService',
@@ -27,4 +31,6 @@ __all__ = [
     'WaldoMissingGPSError',
     'WALDO_NAMESPACE_URI',
     'WALDO_PROCESSOR_VERSION',
+    'WaldoTriggerLogService',
+    'TriggerPoint',
 ]

--- a/app/core/services/waldo/__init__.py
+++ b/app/core/services/waldo/__init__.py
@@ -14,6 +14,7 @@ from .WaldoMetadataService import (
     WaldoHeadingUnavailable,
     WaldoCoverageError,
     WaldoMissingGPSError,
+    ClockCorrectionProposal,
     WALDO_NAMESPACE_URI,
     WALDO_PROCESSOR_VERSION,
 )
@@ -29,6 +30,7 @@ __all__ = [
     'WaldoHeadingUnavailable',
     'WaldoCoverageError',
     'WaldoMissingGPSError',
+    'ClockCorrectionProposal',
     'WALDO_NAMESPACE_URI',
     'WALDO_PROCESSOR_VERSION',
     'WaldoTriggerLogService',

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -541,6 +541,9 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             if self.sun_time_source == 'exif_local_tz_from_gps':
                 text += " " + self.tr(
                     "Capture time zone estimated from GPS location.")
+            elif self.sun_time_source == 'waldo_corrected':
+                text += " " + self.tr(
+                    "Using repaired capture time (camera clock fault).")
             self.sun_label.setText(text)
             self.shadow_check.setEnabled(True)
         else:

--- a/app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py
+++ b/app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py
@@ -1,0 +1,321 @@
+"""
+WaldoClockCorrectionDialog - Confirm and apply a camera clock correction.
+
+Shown when the WALDO pre-pass detects the clock-fault signature (timezone
+inconsistent with GPS longitude + capture time ~half a day ahead of the
+file write time). Presents the evidence and the proposed correction with
+editable values; on Apply, a worker thread stamps a corrected capture UTC
+into the waldo XMP namespace of every image (non-destructive - the EXIF
+fields are never modified). Sun/shadow features prefer the corrected time.
+
+Can also run in auto mode (no confirmation page) to re-apply a previously
+accepted correction to images that were added since.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from zoneinfo import ZoneInfo
+
+from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QPushButton,
+    QProgressBar, QWidget, QPlainTextEdit, QSpinBox, QLineEdit, QCheckBox
+)
+
+from helpers.TranslationMixin import TranslationMixin
+
+from core.services.waldo import (
+    WaldoMetadataService,
+    WaldoProcessResult,
+    ClockCorrectionProposal,
+)
+
+
+class _ClockWorker(QThread):
+    progress = Signal(int, int, str)
+    finished_with_result = Signal(object)
+
+    def __init__(self, service: WaldoMetadataService, image_paths: List[str],
+                 face_shift_h: float, tz_name: Optional[str],
+                 fixed_offset_h: Optional[float]):
+        super().__init__()
+        self._service = service
+        self._image_paths = image_paths
+        self._face_shift_h = face_shift_h
+        self._tz_name = tz_name
+        self._fixed_offset_h = fixed_offset_h
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def run(self):
+        try:
+            result = self._service.apply_clock_correction(
+                self._image_paths,
+                self._face_shift_h,
+                tz_name=self._tz_name,
+                fixed_offset_h=self._fixed_offset_h,
+                progress_cb=lambda i, n, name: self.progress.emit(i, n, name),
+                cancel_cb=lambda: self._cancelled,
+            )
+        except Exception as e:
+            result = WaldoProcessResult()
+            result.errors.append(("<service>", f"{e!r}"))
+        self.finished_with_result.emit(result)
+
+
+class WaldoClockCorrectionDialog(TranslationMixin, QDialog):
+    """Confirmation + progress dialog for the WALDO clock correction."""
+
+    def __init__(self, parent, service: WaldoMetadataService,
+                 image_paths: List[str], proposal: ClockCorrectionProposal,
+                 auto_apply: bool = False):
+        if parent is not None and not isinstance(parent, QWidget):
+            parent = None
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("WALDO Camera Clock Correction"))
+        self.setModal(True)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.resize(560, 360)
+
+        self._service = service
+        self._image_paths = image_paths
+        self._proposal = proposal
+        self._auto_apply = auto_apply
+        self._worker: Optional[_ClockWorker] = None
+        self._result: WaldoProcessResult = WaldoProcessResult()
+
+        # Outcome flags the controller reads after exec():
+        self.applied = False          # worker ran to completion (not cancelled)
+        self.declined = False         # user chose Not Now
+        self.remember_choice = False  # persist the decision for this folder
+        self.accepted_face_shift_h: Optional[int] = None
+        self.accepted_tz_text: Optional[str] = None
+
+        layout = QVBoxLayout(self)
+
+        self._intro_label = QLabel(self.tr(
+            "The camera clock on these images appears to be misconfigured:"))
+        self._intro_label.setWordWrap(True)
+        layout.addWidget(self._intro_label)
+
+        self._evidence = QLabel("\n".join(f"• {line}" for line in proposal.evidence))
+        self._evidence.setWordWrap(True)
+        layout.addWidget(self._evidence)
+
+        self._explain_label = QLabel(self.tr(
+            "ADIAT can stamp a corrected capture time into the image metadata. "
+            "This is non-destructive: the original EXIF fields are not changed, "
+            "and sun/shadow calculations will use the corrected time. Check the "
+            "preview against when the flight actually flew - if it is off by "
+            "12 hours, adjust the clock face error."))
+        self._explain_label.setWordWrap(True)
+        layout.addWidget(self._explain_label)
+
+        form = QFormLayout()
+        self._shift_spin = QSpinBox()
+        self._shift_spin.setRange(-24, 24)
+        self._shift_spin.setValue(proposal.face_shift_h)
+        self._shift_spin.setSuffix(self.tr(" hours"))
+        form.addRow(self.tr("Clock face error to remove:"), self._shift_spin)
+
+        self._tz_edit = QLineEdit()
+        default_tz = proposal.tz_name or (
+            f"{proposal.fixed_offset_h:+.1f}" if proposal.fixed_offset_h is not None else "")
+        self._tz_edit.setText(default_tz)
+        self._tz_edit.setToolTip(self.tr(
+            "IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC "
+            "offset in hours (e.g. -7)"))
+        form.addRow(self.tr("True camera time zone:"), self._tz_edit)
+        self._form_widget = QWidget()
+        self._form_widget.setLayout(form)
+        layout.addWidget(self._form_widget)
+
+        self._preview_label = QLabel()
+        self._preview_label.setWordWrap(True)
+        layout.addWidget(self._preview_label)
+
+        self._remember_check = QCheckBox(self.tr("Remember my choice for this folder"))
+        self._remember_check.setChecked(True)
+        layout.addWidget(self._remember_check)
+
+        self._progress = QProgressBar()
+        self._progress.setVisible(False)
+        layout.addWidget(self._progress)
+
+        self._status_label = QLabel()
+        self._status_label.setWordWrap(True)
+        self._status_label.setVisible(False)
+        layout.addWidget(self._status_label)
+
+        self._summary = QPlainTextEdit()
+        self._summary.setReadOnly(True)
+        self._summary.setVisible(False)
+        layout.addWidget(self._summary, 1)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch()
+        self._apply_button = QPushButton(self.tr("Apply Correction"))
+        self._apply_button.clicked.connect(self._on_apply)
+        self._apply_button.setDefault(True)
+        button_row.addWidget(self._apply_button)
+        self._decline_button = QPushButton(self.tr("Not Now"))
+        self._decline_button.clicked.connect(self._on_decline)
+        button_row.addWidget(self._decline_button)
+        self._cancel_button = QPushButton(self.tr("Cancel"))
+        self._cancel_button.clicked.connect(self._on_cancel)
+        self._cancel_button.setVisible(False)
+        button_row.addWidget(self._cancel_button)
+        self._ok_button = QPushButton(self.tr("OK"))
+        self._ok_button.clicked.connect(self.accept)
+        self._ok_button.setVisible(False)
+        button_row.addWidget(self._ok_button)
+        layout.addLayout(button_row)
+
+        self._shift_spin.valueChanged.connect(self._update_preview)
+        self._tz_edit.textChanged.connect(self._update_preview)
+        self._update_preview()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.activateWindow()
+        self.raise_()
+        if self._auto_apply and self._worker is None:
+            self._start_worker()
+
+    def closeEvent(self, event):
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.cancel()
+            self._worker.wait(2000)
+        super().closeEvent(event)
+
+    @property
+    def result_data(self) -> WaldoProcessResult:
+        return self._result
+
+    # ------------------------------------------------------------------
+    # Correction parameters
+    # ------------------------------------------------------------------
+
+    def _parse_tz_input(self):
+        """Return (tz_name, fixed_offset_h) from the editable field.
+
+        Accepts an IANA zone name or a numeric UTC offset in hours.
+        Returns (None, None) when the input is unusable.
+        """
+        text = self._tz_edit.text().strip()
+        if not text:
+            return None, None
+        try:
+            ZoneInfo(text)
+            return text, None
+        except Exception:
+            pass
+        try:
+            offset = float(text.replace("UTC", "").strip())
+            if -14.0 <= offset <= 14.0:
+                return None, offset
+        except ValueError:
+            pass
+        return None, None
+
+    def _update_preview(self):
+        tz_name, fixed_offset = self._parse_tz_input()
+        if tz_name is None and fixed_offset is None:
+            self._preview_label.setText(self.tr(
+                "Enter a valid time zone (IANA name or UTC offset in hours)."))
+            self._apply_button.setEnabled(False)
+            return
+        try:
+            face_dt = datetime.strptime(self._proposal.sample_face, "%Y:%m:%d %H:%M:%S")
+            corrected = WaldoMetadataService.compute_corrected_utc(
+                face_dt, self._shift_spin.value(), tz_name, fixed_offset)
+            self._preview_label.setText(self.tr(
+                "{name}: camera says {before}  →  corrected {after}").format(
+                    name=self._proposal.sample_name,
+                    before=self._proposal.sample_face,
+                    after=corrected.strftime("%Y-%m-%d %H:%M:%S UTC")))
+            self._apply_button.setEnabled(True)
+        except Exception:
+            self._preview_label.setText(self.tr("Correction preview unavailable."))
+            self._apply_button.setEnabled(False)
+
+    # ------------------------------------------------------------------
+    # Buttons / worker
+    # ------------------------------------------------------------------
+
+    def _on_apply(self):
+        tz_name, fixed_offset = self._parse_tz_input()
+        if tz_name is None and fixed_offset is None:
+            return
+        self.remember_choice = self._remember_check.isChecked()
+        self.accepted_face_shift_h = self._shift_spin.value()
+        self.accepted_tz_text = self._tz_edit.text().strip()
+        self._start_worker()
+
+    def _start_worker(self):
+        tz_name, fixed_offset = self._parse_tz_input()
+        if tz_name is None and fixed_offset is None:
+            return
+        for w in (self._intro_label, self._evidence, self._explain_label,
+                  self._form_widget, self._preview_label, self._remember_check,
+                  self._apply_button, self._decline_button):
+            w.setVisible(False)
+        self._progress.setRange(0, max(1, len(self._image_paths)))
+        self._progress.setValue(0)
+        self._progress.setVisible(True)
+        self._status_label.setText(self.tr("Stamping corrected capture times..."))
+        self._status_label.setVisible(True)
+        self._cancel_button.setVisible(True)
+
+        self._worker = _ClockWorker(
+            self._service, self._image_paths,
+            float(self._shift_spin.value()), tz_name, fixed_offset)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished_with_result.connect(self._on_finished)
+        self._worker.start()
+
+    def _on_decline(self):
+        self.declined = True
+        self.remember_choice = self._remember_check.isChecked()
+        self.reject()
+
+    def _on_cancel(self):
+        if self._worker is not None:
+            self._worker.cancel()
+        self._cancel_button.setEnabled(False)
+        self._cancel_button.setText(self.tr("Cancelling..."))
+
+    def _on_progress(self, current: int, total: int, status_text: str):
+        if total > 0 and self._progress.maximum() != total:
+            self._progress.setRange(0, total)
+        self._progress.setValue(current)
+        self._status_label.setText(status_text)
+
+    def _on_finished(self, result: WaldoProcessResult):
+        self._result = result
+        self.applied = not result.cancelled
+        self._status_label.setVisible(False)
+        self._progress.setMaximum(max(1, self._progress.value()))
+        self._progress.setValue(self._progress.maximum())
+
+        lines = []
+        lines.append(self.tr("Corrected:        {n}").format(n=result.processed))
+        lines.append(self.tr("Already corrected: {n}").format(n=result.already_current))
+        lines.append(self.tr("Errors:           {n}").format(n=len(result.errors)))
+        if result.cancelled:
+            lines.append("")
+            lines.append(self.tr("Cancelled - remaining images are uncorrected."))
+        for name, msg in result.errors[:20]:
+            lines.append(f"  {name}: {msg}")
+        self._summary.setPlainText("\n".join(lines))
+        self._summary.setVisible(True)
+        self._cancel_button.setVisible(False)
+        self._ok_button.setVisible(True)
+        self._ok_button.setDefault(True)
+        self._ok_button.setFocus()

--- a/app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py
+++ b/app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py
@@ -155,10 +155,13 @@ class WaldoPrePassDialog(TranslationMixin, QDialog):
         lines.append(self.tr("Already up-to-date: {n}").format(n=result.already_current))
         lines.append(self.tr("Skipped (non-WALDO): {n}").format(n=result.skipped))
         lines.append(self.tr("Errors:           {n}").format(n=len(result.errors)))
+        notes = getattr(result, 'notes', None) or []
+        for msg in notes:
+            lines.append(f"  {msg}")
         warnings = getattr(result, 'warnings', None) or []
         if warnings:
             lines.append("")
-            lines.append(self.tr("⚠ Capture-time warnings (camera clock is suspect):"))
+            lines.append(self.tr("⚠ Metadata warnings:"))
             for msg in warnings:
                 lines.append(f"  {msg}")
         if result.errors:

--- a/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
+++ b/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
@@ -1,0 +1,124 @@
+"""Tests for WaldoPrePassController clock-correction orchestration."""
+
+import importlib
+import json
+
+from core.services.waldo import ClockCorrectionProposal, WaldoProcessResult
+
+controller_module = importlib.import_module(
+    "core.controllers.images.viewer.WaldoPrePassController")
+WaldoPrePassController = controller_module.WaldoPrePassController
+CLOCK_DECISIONS_SETTING = controller_module.CLOCK_DECISIONS_SETTING
+
+
+class _FakeSettings:
+    def __init__(self):
+        self.values = {}
+
+    def get_setting(self, name, default_value=None):
+        return self.values.get(name, default_value)
+
+    def set_setting(self, name, value):
+        self.values[name] = value
+
+
+class _FakeDialog:
+    """Stands in for WaldoClockCorrectionDialog; scripted outcome."""
+
+    instances = []
+
+    # Class-level script for the next instance:
+    script = {}
+
+    def __init__(self, parent, service, image_paths, proposal, auto_apply=False):
+        self.proposal = proposal
+        self.auto_apply = auto_apply
+        self.applied = self.script.get('applied', False)
+        self.declined = self.script.get('declined', False)
+        self.remember_choice = self.script.get('remember', False)
+        self.accepted_face_shift_h = self.script.get('face_shift', None)
+        self.accepted_tz_text = self.script.get('tz_text', None)
+        self.result_data = WaldoProcessResult()
+        _FakeDialog.instances.append(self)
+
+    def exec(self):
+        return None
+
+
+class _StubService:
+    pass
+
+
+def _proposal():
+    return ClockCorrectionProposal(
+        face_shift_h=-12, tz_name="America/Los_Angeles", fixed_offset_h=-8,
+        evidence=["e1"], sample_name="0_a.jpg",
+        sample_face="2026:07:23 18:49:37",
+        sample_corrected_utc="2026-07-23 13:49:37 UTC")
+
+
+def _make_controller(monkeypatch):
+    monkeypatch.setattr(controller_module, 'WaldoClockCorrectionDialog', _FakeDialog)
+    _FakeDialog.instances = []
+    _FakeDialog.script = {}
+    controller = WaldoPrePassController(parent_viewer=None)
+    controller.settings_service = _FakeSettings()
+    return controller
+
+
+def test_no_proposal_means_no_dialog(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    controller._offer_clock_correction(
+        [str(tmp_path / "0_a.jpg")], None, service=_StubService())
+    assert _FakeDialog.instances == []
+
+
+def test_accept_with_remember_persists_decision(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    _FakeDialog.script = {'applied': True, 'remember': True,
+                          'face_shift': -12, 'tz_text': 'America/Los_Angeles'}
+    controller._offer_clock_correction(
+        [str(tmp_path / "0_a.jpg")], _proposal(), service=_StubService())
+    assert len(_FakeDialog.instances) == 1
+    assert _FakeDialog.instances[0].auto_apply is False
+    stored = json.loads(controller.settings_service.values[CLOCK_DECISIONS_SETTING])
+    decision = next(iter(stored.values()))
+    assert decision == {'decision': 'accepted', 'face_shift_h': -12,
+                        'tz_text': 'America/Los_Angeles'}
+
+
+def test_declined_with_remember_suppresses_future_offers(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    _FakeDialog.script = {'declined': True, 'remember': True}
+    paths = [str(tmp_path / "0_a.jpg")]
+    controller._offer_clock_correction(paths, _proposal(), service=_StubService())
+    assert len(_FakeDialog.instances) == 1
+
+    # Second open: decision remembered, dialog never constructed again.
+    controller._offer_clock_correction(paths, _proposal(), service=_StubService())
+    assert len(_FakeDialog.instances) == 1
+
+
+def test_stored_acceptance_reapplies_in_auto_mode(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    paths = [str(tmp_path / "0_a.jpg")]
+    import os
+    folder_key = os.path.normcase(os.path.abspath(str(tmp_path)))
+    controller.settings_service.values[CLOCK_DECISIONS_SETTING] = json.dumps({
+        folder_key: {'decision': 'accepted', 'face_shift_h': -12,
+                     'tz_text': 'America/Los_Angeles'}})
+    _FakeDialog.script = {'applied': True, 'remember': False}
+    controller._offer_clock_correction(paths, _proposal(), service=_StubService())
+    assert len(_FakeDialog.instances) == 1
+    dlg = _FakeDialog.instances[0]
+    assert dlg.auto_apply is True
+    assert dlg.proposal.face_shift_h == -12
+    assert dlg.proposal.tz_name == 'America/Los_Angeles'
+
+
+def test_decline_without_remember_is_not_persisted(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    _FakeDialog.script = {'declined': True, 'remember': False}
+    controller._offer_clock_correction(
+        [str(tmp_path / "0_a.jpg")], _proposal(), service=_StubService())
+    assert CLOCK_DECISIONS_SETTING not in controller.settings_service.values

--- a/app/tests/core/services/shadow/test_solar_position.py
+++ b/app/tests/core/services/shadow/test_solar_position.py
@@ -46,6 +46,34 @@ def test_resolve_utc_from_gps_stamps():
     assert utc == datetime(2025, 6, 15, 19, 30, 0, tzinfo=timezone.utc)
 
 
+@pytest.mark.parametrize("key", [
+    'CaptureUtcCorrected',            # per-namespace parse (bare key)
+    'waldo:CaptureUtcCorrected',      # merged parse (prefixed key)
+    'XMP-waldo:CaptureUtcCorrected',  # exiftool-style prefix
+])
+def test_resolve_utc_prefers_waldo_corrected_over_everything(key):
+    # Even authoritative GPS stamps lose to an operator-confirmed clock
+    # repair: the repair exists precisely because the camera fields lie.
+    exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (0, 1)))
+    xmp = {key: '2026-07-23T13:49:37+00:00'}
+    utc, source = resolve_capture_utc(exif, xmp)
+    assert source == 'waldo_corrected'
+    assert utc == datetime(2026, 7, 23, 13, 49, 37, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_bad_corrected_value_falls_through():
+    exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (0, 1)))
+    xmp = {'CaptureUtcCorrected': 'not-a-timestamp'}
+    utc, source = resolve_capture_utc(exif, xmp)
+    assert source == 'gps'
+    assert utc == datetime(2025, 6, 15, 19, 30, 0, tzinfo=timezone.utc)
+
+
+def test_timezone_name_for_position_returns_zone_or_none():
+    name = solar_mod.timezone_name_for_position(_TX_LAT, _TX_LON)
+    assert name in ('America/Chicago', None)  # None only if tzfinder missing
+
+
 def test_resolve_utc_from_gps_with_fractional_seconds():
     # 19h, 30m, 15.5s
     exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (155, 10)))

--- a/app/tests/core/services/waldo/test_waldo_clock_correction.py
+++ b/app/tests/core/services/waldo/test_waldo_clock_correction.py
@@ -1,0 +1,262 @@
+"""Unit tests for the WALDO camera clock correction (detect / compute / apply)."""
+
+import importlib
+import os
+from datetime import datetime, timedelta, timezone
+
+import piexif
+import pytest
+
+from core.services.waldo.WaldoMetadataService import (
+    WaldoMetadataService,
+    CLOCK_CORRECTED_UTC_XMP,
+    CLOCK_FACE_SHIFT_XMP,
+    CLOCK_TIMEZONE_XMP,
+    WALDO_NAMESPACE_URI,
+)
+
+waldo_module = importlib.import_module("core.services.waldo.WaldoMetadataService")
+
+
+# --------------------------------------------------------------------------
+# compute_corrected_utc
+# --------------------------------------------------------------------------
+
+def test_compute_corrected_utc_iana_zone_dst_aware():
+    # July in America/Los_Angeles is PDT (UTC-7): face 18:49 - 12h = 06:49
+    # local -> 13:49 UTC.
+    face = datetime(2026, 7, 23, 18, 49, 37)
+    out = WaldoMetadataService.compute_corrected_utc(
+        face, -12, "America/Los_Angeles", None)
+    assert out == datetime(2026, 7, 23, 13, 49, 37, tzinfo=timezone.utc)
+
+
+def test_compute_corrected_utc_winter_uses_standard_time():
+    # January is PST (UTC-8): the IANA zone handles DST per date.
+    # 18:49 - 12h = 06:49 PST -> 14:49 UTC (vs 13:49 for the PDT case above).
+    face = datetime(2026, 1, 23, 18, 49, 37)
+    out = WaldoMetadataService.compute_corrected_utc(
+        face, -12, "America/Los_Angeles", None)
+    assert out == datetime(2026, 1, 23, 14, 49, 37, tzinfo=timezone.utc)
+
+
+def test_compute_corrected_utc_fixed_offset_fallback():
+    face = datetime(2026, 7, 23, 18, 49, 37)
+    out = WaldoMetadataService.compute_corrected_utc(face, -12, None, -7.0)
+    assert out == datetime(2026, 7, 23, 13, 49, 37, tzinfo=timezone.utc)
+    # A bogus zone name falls back to the fixed offset instead of raising.
+    out = WaldoMetadataService.compute_corrected_utc(face, -12, "Not/AZone", -7.0)
+    assert out == datetime(2026, 7, 23, 13, 49, 37, tzinfo=timezone.utc)
+
+
+def test_compute_corrected_utc_no_timezone_raises():
+    with pytest.raises(ValueError):
+        WaldoMetadataService.compute_corrected_utc(
+            datetime(2026, 7, 23, 18, 0, 0), -12, None, None)
+
+
+# --------------------------------------------------------------------------
+# propose_clock_correction
+# --------------------------------------------------------------------------
+
+def _fault_exif(face="2026:07:23 18:49:37", offset="-06:00"):
+    return {
+        'Exif': {
+            piexif.ExifIFD.DateTimeOriginal: face.encode(),
+            piexif.ExifIFD.OffsetTimeOriginal: offset.encode(),
+        },
+        'GPS': {},
+    }
+
+
+def _make_image(tmp_path, name="0_000_02_035.jpg",
+                mtime=datetime(2026, 7, 23, 17, 21, 0, tzinfo=timezone.utc)):
+    p = tmp_path / name
+    p.write_bytes(b"\xff\xd8\xff\xd9")
+    ts = mtime.timestamp()
+    os.utime(p, (ts, ts))
+    return str(p)
+
+
+@pytest.fixture
+def fault_setup(tmp_path, monkeypatch):
+    """One WALDO image exhibiting the full clock-fault signature."""
+    # Claimed capture: 18:49:37 at -06:00 -> 2026-07-24 00:49:37 UTC.
+    # File mtime 2026-07-23 17:21 UTC -> claimed is ~7.5 h ahead (flip window).
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        staticmethod(lambda exif_data: {'latitude': 41.28, 'longitude': -122.885}))
+    monkeypatch.setattr(waldo_module, 'timezone_name_for_position',
+                        lambda lat, lon: 'America/Los_Angeles')
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: None))
+    return path
+
+
+def test_propose_fires_on_full_signature(fault_setup):
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_clock_correction([fault_setup])
+    assert proposal is not None
+    assert proposal.face_shift_h == -12
+    assert proposal.tz_name == 'America/Los_Angeles'
+    assert proposal.sample_face == "2026:07:23 18:49:37"
+    # 18:49 - 12h = 06:49 PDT -> 13:49 UTC
+    assert proposal.sample_corrected_utc == "2026-07-23 13:49:37 UTC"
+    assert len(proposal.evidence) == 2
+
+
+def test_propose_fires_on_small_ahead_margin(tmp_path, fault_setup, monkeypatch):
+    """The real field case: a 12 h flip offset by a ~10 h download delay
+    leaves the claimed capture only ~28 min ahead of the mtime. Any
+    provable ahead margin plus the timezone mismatch must still fire."""
+    # Claimed capture 2026-07-24 00:49:37 UTC; file written 28 min earlier.
+    path = _make_image(tmp_path, name="0_000_04_000.jpg",
+                       mtime=datetime(2026, 7, 24, 0, 21, 0, tzinfo=timezone.utc))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_clock_correction([path])
+    assert proposal is not None
+    assert proposal.face_shift_h == -12
+    assert "min AFTER" in proposal.evidence[1]
+
+
+def test_propose_fires_on_ahead_proof_alone(fault_setup, monkeypatch):
+    # The stamped offset agrees with longitude but the file time proves the
+    # clock runs ahead: still propose, with the AM/PM flip default.
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif(offset="-08:00")))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_clock_correction([fault_setup])
+    assert proposal is not None
+    assert proposal.face_shift_h == -12
+    assert len(proposal.evidence) == 1  # no timezone line
+
+
+def test_propose_tz_mismatch_alone_defaults_to_zone_fix(tmp_path, fault_setup, monkeypatch):
+    # A pre-pass restamp resets mtime, destroying the ahead-proof: the
+    # timezone mismatch alone must still propose, but with face shift 0 and
+    # a caution that a 12 h flip cannot be proven from these files.
+    path = _make_image(tmp_path, name="0_000_02_036.jpg",
+                       mtime=datetime(2026, 7, 24, 1, 0, 0, tzinfo=timezone.utc))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_clock_correction([path])
+    assert proposal is not None
+    assert proposal.face_shift_h == 0
+    assert any("cannot be proven" in e for e in proposal.evidence)
+
+
+def test_propose_quiet_when_nothing_provable(tmp_path, fault_setup, monkeypatch):
+    # Offset consistent with longitude AND file written after the claimed
+    # capture: no provable symptom, no proposal.
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif(offset="-08:00")))
+    path = _make_image(tmp_path, name="0_000_02_037.jpg",
+                       mtime=datetime(2026, 7, 24, 12, 0, 0, tzinfo=timezone.utc))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.propose_clock_correction([path]) is None
+
+
+def test_propose_quiet_when_already_corrected(fault_setup, monkeypatch):
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-07-23T13:49:37+00:00"))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.propose_clock_correction([fault_setup]) is None
+
+
+# --------------------------------------------------------------------------
+# apply_clock_correction
+# --------------------------------------------------------------------------
+
+def test_apply_stamps_corrected_fields(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    written = {}
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'add_xmp_fields',
+                        staticmethod(lambda p, fields: written.update({p: fields})))
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: None))
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = svc.apply_clock_correction(
+        [path], -12, tz_name="America/Los_Angeles")
+
+    assert result.processed == 1 and not result.errors
+    fields = {name: value for ns, name, value in written[path]}
+    assert fields[CLOCK_CORRECTED_UTC_XMP] == "2026-07-23T13:49:37+00:00"
+    assert fields[CLOCK_FACE_SHIFT_XMP] == "-12"
+    assert fields[CLOCK_TIMEZONE_XMP] == "America/Los_Angeles"
+    assert all(ns == WALDO_NAMESPACE_URI for ns, _, _ in written[path])
+
+
+def test_apply_is_idempotent(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-07-23T13:49:37+00:00"))
+    calls = []
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'add_xmp_fields',
+                        staticmethod(lambda p, fields: calls.append(p)))
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = svc.apply_clock_correction([path], -12, tz_name="America/Los_Angeles")
+    assert result.already_current == 1 and result.processed == 0
+    assert calls == []
+
+
+def test_apply_skips_non_waldo_and_reports_missing_exif(tmp_path, monkeypatch):
+    waldo = _make_image(tmp_path, name="0_000_02_035.jpg")
+    other = _make_image(tmp_path, name="DJI_0001.jpg")
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: {'Exif': {}, 'GPS': {}}))
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: None))
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = svc.apply_clock_correction([waldo, other], -12, fixed_offset_h=-7.0)
+    assert result.skipped == 1
+    assert len(result.errors) == 1
+    assert "DateTimeOriginal" in result.errors[0][1]
+
+
+def test_apply_cancel_stops_early(tmp_path, monkeypatch):
+    paths = [_make_image(tmp_path, name=f"0_000_02_{i:03d}.jpg") for i in range(5)]
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'add_xmp_fields',
+                        staticmethod(lambda p, fields: None))
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: None))
+
+    seen = []
+
+    def cancel_after_two():
+        return len(seen) >= 2
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = svc.apply_clock_correction(
+        paths, -12, fixed_offset_h=-7.0,
+        progress_cb=lambda i, n, s: seen.append(i),
+        cancel_cb=cancel_after_two)
+    assert result.cancelled
+    assert result.processed < 5
+
+
+# --------------------------------------------------------------------------
+# audit softening
+# --------------------------------------------------------------------------
+
+def test_audit_quiet_when_correction_stamped(fault_setup, monkeypatch):
+    """The audit must stop warning once the operator has repaired the clock."""
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-07-23T13:49:37+00:00"))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.audit_capture_times([fault_setup]) == []
+
+
+def test_audit_still_warns_without_correction(fault_setup):
+    svc = WaldoMetadataService(terrain_service=None)
+    warnings = svc.audit_capture_times([fault_setup])
+    assert warnings  # timezone mismatch + AM/PM flip both present

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -179,6 +179,36 @@ def test_heading_cross_cam_fallback():
     assert cam1.heading_deg is not None  # filled from cam 0
 
 
+def test_heading_serpentine_lane_edges_use_one_sided_bearing():
+    """Lane-edge images must derive from their OWN lane, never inherit the
+    previous lane's heading across the turn gap.
+
+    Serpentine field flights showed the first image of each lane stamped
+    ~180 deg flipped: the >30 s turn starved the two-sided bearing pass and
+    the forward fill copied the opposite lane's heading.
+    """
+    t0 = datetime(2026, 1, 1, 12, 0, 0)
+    records = []
+    # Lane A: northbound, captures every 2 s.
+    for i in range(4):
+        records.append(_make_record(0, i, 37.000 + i * 0.001, -120.000,
+                                    t0 + timedelta(seconds=i * 2)))
+    # 90 s turn gap (beyond MAX_NEIGHBOR_DT_S), then lane B: SOUTHBOUND.
+    for i in range(4):
+        records.append(_make_record(0, 10 + i, 37.003 - i * 0.001, -120.002,
+                                    t0 + timedelta(seconds=90 + i * 2)))
+    svc = WaldoMetadataService(terrain_service=None)
+    svc.derive_headings(records)
+    lane_a = records[:4]
+    lane_b = records[4:]
+    for r in lane_a:
+        diff = min(abs(r.heading_deg), abs(360.0 - r.heading_deg))
+        assert diff < 5.0, f"lane A image {r.name} heading {r.heading_deg}"
+    for r in lane_b:
+        assert abs(r.heading_deg - 180.0) < 5.0, \
+            f"lane B image {r.name} heading {r.heading_deg} (flip regression)"
+
+
 # --------------------------------------------------------------------------
 # process_folder progress phasing
 # --------------------------------------------------------------------------

--- a/app/tests/core/services/waldo/test_waldo_trigger_log.py
+++ b/app/tests/core/services/waldo/test_waldo_trigger_log.py
@@ -1,0 +1,332 @@
+"""Unit tests for WaldoTriggerLogService and its WaldoMetadataService hookup."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from core.services.waldo.WaldoMetadataService import (
+    WaldoMetadataService,
+    WaldoImageRecord,
+    WaldoProcessResult,
+)
+from core.services.waldo.WaldoTriggerLog import (
+    TriggerPoint,
+    WaldoTriggerLogService,
+)
+
+
+# --------------------------------------------------------------------------
+# KML synthesis helpers
+# --------------------------------------------------------------------------
+
+KML_HEADER = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<kml xmlns="http://www.opengis.net/kml/2.2">\n'
+    '<Document> <name>Test_Triggers</name>\n'
+)
+
+
+def _placemark(name, lat, lon, alt=2400.0):
+    # Real files carry a trailing space inside <name> — reproduce it.
+    return (
+        f'<Placemark> <name>{name} </name> <styleUrl>#whiteDot</styleUrl> '
+        f'<Point> <coordinates>{lon:.6f},{lat:.6f},{alt:.2f}</coordinates> '
+        f'</Point> </Placemark>\n'
+    )
+
+
+def _write_kml(path, placemarks, close=True):
+    text = KML_HEADER + "".join(placemarks)
+    if close:
+        text += "</Document>\n</kml>\n"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+# Lane geometry: 0.002 deg latitude ~= 222 m spacing (inside the 600 m
+# neighbour guard); 0.02 deg ~= 2.2 km (outside it).
+def _lane(lane_idx, frames, lat0, lon, ascending=True):
+    marks = []
+    for j, frame in enumerate(frames):
+        lat = lat0 + (j if ascending else -j) * 0.002
+        marks.append((f"000_{lane_idx:02d}_{frame:03d}", lat, lon))
+    return marks
+
+
+# --------------------------------------------------------------------------
+# parse_triggers_kml
+# --------------------------------------------------------------------------
+
+def test_parse_reads_names_and_coords_in_document_order(tmp_path):
+    marks = [_placemark("000_12_000", 41.0, -122.0),
+             _placemark("000_12_001", 41.002, -122.0)]
+    path = _write_kml(tmp_path / "t.kml", marks)
+    points = WaldoTriggerLogService.parse_triggers_kml(path)
+    assert [p.name for p in points] == ["000_12_000", "000_12_001"]
+    assert points[0].lat == pytest.approx(41.0)
+    assert points[0].lon == pytest.approx(-122.0)
+    assert points[0].alt == pytest.approx(2400.0)
+
+
+def test_parse_tolerates_truncated_file(tmp_path):
+    # Field Position/Trigger KMLs can end mid-stream with no closing tags.
+    marks = [_placemark("000_12_000", 41.0, -122.0)]
+    text = KML_HEADER + "".join(marks) + \
+        '<Placemark> <name>000_12_001 </name> <Point> <coordinates>-122.000000,41.002'
+    path = tmp_path / "trunc.kml"
+    path.write_text(text, encoding="utf-8")
+    points = WaldoTriggerLogService.parse_triggers_kml(str(path))
+    assert len(points) == 2
+    assert points[1].lat == pytest.approx(41.002)
+    assert points[1].alt is None
+
+
+def test_parse_skips_linestring_placemarks(tmp_path):
+    # Position KMLs hold a LineString track — must not parse as triggers.
+    text = KML_HEADER + (
+        '<Placemark id="X"> <name>Track</name> <LineString> <coordinates>\n'
+        '-122.0,41.0,3000\n-122.0,41.1,3000\n</coordinates> </LineString> </Placemark>\n'
+    )
+    path = tmp_path / "pos.kml"
+    path.write_text(text, encoding="utf-8")
+    assert WaldoTriggerLogService.parse_triggers_kml(str(path)) == []
+
+
+def test_parse_skips_malformed_coordinates(tmp_path):
+    marks = [
+        _placemark("000_12_000", 41.0, -122.0),
+        '<Placemark> <name>bad </name> <Point> <coordinates>not,numbers</coordinates> </Point> </Placemark>\n',
+        _placemark("000_12_001", 41.002, -122.0),
+    ]
+    path = _write_kml(tmp_path / "t.kml", marks)
+    points = WaldoTriggerLogService.parse_triggers_kml(path)
+    assert [p.name for p in points] == ["000_12_000", "000_12_001"]
+
+
+def test_parse_unreadable_path_returns_empty(tmp_path):
+    assert WaldoTriggerLogService.parse_triggers_kml(str(tmp_path / "nope.kml")) == []
+
+
+# --------------------------------------------------------------------------
+# image_trigger_name
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("image,expected", [
+    ("0_000_12_035.jpg", "000_12_035"),
+    ("1_000_00_002.JPG", "000_00_002"),
+    (r"E:\somewhere\1_000_04_019.jpg", "000_04_019"),
+    ("DJI_0001.JPG", None),
+    ("2_000_00_000.jpg", None),
+])
+def test_image_trigger_name(image, expected):
+    assert WaldoTriggerLogService.image_trigger_name(image) == expected
+
+
+# --------------------------------------------------------------------------
+# headings_by_name
+# --------------------------------------------------------------------------
+
+def _points(marks):
+    return [TriggerPoint(name=n, lat=lat, lon=lon, alt=None) for n, lat, lon in marks]
+
+
+def test_headings_serpentine_lanes_get_opposite_directions():
+    # Lane 01 flown north (frames ascending), lane 00 flown SOUTH while its
+    # frame numbers still ascend geographically north — the serpentine trap.
+    lane_a = _lane(1, range(5), 41.0, -122.0, ascending=True)
+    lane_b = _lane(0, [4, 3, 2, 1, 0], 41.008, -122.003, ascending=False)
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane_a + lane_b))
+    for j in range(5):
+        assert headings[f"000_01_{j:03d}"] == pytest.approx(0.0, abs=3.0) or \
+            headings[f"000_01_{j:03d}"] == pytest.approx(360.0, abs=3.0)
+    for j in range(5):
+        assert headings[f"000_00_{j:03d}"] == pytest.approx(180.0, abs=3.0)
+
+
+def test_headings_recaptured_frames_get_recapture_direction():
+    # Frames 1-2 of lane 00 were missed on the northbound pass and re-flown
+    # SOUTHBOUND at the end of the flight. Their headings must come from the
+    # recapture pass, not from where their names sit in the lane.
+    lane = _lane(0, [0, 3, 4], 41.0, -122.0, ascending=True)   # 41.000/002/004
+    recapture = [("000_00_002", 41.004, -122.0),               # flying south now
+                 ("000_00_001", 41.002, -122.0)]
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane + recapture))
+    assert headings["000_00_000"] == pytest.approx(0.0, abs=3.0)
+    assert headings["000_00_002"] == pytest.approx(180.0, abs=3.0)
+    assert headings["000_00_001"] == pytest.approx(180.0, abs=3.0)
+
+
+def test_headings_lane_ends_use_one_sided_bearing():
+    # A jump >600 m (0.02 deg) separates two lanes; the triggers flanking the
+    # jump must not derive a bearing across it.
+    lane_a = _lane(1, range(3), 41.0, -122.0, ascending=True)
+    lane_b = _lane(0, range(3), 41.1, -122.003, ascending=True)
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane_a + lane_b))
+    # Last of lane A and first of lane B still get their own lane's direction.
+    assert headings["000_01_002"] == pytest.approx(0.0, abs=3.0)
+    assert headings["000_00_000"] == pytest.approx(0.0, abs=3.0)
+
+
+def test_headings_isolated_trigger_gets_none():
+    lane = _lane(1, range(3), 41.0, -122.0, ascending=True)
+    isolated = [("000_09_050", 41.5, -122.5)]
+    headings = WaldoTriggerLogService.headings_by_name(_points(lane + isolated))
+    assert "000_09_050" not in headings
+    assert "000_01_001" in headings
+
+
+def test_headings_stationary_duplicate_neighbour_ignored():
+    # A duplicate point (<1 m away) must not produce a degenerate bearing.
+    marks = [("000_00_000", 41.0, -122.0),
+             ("000_00_001", 41.0, -122.0),
+             ("000_00_002", 41.002, -122.0)]
+    headings = WaldoTriggerLogService.headings_by_name(_points(marks))
+    assert headings["000_00_001"] == pytest.approx(0.0, abs=3.0)
+
+
+# --------------------------------------------------------------------------
+# chronology_fraction
+# --------------------------------------------------------------------------
+
+def _rec(name, lat, lon, ts, cam=0, path=None):
+    return WaldoImageRecord(path=path or name, name=name, cam_idx=cam,
+                            lat=lat, lon=lon, timestamp=ts)
+
+
+def test_chronology_consistent_timestamps_score_high():
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    records = [_rec(f"0_{n}.jpg", lat, lon, t0 + timedelta(seconds=4 * j))
+               for j, (n, lat, lon) in enumerate(marks)]
+    frac = WaldoTriggerLogService.chronology_fraction(_points(marks), records)
+    assert frac == pytest.approx(1.0)
+
+
+def test_chronology_reversed_timestamps_score_low():
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    records = [_rec(f"0_{n}.jpg", lat, lon, t0 - timedelta(seconds=4 * j))
+               for j, (n, lat, lon) in enumerate(marks)]
+    frac = WaldoTriggerLogService.chronology_fraction(_points(marks), records)
+    assert frac == pytest.approx(0.0)
+
+
+def test_chronology_too_few_matches_returns_none():
+    marks = _lane(0, range(2), 41.0, -122.0, ascending=True)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    records = [_rec(f"0_{n}.jpg", lat, lon, t0)
+               for n, lat, lon in marks]
+    assert WaldoTriggerLogService.chronology_fraction(_points(marks), records) is None
+
+
+# --------------------------------------------------------------------------
+# discover
+# --------------------------------------------------------------------------
+
+def _flight_layout(tmp_path, marks, kml_name="20260723_65561_Triggers.kml"):
+    """Field layout: <root>/<kml> with images two levels down in batch dirs."""
+    batch_dir = tmp_path / "20260723_65561" / "batch1"
+    batch_dir.mkdir(parents=True)
+    kml = _write_kml(tmp_path / kml_name, [_placemark(n, lat, lon) for n, lat, lon in marks])
+    records = [_rec(f"0_{n}.jpg", lat, lon, None, path=str(batch_dir / f"0_{n}.jpg"))
+               for n, lat, lon in marks]
+    return kml, records
+
+
+def test_discover_finds_kml_levels_above_images(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    kml, records = _flight_layout(tmp_path, marks)
+    found = WaldoTriggerLogService().discover(records)
+    assert found is not None
+    assert found[0] == kml
+    assert len(found[1]) == 5
+
+
+def test_discover_rejects_name_collision_from_other_flight(tmp_path):
+    # A sibling flight's log contains the SAME trigger names at different
+    # positions (every flight numbers lanes from zero). GPS proximity must
+    # pick the right log.
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    decoy_marks = [(n, lat + 1.0, lon + 1.0) for n, lat, lon in marks]
+    kml, records = _flight_layout(tmp_path, marks)
+    _write_kml(tmp_path / "20260723_99999_Triggers.kml",
+               [_placemark(n, lat, lon) for n, lat, lon in decoy_marks])
+    found = WaldoTriggerLogService().discover(records)
+    assert found is not None
+    assert found[0] == kml
+
+
+def test_discover_returns_none_without_positional_match(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    _, records = _flight_layout(tmp_path, marks)
+    # Re-write the KML with every trigger displaced ~111 km: names all match
+    # but no position does, so the log must be rejected.
+    far_marks = [(n, lat + 1.0, lon) for n, lat, lon in marks]
+    _write_kml(tmp_path / "20260723_65561_Triggers.kml",
+               [_placemark(n, lat, lon) for n, lat, lon in far_marks])
+    assert WaldoTriggerLogService().discover(records) is None
+
+
+def test_discover_returns_none_when_no_kml_exists(tmp_path):
+    batch_dir = tmp_path / "flight" / "batch1"
+    batch_dir.mkdir(parents=True)
+    records = [_rec("0_000_00_000.jpg", 41.0, -122.0, None,
+                    path=str(batch_dir / "0_000_00_000.jpg"))]
+    assert WaldoTriggerLogService().discover(records) is None
+
+
+# --------------------------------------------------------------------------
+# WaldoMetadataService._apply_trigger_log_headings integration
+# --------------------------------------------------------------------------
+
+def test_apply_corrects_flipped_headings_and_warns(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)  # truth: north
+    _, records = _flight_layout(tmp_path, marks)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    for j, rec in enumerate(records):
+        rec.timestamp = t0 + timedelta(seconds=4 * j)
+        rec.heading_deg = 180.0  # timestamp derivation got these flipped
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = WaldoProcessResult()
+    svc._apply_trigger_log_headings(records, result)
+
+    for rec in records:
+        assert rec.heading_deg == pytest.approx(0.0, abs=3.0) or \
+            rec.heading_deg == pytest.approx(360.0, abs=3.0)
+    assert any("corrected the flight direction of 5" in w for w in result.warnings)
+    assert any("Trigger log" in n and "5 of 5" in n for n in result.notes)
+
+
+def test_apply_rejects_log_contradicting_timestamps(tmp_path):
+    marks = _lane(0, range(5), 41.0, -122.0, ascending=True)
+    _, records = _flight_layout(tmp_path, marks)
+    t0 = datetime(2026, 7, 23, 6, 30, 0)
+    for j, rec in enumerate(records):
+        rec.timestamp = t0 - timedelta(seconds=4 * j)  # doc order backwards
+        rec.heading_deg = 123.0
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = WaldoProcessResult()
+    svc._apply_trigger_log_headings(records, result)
+
+    assert all(rec.heading_deg == 123.0 for rec in records)
+    assert any("ignored" in w for w in result.warnings)
+    assert result.notes == []
+
+
+def test_apply_no_kml_is_a_quiet_noop(tmp_path):
+    batch_dir = tmp_path / "flight" / "batch1"
+    batch_dir.mkdir(parents=True)
+    records = [_rec("0_000_00_000.jpg", 41.0, -122.0,
+                    datetime(2026, 7, 23, 6, 30, 0),
+                    path=str(batch_dir / "0_000_00_000.jpg"))]
+    records[0].heading_deg = 77.0
+
+    svc = WaldoMetadataService(terrain_service=None)
+    result = WaldoProcessResult()
+    svc._apply_trigger_log_headings(records, result)
+
+    assert records[0].heading_deg == 77.0
+    assert result.warnings == []
+    assert result.notes == []

--- a/app/tests/core/views/images/viewer/dialogs/test_waldo_clock_correction_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_waldo_clock_correction_dialog.py
@@ -1,0 +1,113 @@
+"""Tests for WaldoClockCorrectionDialog (confirm/edit/apply flow)."""
+
+import pytest
+
+from core.services.waldo import ClockCorrectionProposal, WaldoProcessResult
+from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import (
+    WaldoClockCorrectionDialog,
+)
+
+
+class _StubService:
+    """Records apply_clock_correction calls; returns canned counts."""
+
+    def __init__(self):
+        self.calls = []
+
+    def apply_clock_correction(self, image_paths, face_shift_h, tz_name=None,
+                               fixed_offset_h=None, progress_cb=None,
+                               cancel_cb=None):
+        self.calls.append({
+            'paths': list(image_paths),
+            'face_shift_h': face_shift_h,
+            'tz_name': tz_name,
+            'fixed_offset_h': fixed_offset_h,
+        })
+        if progress_cb:
+            progress_cb(1, len(image_paths), "working")
+        result = WaldoProcessResult()
+        result.processed = len(image_paths)
+        return result
+
+
+def _proposal():
+    return ClockCorrectionProposal(
+        face_shift_h=-12,
+        tz_name="America/Los_Angeles",
+        fixed_offset_h=-8,
+        evidence=["Stamped timezone is UTC-6 but GPS longitude implies UTC-8.2.",
+                  "Claimed capture is 7.5 h after the file was written."],
+        sample_name="0_000_02_035.jpg",
+        sample_face="2026:07:23 18:49:37",
+        sample_corrected_utc="2026-07-23 13:49:37 UTC",
+    )
+
+
+def test_dialog_preview_uses_proposal_defaults(qtbot):
+    dlg = WaldoClockCorrectionDialog(None, _StubService(), ["0_a.jpg"], _proposal())
+    qtbot.addWidget(dlg)
+    assert dlg._shift_spin.value() == -12
+    assert dlg._tz_edit.text() == "America/Los_Angeles"
+    # 18:49 face - 12h in PDT -> 13:49 UTC
+    assert "13:49:37 UTC" in dlg._preview_label.text()
+    assert dlg._apply_button.isEnabled()
+
+
+def test_dialog_invalid_timezone_disables_apply(qtbot):
+    dlg = WaldoClockCorrectionDialog(None, _StubService(), ["0_a.jpg"], _proposal())
+    qtbot.addWidget(dlg)
+    dlg._tz_edit.setText("garbage/zone!!")
+    assert not dlg._apply_button.isEnabled()
+    dlg._tz_edit.setText("-7")  # numeric offsets are accepted too
+    assert dlg._apply_button.isEnabled()
+
+
+def test_dialog_apply_runs_worker_and_records_choice(qtbot):
+    service = _StubService()
+    dlg = WaldoClockCorrectionDialog(None, service, ["0_a.jpg", "0_b.jpg"], _proposal())
+    qtbot.addWidget(dlg)
+    dlg._on_apply()
+    qtbot.waitUntil(lambda: dlg.applied, timeout=5000)
+    assert service.calls and service.calls[0]['face_shift_h'] == -12.0
+    assert service.calls[0]['tz_name'] == "America/Los_Angeles"
+    assert dlg.accepted_face_shift_h == -12
+    assert dlg.accepted_tz_text == "America/Los_Angeles"
+    assert dlg.remember_choice is True
+    assert dlg.result_data.processed == 2
+
+
+def test_dialog_decline_sets_flags_without_applying(qtbot):
+    service = _StubService()
+    dlg = WaldoClockCorrectionDialog(None, service, ["0_a.jpg"], _proposal())
+    qtbot.addWidget(dlg)
+    dlg._remember_check.setChecked(False)
+    dlg._on_decline()
+    assert dlg.declined is True
+    assert dlg.remember_choice is False
+    assert dlg.applied is False
+    assert service.calls == []
+
+
+def test_dialog_auto_mode_applies_on_show(qtbot):
+    service = _StubService()
+    dlg = WaldoClockCorrectionDialog(None, service, ["0_a.jpg"], _proposal(),
+                                     auto_apply=True)
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitUntil(lambda: dlg.applied, timeout=5000)
+    assert service.calls
+    dlg.close()
+
+
+def test_dialog_fixed_offset_input_reaches_service(qtbot):
+    service = _StubService()
+    proposal = _proposal()
+    proposal.tz_name = None
+    proposal.fixed_offset_h = -7.0
+    dlg = WaldoClockCorrectionDialog(None, service, ["0_a.jpg"], proposal)
+    qtbot.addWidget(dlg)
+    assert dlg._tz_edit.text() == "-7.0"
+    dlg._on_apply()
+    qtbot.waitUntil(lambda: dlg.applied, timeout=5000)
+    assert service.calls[0]['tz_name'] is None
+    assert service.calls[0]['fixed_offset_h'] == pytest.approx(-7.0)

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -1679,70 +1679,70 @@ Please check your credentials and try again.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>CalTopo Login &amp; Map Selection</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Current map: Not selected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>I&apos;m Logged In - Export Data</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Click this after logging in and navigating to your map</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Initialization Error</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Failed to initialize CalTopo browser:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Failed to Load</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Failed to load CalTopo. Please check your internet connection and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Current map: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>No Map Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Browser Not Ready</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>The CalTopo browser is still loading. Please wait a moment and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Starting export...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Authentication Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser not initialized. Please try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Please check:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Offline Mode Enabled</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Turn off Offline Only to export to CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Nothing Selected</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Please ensure your images have GPS coordinates and are nadir shots.</translation
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>No Map Selected</translation>
     </message>
@@ -2137,7 +2137,7 @@ The map URL should look like:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 The reason was written to the log (adiat_logs.txt) and the console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Photos uploaded: {uploaded} of {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 The items should now be visible on your map.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Export Successful</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Partial Success</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Export Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Export Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Exporting to CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Logged Out</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Successfully logged out from CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>Loading CalTopo Maps</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Connecting to CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Fetching account data and maps...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Connection Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Number of corners: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Authentication Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>No CalTopo session cookies were captured. Please log in and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Number of corners: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ The reason was written to the log (adiat_logs.txt) and the console.
 Would you like to re-enter your Team ID, Credential ID and Credential Secret?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exporting to CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparing data and exporting...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Errors:           {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Per-image errors:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Cancelling...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Cancellation requested...</translation>
     </message>

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -10359,32 +10359,37 @@ Expected to find files named:
         <translation>Capture time zone estimated from GPS location.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="548"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <source>Using repaired capture time (camera clock fault).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
         <source>the sun was below the horizon at capture</source>
         <translation>the sun was below the horizon at capture</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="550"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
         <source>sun position unavailable</source>
         <translation>sun position unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Shadow unavailable: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Place the person and shadow on the DEM terrain surface</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="654"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terrain (DEM) data is not available for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="914"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Choose Overlay Color</source>
         <translation>Choose Overlay Color</translation>
     </message>
@@ -15797,6 +15802,114 @@ Please install it using: pip install qimage2ndarray</translation>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2173"/>
         <source>Loading gallery...</source>
         <translation>Loading gallery...</translation>
+    </message>
+</context>
+<context>
+    <name>WaldoClockCorrectionDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="77"/>
+        <source>WALDO Camera Clock Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="99"/>
+        <source>The camera clock on these images appears to be misconfigured:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
+        <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="120"/>
+        <source> hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="121"/>
+        <source>Clock face error to remove:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
+        <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="130"/>
+        <source>True camera time zone:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="139"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="159"/>
+        <source>Apply Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="163"/>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="166"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="170"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="231"/>
+        <source>Enter a valid time zone (IANA name or UTC offset in hours).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="239"/>
+        <source>{name}: camera says {before}  →  corrected {after}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="245"/>
+        <source>Correction preview unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="272"/>
+        <source>Stamping corrected capture times...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="292"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished">Cancelling...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="308"/>
+        <source>Corrected:        {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="309"/>
+        <source>Already corrected: {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="310"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Errors:           {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="313"/>
+        <source>Cancelled - remaining images are uncorrected.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -1679,70 +1679,70 @@ Compruebe sus credenciales e inténtelo de nuevo.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>Inicio de sesión y selección de mapa de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Mapa actual: No seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Inicie sesión → Vaya a su mapa → Haga clic en &apos;He iniciado sesión&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>He iniciado sesión - Exportar datos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Haga clic en esto tras iniciar sesión y navegar hasta su mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Error de inicialización</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Error al inicializar el navegador de CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Error al cargar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Error al cargar CalTopo. Compruebe su conexión a Internet e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Mapa actual: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>Ningún mapa seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 La URL del mapa debe contener un ID de mapa (p. ej., /m/ABC123 o #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Navegador no listo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>El navegador de CalTopo aún se está cargando. Espere un momento e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Iniciando exportación...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Error de autenticación</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Navegador no inicializado. Inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Compruebe:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Modo sin conexión habilitado</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Desactive Solo sin conexión para exportar a CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Nada seleccionado</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Seleccione al menos un tipo de datos (AOI marcados, ubicaciones de dron/imagen o área de cobertura) para exportar.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Asegúrese de que sus imágenes tengan coordenadas GPS y sean tomas nadir.</tran
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>Ningún mapa seleccionado</translation>
     </message>
@@ -2137,7 +2137,7 @@ La URL del mapa debería verse así:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Abra su mapa en la ventana de CalTopo antes de hacer clic en &apos;He iniciado sesión - Exportar datos&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consola.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Fotos subidas: {uploaded} de {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 Los elementos ya deberían aparecer en su mapa.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Los detalles de lo que falló se registraron en el archivo de registro (adiat_logs.txt) y en la consola.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Exportación exitosa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Éxito parcial</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Exportación fallida</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Error de exportación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ Los detalles de lo que falló se registraron en el archivo de registro (adiat_lo
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Number of corners: {count}</source>
 Número de esquinas: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Exportando a CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Sesión cerrada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Sesión cerrada correctamente en CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>Cargando mapas de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Conectando a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Obteniendo datos de la cuenta y mapas...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Error de conexión</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Número de esquinas: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Error de autenticación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>No se capturaron cookies de sesión de CalTopo. Inicie sesión e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Número de esquinas: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consol
 ¿Desea volver a introducir su ID de equipo, ID de credencial y secreto de credencial?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exportando a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparando datos y exportando...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Errores:          {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Errores por imagen:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Cancelando...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Cancelación solicitada...</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -10359,32 +10359,37 @@ Se esperaba encontrar archivos con estos nombres:
         <translation>Zona horaria de captura estimada a partir de la ubicación GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="548"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <source>Using repaired capture time (camera clock fault).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
         <source>the sun was below the horizon at capture</source>
         <translation>el sol estaba por debajo del horizonte durante la captura</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="550"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
         <source>sun position unavailable</source>
         <translation>posición del sol no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Sombra no disponible: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Colocar la persona y la sombra sobre la superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="654"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Los datos de terreno (DEM) no están disponibles para esta imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="914"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Choose Overlay Color</source>
         <translation>Elegir color de superposición</translation>
     </message>
@@ -15797,6 +15802,114 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2173"/>
         <source>Loading gallery...</source>
         <translation>Cargando galería...</translation>
+    </message>
+</context>
+<context>
+    <name>WaldoClockCorrectionDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="77"/>
+        <source>WALDO Camera Clock Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="99"/>
+        <source>The camera clock on these images appears to be misconfigured:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
+        <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="120"/>
+        <source> hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="121"/>
+        <source>Clock face error to remove:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
+        <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="130"/>
+        <source>True camera time zone:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="139"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="159"/>
+        <source>Apply Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="163"/>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="166"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="170"/>
+        <source>OK</source>
+        <translation type="unfinished">Aceptar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="231"/>
+        <source>Enter a valid time zone (IANA name or UTC offset in hours).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="239"/>
+        <source>{name}: camera says {before}  →  corrected {after}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="245"/>
+        <source>Correction preview unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="272"/>
+        <source>Stamping corrected capture times...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="292"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished">Cancelando...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="308"/>
+        <source>Corrected:        {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="309"/>
+        <source>Already corrected: {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="310"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Errores:          {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="313"/>
+        <source>Cancelled - remaining images are uncorrected.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -1679,70 +1679,70 @@ Controlla le tue credenziali e riprova.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>Accesso CalTopo &amp; Selezione Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Mappa corrente: Non selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Accedi → Naviga verso la tua mappa → Clicca &apos;Sono connesso&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>Sono connesso - Esporta Dati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Clicca qui dopo aver effettuato l&apos;accesso e aver navigato verso la tua mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Errore di Inizializzazione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Impossibile inizializzare il browser CalTopo:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Caricamento Fallito</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Impossibile caricare CalTopo. Controlla la tua connessione internet e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Mappa corrente: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 L&apos;URL della mappa deve contenere un ID mappa (es., /m/ABC123 o #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Browser non pronto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>Il browser CalTopo è ancora in fase di caricamento. Attendi un momento e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Inizio esportazione...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Autenticazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser non inizializzato. Riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Controlla:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Modalità Offline Abilitata</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Disattiva Solo Offline per esportare su CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Nessuna Selezione</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Seleziona almeno un tipo di dati (AOI contrassegnate, posizioni drone/immagini o area di copertura) da esportare.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Assicurati che le tue immagini abbiano le coordinate GPS e siano scatti nadirali
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
@@ -2137,7 +2137,7 @@ L&apos;URL della mappa dovrebbe essere simile a:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Apri la mappa nella finestra CalTopo prima di fare clic su &apos;Sono connesso - Esporta Dati&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 Il motivo è stato scritto nel registro (adiat_logs.txt) e nella console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Foto caricate: {uploaded} di {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 Gli elementi dovrebbero ora essere visibili sulla mappa.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 I dettagli di eventuali errori sono stati scritti nel registro (adiat_logs.txt) e nella console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Esportazione Riuscita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Successo Parziale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Esportazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Errore di Esportazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ I dettagli di eventuali errori sono stati scritti nel registro (adiat_logs.txt) 
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Area in metri quadrati: {sqm:.0f} m²
 Numero di angoli: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Esportazione su CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Disconnessione da CalTopo riuscita.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>Caricamento Mappe CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Connessione a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Recupero dati account e mappe...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Errore di Connessione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Numero di angoli: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Autenticazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>Nessun cookie di sessione CalTopo acquisito. Effettua l&apos;accesso e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Numero di angoli: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ Il motivo è stato scritto nel registro (adiat_logs.txt) e nella console.
 Vuoi reinserire ID team, ID credenziale e segreto credenziale?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Esportazione su CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparazione dati ed esportazione...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Errori:           {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Errori per immagine:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Annullamento...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Annullamento richiesto...</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -10359,32 +10359,37 @@ Nomi dei file cercati:
         <translation>Fuso orario dello scatto stimato dalla posizione GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="548"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <source>Using repaired capture time (camera clock fault).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
         <source>the sun was below the horizon at capture</source>
         <translation>il sole era sotto l&apos;orizzonte al momento dello scatto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="550"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
         <source>sun position unavailable</source>
         <translation>posizione del sole non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Ombra non disponibile: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Posiziona la persona e l&apos;ombra sulla superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="654"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>I dati del terreno (DEM) non sono disponibili per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="914"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Choose Overlay Color</source>
         <translation>Scegli colore sovrapposizione</translation>
     </message>
@@ -15797,6 +15802,114 @@ Installalo usando: pip install qimage2ndarray</translation>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2173"/>
         <source>Loading gallery...</source>
         <translation>Caricamento galleria...</translation>
+    </message>
+</context>
+<context>
+    <name>WaldoClockCorrectionDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="77"/>
+        <source>WALDO Camera Clock Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="99"/>
+        <source>The camera clock on these images appears to be misconfigured:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
+        <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="120"/>
+        <source> hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="121"/>
+        <source>Clock face error to remove:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
+        <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="130"/>
+        <source>True camera time zone:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="139"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="159"/>
+        <source>Apply Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="163"/>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="166"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annulla</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="170"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="231"/>
+        <source>Enter a valid time zone (IANA name or UTC offset in hours).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="239"/>
+        <source>{name}: camera says {before}  →  corrected {after}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="245"/>
+        <source>Correction preview unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="272"/>
+        <source>Stamping corrected capture times...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="292"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="308"/>
+        <source>Corrected:        {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="309"/>
+        <source>Already corrected: {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="310"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Errori:           {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="313"/>
+        <source>Cancelled - remaining images are uncorrected.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -1679,70 +1679,70 @@ Controleer uw inloggegevens en probeer het opnieuw.</translation>
 <context>
     <name>CalTopoAuthDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="155"/>
         <source>CalTopo Login &amp; Map Selection</source>
         <translation>CalTopo aanmelden &amp; kaartselectie</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="249"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="240"/>
         <source>Current map: Not selected</source>
         <translation>Huidige kaart: niet geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="253"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="244"/>
         <source>(Login → Navigate to your map → Click &apos;I&apos;m Logged In&apos;)</source>
         <translation>(Aanmelden → navigeer naar uw kaart → klik op &apos;Ik ben aangemeld&apos;)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="267"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="821"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="258"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="799"/>
         <source>I&apos;m Logged In - Export Data</source>
         <translation>Ik ben aangemeld - Gegevens exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="269"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="260"/>
         <source>Click this after logging in and navigating to your map</source>
         <translation>Klik hierop na het aanmelden en navigeren naar uw kaart</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="272"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="263"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="378"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="369"/>
         <source>Initialization Error</source>
         <translation>Initialisatiefout</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="379"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="370"/>
         <source>Failed to initialize CalTopo browser:
 {error}</source>
         <translation>Kan CalTopo-browser niet initialiseren:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="423"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="414"/>
         <source>Failed to Load</source>
         <translation>Laden mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="425"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Kan CalTopo niet laden. Controleer uw internetverbinding en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="456"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="447"/>
         <source>Current map: {map_id}</source>
         <translation>Huidige kaart: {map_id}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="484"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="475"/>
         <source>No Map Selected</source>
         <translation>Geen kaart geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1751,33 +1751,33 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
 De kaart-URL moet een kaart-ID bevatten (bijv. /m/ABC123 of #id=ABC123).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="495"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="486"/>
         <source>Browser Not Ready</source>
         <translation>Browser niet gereed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="496"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>De CalTopo-browser laadt nog. Wacht even en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="504"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="493"/>
         <source>Starting export...</source>
         <translation>Export starten...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="522"/>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="782"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="762"/>
         <source>Authentication Failed</source>
         <translation>Authenticatie mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser niet geïnitialiseerd. Probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="784"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1983,13 +1983,13 @@ Controleer:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="487"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1292"/>
         <source>Offline Mode Enabled</source>
         <translation>Offline-modus ingeschakeld</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="489"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1303"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1294"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2005,13 +2005,13 @@ Schakel Alleen offline uit om naar CalTopo te exporteren.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="500"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1305"/>
         <source>Nothing Selected</source>
         <translation>Niets geselecteerd</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="502"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1316"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1307"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Selecteer ten minste één gegevenstype (gemarkeerde AOI&apos;s, drone-/afbeeldingslocaties of dekkingsgebied) om te exporteren.</translation>
     </message>
@@ -2121,7 +2121,7 @@ Zorg dat uw afbeeldingen GPS-coördinaten hebben en nadirale opnamen zijn.</tran
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="636"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="679"/>
         <source>No Map Selected</source>
         <translation>Geen kaart geselecteerd</translation>
     </message>
@@ -2137,7 +2137,7 @@ De kaart-URL moet er zo uitzien:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="685"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2146,7 +2146,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Open uw kaart in het CalTopo-venster voordat u op &apos;Ik ben aangemeld - Gegevens exporteren&apos; klikt.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1618"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1607"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2155,12 +2155,12 @@ The reason was written to the log (adiat_logs.txt) and the console.</source>
 De reden is vastgelegd in het logbestand (adiat_logs.txt) en de console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
         <source>Photos uploaded: {uploaded} of {total}.</source>
         <translation>Geüploade foto&apos;s: {uploaded} van {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1635"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1624"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2169,7 +2169,7 @@ The items should now be visible on your map.</source>
 De items zouden nu op uw kaart zichtbaar moeten zijn.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1644"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2178,30 +2178,30 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Details over wat is mislukt, staan in het logbestand (adiat_logs.txt) en de console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1633"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1622"/>
         <source>Export Successful</source>
         <translation>Export geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1642"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
         <source>Partial Success</source>
         <translation>Gedeeltelijk geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1616"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1605"/>
         <source>Export Failed</source>
         <translation>Export mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="726"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1381"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1576"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1372"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1567"/>
         <source>Export Error</source>
         <translation>Exportfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="728"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1578"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1569"/>
         <source>An error occurred during CalTopo export:
 
 {error}</source>
@@ -2210,7 +2210,7 @@ Details over wat is mislukt, staan in het logbestand (adiat_logs.txt) en de cons
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1058"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1049"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2219,42 +2219,42 @@ Gebied in vierkante meter: {sqm:.0f} m²
 Aantal hoeken: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1529"/>
         <source>Exporting to CalTopo</source>
         <translation>Exporteren naar CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1269"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1260"/>
         <source>Logged Out</source>
         <translation>Afgemeld</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1270"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1261"/>
         <source>Successfully logged out from CalTopo.</source>
         <translation>Succesvol afgemeld bij CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1420"/>
         <source>Loading CalTopo Maps</source>
         <translation>CalTopo-kaarten laden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1432"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1423"/>
         <source>Connecting to CalTopo...</source>
         <translation>Verbinden met CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1433"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1424"/>
         <source>Fetching account data and maps...</source>
         <translation>Accountgegevens en kaarten ophalen...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1488"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1479"/>
         <source>Connection Error</source>
         <translation>Verbindingsfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1481"/>
         <source>An error occurred while connecting to CalTopo API:
 
 {error}</source>
@@ -2263,18 +2263,18 @@ Aantal hoeken: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="698"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1493"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="694"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1484"/>
         <source>Authentication Failed</source>
         <translation>Authenticatie mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="699"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
         <source>No CalTopo session cookies were captured. Please log in and try again.</source>
         <translation>Er zijn geen CalTopo-sessiecookies vastgelegd. Meld u aan en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1383"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1374"/>
         <source>An error occurred during CalTopo API export:
 
 {error}</source>
@@ -2283,7 +2283,7 @@ Aantal hoeken: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1495"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1486"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2296,12 +2296,12 @@ De reden is vastgelegd in het logbestand (adiat_logs.txt) en de console.
 Wilt u uw team-ID, referentie-ID en referentiegeheim opnieuw invoeren?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1541"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1532"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exporteren naar CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1542"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1533"/>
         <source>Preparing data and exporting...</source>
         <translation>Gegevens voorbereiden en exporteren...</translation>
     </message>
@@ -15857,22 +15857,22 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Fouten:          {n}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="161"/>
-        <source>⚠ Capture-time warnings (camera clock is suspect):</source>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="164"/>
+        <source>⚠ Metadata warnings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="166"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="169"/>
         <source>Per-image errors:</source>
         <translation>Fouten per afbeelding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="183"/>
         <source>Cancelling...</source>
         <translation>Annuleren...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="181"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="184"/>
         <source>Cancellation requested...</source>
         <translation>Annulering aangevraagd...</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -10359,32 +10359,37 @@ Verwachte bestandsnamen:
         <translation>Tijdzone van opname geschat op basis van GPS-locatie.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="548"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <source>Using repaired capture time (camera clock fault).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
         <source>the sun was below the horizon at capture</source>
         <translation>de zon stond tijdens de opname onder de horizon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="550"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
         <source>sun position unavailable</source>
         <translation>zonnestand niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Schaduw niet beschikbaar: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Plaats de persoon en schaduw op het DEM-terreinoppervlak</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="654"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terreingegevens (DEM) zijn niet beschikbaar voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="914"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Choose Overlay Color</source>
         <translation>Overlaykleur kiezen</translation>
     </message>
@@ -15797,6 +15802,114 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2173"/>
         <source>Loading gallery...</source>
         <translation>Galerij laden...</translation>
+    </message>
+</context>
+<context>
+    <name>WaldoClockCorrectionDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="77"/>
+        <source>WALDO Camera Clock Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="99"/>
+        <source>The camera clock on these images appears to be misconfigured:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
+        <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="120"/>
+        <source> hours</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="121"/>
+        <source>Clock face error to remove:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
+        <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="130"/>
+        <source>True camera time zone:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="139"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="159"/>
+        <source>Apply Correction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="163"/>
+        <source>Not Now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="166"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="170"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="231"/>
+        <source>Enter a valid time zone (IANA name or UTC offset in hours).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="239"/>
+        <source>{name}: camera says {before}  →  corrected {after}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="245"/>
+        <source>Correction preview unavailable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="272"/>
+        <source>Stamping corrected capture times...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="292"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished">Annuleren...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="308"/>
+        <source>Corrected:        {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="309"/>
+        <source>Already corrected: {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="310"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Fouten:          {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="313"/>
+        <source>Cancelled - remaining images are uncorrected.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
**Stacked on #131** — the first two commits are that PR; review only the last commit here. Merging #131 first will reduce this diff to the clock-correction commit alone.

## Problem

The WALDO pod's camera writes a wrong timezone field (UTC−6 at a UTC−8 longitude) **and** a 12-hour AM/PM clock-face flip. Combined ~11 h effective error: every sun/shadow computation is silently wrong while nothing looks broken (a 12 h flip produces nearly the same solar elevation). Fixing the camera only helps future flights — existing datasets stay poisoned.

## Fix: detect → confirm → stamp (EXIF never modified)

- **Detection** (`propose_clock_correction`) samples a few files for *provable* symptoms:
  - stamped timezone inconsistent with the GPS longitude, and/or
  - claimed capture time AFTER the file's own mtime — impossible, so the clock provably runs ahead. The flip *magnitude* is deliberately not inferred from mtime: the post-flight download delay offsets it (field data showed a 12 h flip as just 28 min of ahead-margin).
  - The −12 h flip is proposed as default only when the ahead-proof exists; a timezone mismatch alone proposes a pure zone fix and the operator adds the flip after checking the live preview against the real flight window.
- **Confirmation dialog** shows the evidence, editable face-shift/timezone (IANA name or fixed offset) with a live before→after preview, then applies with progress. Per-folder accept/decline is remembered; a remembered acceptance re-applies automatically to images added later, without re-asking.
- **Stamping** (`apply_clock_correction`) writes `waldo:CaptureUtcCorrected` (+ the shift and zone used) per image — idempotent, non-destructive. The true zone comes from the GPS position via the existing timezonefinder dependency, so DST is correct per capture date.
- **Consumption**: `resolve_capture_utc` prefers the corrected stamp over all EXIF fields; the person-reference dialog labels the repaired time source; the capture-time audit goes quiet on corrected images.
- **Ordering matters**: the controller runs detection BEFORE the pre-pass stamps anything — stamping rewrites the files and resets the mtimes the ahead-proof depends on.

## Validation

- 31 new tests: detection positive/negative/degraded cases, DST-aware correction math (PDT vs PST), idempotent apply + cancel, resolver preference across XMP key shapes, dialog flow (confirm/edit/decline/auto), controller decision persistence. Affected suites 141 green, flake8 clean, translations extracted.
- Live read-only run against three real Siskiyou flights: the never-restamped flight gets the full −12 h proposal automatically (corrected sample lands in the known morning flight window); previously-stamped flights (mtime evidence destroyed by earlier pre-pass writes) still get the zone-fix offer with the documented caution.