### PR TITLE
fix(waldo): cam1 180° orientation, flight-axis roll in all renderers, clock amendment

### DIFF
--- a/app/core/controllers/images/viewer/WaldoPrePassController.py
+++ b/app/core/controllers/images/viewer/WaldoPrePassController.py
@@ -13,17 +13,16 @@ non-destructive corrected capture time (stamped in the waldo XMP namespace).
 The per-folder decision is remembered in settings.
 """
 
-import json
 import os
 from typing import List, Optional
 
 from core.services.LoggerService import LoggerService
 from core.services.SettingsService import SettingsService
 from core.services.waldo import WaldoMetadataService
+from core.services.waldo import WaldoClockDecisions
+from core.services.waldo.WaldoClockDecisions import CLOCK_DECISIONS_SETTING
 from core.views.images.viewer.dialogs.WaldoPrePassDialog import WaldoPrePassDialog
 from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import WaldoClockCorrectionDialog
-
-CLOCK_DECISIONS_SETTING = 'WaldoClockCorrections'
 
 
 class WaldoPrePassController:
@@ -104,19 +103,10 @@ class WaldoPrePassController:
     # ------------------------------------------------------------------
 
     def _clock_decisions(self) -> dict:
-        raw = self.settings_service.get_setting(CLOCK_DECISIONS_SETTING)
-        if not raw:
-            return {}
-        try:
-            decisions = json.loads(raw)
-            return decisions if isinstance(decisions, dict) else {}
-        except (TypeError, ValueError):
-            return {}
+        return WaldoClockDecisions.get_decisions(self.settings_service)
 
     def _store_clock_decision(self, folder_key: str, decision: dict):
-        decisions = self._clock_decisions()
-        decisions[folder_key] = decision
-        self.settings_service.set_setting(CLOCK_DECISIONS_SETTING, json.dumps(decisions))
+        WaldoClockDecisions.store_decision(folder_key, decision, self.settings_service)
 
     def _offer_clock_correction(self, waldo_paths: List[str], proposal,
                                 service: Optional[WaldoMetadataService] = None):
@@ -127,22 +117,40 @@ class WaldoPrePassController:
         'declined' suppresses the offer; a remembered acceptance re-applies
         silently (progress only) so images added to the folder later get
         corrected without re-asking.
+
+        When no fault proposal exists but an APPLIED correction fails the
+        physical sanity check (sun below the horizon on daylight imagery),
+        an amendment prefilled from the stamped values is offered instead -
+        overriding any remembered decision, since the evidence contradicts
+        it.
         """
-        if not waldo_paths or proposal is None:
+        if not waldo_paths:
             return
         try:
             if service is None:
                 service = WaldoMetadataService(terrain_service=None)
 
+            amend_reason = None
+            if proposal is None:
+                amend_reason = service.stamped_correction_suspect(waldo_paths)
+                if amend_reason is None:
+                    return
+                proposal = service.propose_amendment(waldo_paths)
+                if proposal is None:
+                    return
+                proposal.evidence.insert(0, amend_reason)
+
             folder_key = os.path.normcase(os.path.abspath(os.path.dirname(waldo_paths[0])))
             decision = self._clock_decisions().get(folder_key)
-            if decision and decision.get('decision') == 'declined':
+            if amend_reason is None and decision and decision.get('decision') == 'declined':
                 self.logger.info(
                     "WaldoPrePassController: clock fault detected but correction "
                     "was previously declined for this folder.")
                 return
 
-            auto = bool(decision and decision.get('decision') == 'accepted')
+            # A failed sanity check always re-asks; never silently re-applies.
+            auto = (amend_reason is None
+                    and bool(decision and decision.get('decision') == 'accepted'))
             if auto:
                 proposal.face_shift_h = int(decision.get('face_shift_h', proposal.face_shift_h))
                 tz_text = decision.get('tz_text')

--- a/app/core/services/coverage/kernel.py
+++ b/app/core/services/coverage/kernel.py
@@ -37,11 +37,16 @@ from core.services.coverage.contracts import (
 )
 
 
-def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float) -> np.ndarray:
+def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float,
+                          roll_axis_deg: Optional[float] = None) -> np.ndarray:
     """3x3 rotation from camera frame (X=right, Y=down, Z=optical) to NED.
 
-    Mirrors ``AOIService._calculate_ground_position`` step 2 (+ Rodrigues roll
-    about the heading axis) so this kernel and the viewer FOV stay consistent.
+    Mirrors ``AOIService._calculate_ground_position`` step 2 (+ Rodrigues
+    roll) so this kernel and the viewer FOV stay consistent. The roll
+    rotates about the camera-yaw azimuth by default; ``roll_axis_deg``
+    overrides the axis azimuth for stamps that express roll about the
+    FLIGHT axis (WALDO processor version >= 6) - using the wrong axis
+    mirrors the footprint to the opposite side of the track.
     """
     opt_elevation = math.radians(pitch_deg)
     opt_azimuth = math.radians(yaw_deg)
@@ -64,7 +69,9 @@ def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float) -> 
 
     if roll_deg != 0.0:
         roll_rad = math.radians(roll_deg)
-        heading_axis = np.array([math.cos(opt_azimuth), math.sin(opt_azimuth), 0.0])
+        axis_azimuth = (math.radians(roll_axis_deg)
+                        if roll_axis_deg is not None else opt_azimuth)
+        heading_axis = np.array([math.cos(axis_azimuth), math.sin(axis_azimuth), 0.0])
         kx, ky, kz = heading_axis
         K = np.array([
             [0.0, -kz, ky],
@@ -92,7 +99,8 @@ def project_footprint_corners(fg, params) -> List[Tuple[float, float]]:
     Used only to size the frame bbox.
     """
     hw, hh = _frustum_half_extents(fg)
-    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg)
+    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg,
+                              roll_axis_deg=getattr(fg, 'roll_axis_deg', None))
     corners = []
     for sx in (-hw, hw):
         for sy in (-hh, hh):
@@ -156,7 +164,8 @@ def compute_target_mask_and_gsd(dem: np.ndarray, spec: GridSpec, fg,
     dn = (ys[:, np.newaxis] - cam_y) * meters_per_unit      # (H, 1) north meters
     dd = cam_z - dem                                        # (H, W) down meters
 
-    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg)
+    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg,
+                              roll_axis_deg=getattr(fg, 'roll_axis_deg', None))
     Rt = R.T  # camera <- NED
     # p_cam = R^T @ [north, east, down]
     px = Rt[0, 0] * dn + Rt[0, 1] * de + Rt[0, 2] * dd

--- a/app/core/services/image/CoverageExtentService.py
+++ b/app/core/services/image/CoverageExtentService.py
@@ -276,9 +276,14 @@ class CoverageExtentService:
             # Calculate the four corners of the image in GPS coordinates
             # Corners in image space (centered at the drone-nadir point on the
             # ground plane). Outward roll shifts that center cross-track by
-            # h*tan(roll); positive roll points the optical axis to the LEFT
-            # of heading (matches AOIService convention), so the centroid
-            # offset along the camera-X (right) axis is -h*tan(roll).
+            # h*tan(roll). The AXIS the roll rotates about depends on the
+            # stamping convention: WALDO processor version >= 6 expresses it
+            # about the FLIGHT axis (positive roll tilts LEFT of the flight
+            # direction), older stamps about the camera-yaw axis (positive
+            # roll tilts LEFT of the image-up bearing). Using the wrong axis
+            # mirrors the footprint to the opposite side of the track, so the
+            # shift is computed in earth (east/north) space and added after
+            # the corner rotation.
             agl_m = effective_agl_m  # DEM-corrected AGL when terrain resolved
             if agl_m is None or agl_m <= 0:
                 agl_m = image_service.get_relative_altitude('m')
@@ -288,13 +293,29 @@ class CoverageExtentService:
                     agl_m = self.custom_altitude_ft / 3.28084
                 else:
                     agl_m = 0.0
-            roll_offset_x = -agl_m * math.tan(math.radians(gimbal_roll))
+
+            roll_east_m = 0.0
+            roll_north_m = 0.0
+            if gimbal_roll:
+                roll_axis = None
+                try:
+                    axis_raw = image_service.get_roll_axis_azimuth()
+                    roll_axis = float(axis_raw) if axis_raw is not None else None
+                except Exception:
+                    roll_axis = None
+                # Positive roll points the optical axis LEFT of the axis
+                # bearing (AOIService Rodrigues convention).
+                axis_bearing = roll_axis if roll_axis is not None else bearing
+                left_bearing = math.radians(axis_bearing - 90.0)
+                offset_m = agl_m * math.tan(math.radians(gimbal_roll))
+                roll_east_m = offset_m * math.sin(left_bearing)
+                roll_north_m = offset_m * math.cos(left_bearing)
 
             corners_image = [
-                (roll_offset_x - width_m / 2, -height_m / 2),  # Top-left
-                (roll_offset_x + width_m / 2, -height_m / 2),  # Top-right
-                (roll_offset_x + width_m / 2, height_m / 2),   # Bottom-right
-                (roll_offset_x - width_m / 2, height_m / 2)    # Bottom-left
+                (-width_m / 2, -height_m / 2),  # Top-left
+                (width_m / 2, -height_m / 2),   # Top-right
+                (width_m / 2, height_m / 2),    # Bottom-right
+                (-width_m / 2, height_m / 2)    # Bottom-left
             ]
 
             # Rotate corners by bearing and convert to GPS
@@ -308,6 +329,10 @@ class CoverageExtentService:
                 # Rotate
                 x_rot = x * cos_b - y * sin_b
                 y_rot = x * sin_b + y * cos_b
+
+                # Apply the cross-track roll shift in earth space
+                x_rot += roll_east_m
+                y_rot += roll_north_m
 
                 # Convert to lat/lon offset
                 delta_lat = y_rot / self.earth_radius * (180 / math.pi)

--- a/app/core/services/image/FrameGeometry.py
+++ b/app/core/services/image/FrameGeometry.py
@@ -53,6 +53,10 @@ class FrameGeometry:
     bearing_confidence: float                    # 1.0 for gimbal/flight; mapped for 'calculated'; 0.25 for 'default'
     asl_alt_m: Optional[float] = None            # raw EXIF ASL altitude (datum fallback only)
     cam_elev_m: Optional[float] = None           # filled by the caller: DEM(nadir) + agl_m
+    # Azimuth of the axis roll_deg rotates about; None = camera-yaw axis.
+    # WALDO processor version >= 6 expresses roll about the FLIGHT axis -
+    # rolling about the wrong axis mirrors the footprint across the track.
+    roll_axis_deg: Optional[float] = None
 
     @classmethod
     def from_image_service(cls, image_service: "ImageService",
@@ -105,6 +109,14 @@ class FrameGeometry:
             if abs(roll_deg) > 90.0:
                 roll_deg = 0.0
 
+            roll_axis_deg = None
+            if roll_deg:
+                try:
+                    axis_raw = image_service.get_roll_axis_azimuth()
+                    roll_axis_deg = float(axis_raw) if axis_raw is not None else None
+                except Exception:
+                    roll_axis_deg = None
+
             return cls(
                 lat=lat,
                 lon=lon,
@@ -120,6 +132,7 @@ class FrameGeometry:
                 bearing_confidence=cls._confidence_for(yaw_source, bearing_quality),
                 asl_alt_m=image_service.get_asl_altitude('m'),
                 cam_elev_m=None,
+                roll_axis_deg=roll_axis_deg,
             )
         except Exception:
             return None

--- a/app/core/services/waldo/WaldoClockDecisions.py
+++ b/app/core/services/waldo/WaldoClockDecisions.py
@@ -1,0 +1,50 @@
+"""
+WaldoClockDecisions - Per-folder persistence of clock-correction choices.
+
+Stores the operator's accept/decline decision (and the accepted values) for
+each image folder in application settings, so the pre-pass neither re-asks
+on every open nor silently re-applies stale values after an amendment.
+Shared by WaldoPrePassController (folder-open flow) and the Person
+Reference dialog's manual "Adjust clock" flow.
+"""
+
+import json
+import os
+from typing import Optional
+
+from core.services.SettingsService import SettingsService
+
+CLOCK_DECISIONS_SETTING = 'WaldoClockCorrections'
+
+
+def folder_key_for(path: str) -> str:
+    """Canonical settings key for the folder containing an image path."""
+    return os.path.normcase(os.path.abspath(os.path.dirname(path)))
+
+
+def get_decisions(settings_service: Optional[SettingsService] = None) -> dict:
+    """All stored per-folder decisions ({folder_key: decision_dict})."""
+    settings_service = settings_service or SettingsService()
+    raw = settings_service.get_setting(CLOCK_DECISIONS_SETTING)
+    if not raw:
+        return {}
+    try:
+        decisions = json.loads(raw)
+        return decisions if isinstance(decisions, dict) else {}
+    except (TypeError, ValueError):
+        return {}
+
+
+def get_decision(folder_key: str,
+                 settings_service: Optional[SettingsService] = None) -> Optional[dict]:
+    """The stored decision for one folder, or None."""
+    return get_decisions(settings_service).get(folder_key)
+
+
+def store_decision(folder_key: str, decision: dict,
+                   settings_service: Optional[SettingsService] = None):
+    """Persist (or overwrite) the decision for one folder."""
+    settings_service = settings_service or SettingsService()
+    decisions = get_decisions(settings_service)
+    decisions[folder_key] = decision
+    settings_service.set_setting(CLOCK_DECISIONS_SETTING, json.dumps(decisions))

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -62,7 +62,16 @@ WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
 # heading - 15 of 1464 images on field data), and cannot handle frames
 # re-flown in the opposite direction. The bump restamps existing datasets
 # so those images get corrected on their next open.
-WALDO_PROCESSOR_VERSION = "8"
+# Version 9: cam 1 is stored with image-top = plane FORWARD, not backward.
+# Content-vs-GPS-motion measurement on two independent flights proved the
+# two cameras come out of the WALDO ground software rotated 180 deg from
+# each other (the pods are body-opposed); v5..v8 stamped both cams
+# image-top = backward, so every 1_* image had its pixel-to-ground mapping
+# rotated 180 deg. The orientation safety net also aggregates in
+# track-RELATIVE space now: the old absolute circular mean mixed opposite
+# serpentine lanes into meaningless statistics and silently fell back to
+# the (wrong, for cam 1) model.
+WALDO_PROCESSOR_VERSION = "9"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 
@@ -77,6 +86,14 @@ CLOCK_TIMEZONE_XMP = "ClockTimeZone"
 STATIONARY_THRESHOLD_M = 5.0
 MAX_NEIGHBOR_DT_S = 30.0
 OUTWARD_ROLL_DEG = 22.5
+
+# Mounting-model image-top offset from the plane heading, per camera.
+# The two DSLR bodies are mounted opposed, and the ground software keeps
+# each body's native orientation: cam 0 (`0_*`, RIGHT pod) comes out with
+# image-top = plane BACKWARD, cam 1 (`1_*`, LEFT pod) with image-top =
+# plane FORWARD. Field-verified by inter-frame content motion vs the GPS
+# track on two independent flights (2026-07-25 and 2026-08-07).
+MODEL_IMAGE_UP_OFFSET_DEG = {0: 180.0, 1: 0.0}
 
 # Orientation-measurement tunables. Field imagery showed the mounting-model
 # yaw assumption off by ~41 degrees (post-flight software had normalized the
@@ -201,23 +218,25 @@ class WaldoMetadataService:
 
     @staticmethod
     def compute_optical_axis_angles(heading_deg: float, cam_idx: int,
-                                    image_up_deg: Optional[float] = None) -> Dict[str, float]:
+                                    measured_orientation: Optional[Tuple[str, float]] = None
+                                    ) -> Dict[str, float]:
         """Return drone-dji-style gimbal triple for a WALDO capture.
 
         Yaw — the compass bearing of the stored JPEG's top edge, which is
         what AOIService and the FOV-box renderer consume:
 
-        - When `image_up_deg` is given it is the *measured* orientation
-          (from inter-frame content motion vs the GPS track; see
-          measure_image_up_bearing) and is used directly. Field imagery
-          proved the mounting model below wrong by ~41° on flights whose
-          post-flight software had normalized frames north-up, so a
-          measurement always wins over the model.
-        - Fallback (no measurement): the pod-mounting model, per WALDO
-          operator 2026-05-04 + screenshot. Cam 0 (`0_*`, RIGHT pod) is
-          stored rotated 180° by post-flight software; cam 1 (`1_*`,
-          LEFT pod) has body top facing the tail. Both stored images then
-          share image-top = plane backward: `yaw = heading + 180°`.
+        - Default: the pod-mounting model. The two DSLR bodies are mounted
+          opposed and each keeps its native orientation through the ground
+          software, so the image-top offset from the plane heading is
+          per-camera (MODEL_IMAGE_UP_OFFSET_DEG): cam 0 backward, cam 1
+          FORWARD. v5..v8 wrongly stamped both cams backward — every 1_*
+          image was 180 deg off (field-verified 2026-08-07).
+        - `measured_orientation` overrides the model when the inter-frame
+          content-motion measurement confidently contradicts it (see
+          measure_image_up_orientation). It is ('offset', deg) for a
+          track-relative image-top offset (normal WALDO storage), or
+          ('absolute', deg) for a fixed compass image-top (post-flight
+          software that normalizes frames, e.g. north-up).
 
         Roll — the pods physically tilt ±OUTWARD_ROLL_DEG cross-track
         (cam 0 to plane RIGHT, cam 1 to plane LEFT). As of processor
@@ -232,10 +251,16 @@ class WaldoMetadataService:
         """
         if cam_idx not in (0, 1):
             raise ValueError(f"Invalid WALDO cam_idx {cam_idx}")
-        if image_up_deg is not None:
-            yaw = float(image_up_deg) % 360.0
+        if measured_orientation is not None:
+            mode, value = measured_orientation
+            if mode == 'absolute':
+                yaw = float(value) % 360.0
+            elif mode == 'offset':
+                yaw = (float(heading_deg) + float(value)) % 360.0
+            else:
+                raise ValueError(f"Invalid orientation mode {mode!r}")
         else:
-            yaw = (float(heading_deg) + 180.0) % 360.0
+            yaw = (float(heading_deg) + MODEL_IMAGE_UP_OFFSET_DEG[cam_idx]) % 360.0
         roll = (-OUTWARD_ROLL_DEG) if cam_idx == 0 else (+OUTWARD_ROLL_DEG)
         return {
             'pitch': -90.0,
@@ -325,47 +350,62 @@ class WaldoMetadataService:
         spread_deg = math.degrees(math.sqrt(-2.0 * math.log(resultant)))
         return mean_deg, spread_deg
 
-    def _pair_motion_bearing(self, group: List["WaldoImageRecord"]) -> Optional[Tuple[float, float, int]]:
-        """Coarse image-top bearing from inter-frame motion vs the GPS track.
+    def _pair_motion_samples(self, group: List["WaldoImageRecord"]) -> List[Tuple[float, float, float]]:
+        """Per-pair orientation samples from inter-frame motion vs the track.
+
+        Pairs are name-consecutive frames (spatially adjacent regardless of
+        capture order; the spatial displacement between two frames gives the
+        same absolute image-top either way). Each sample carries the pair's
+        plane heading so the caller can aggregate in track-relative space.
 
         Returns:
-            (mean_deg, spread_deg, sample_count), or None with no usable pairs.
+            list of (image_up_deg, pair_heading_deg, inlier_weight).
         """
         candidates = []
         for a, b in zip(group, group[1:]):
+            if a.heading_deg is None:
+                continue
             north_m = (b.lat - a.lat) * 111320.0
             east_m = (b.lon - a.lon) * 111320.0 * math.cos(math.radians(a.lat))
             dist = math.hypot(north_m, east_m)
             if dist < ORIENTATION_MIN_BASELINE_M:
                 continue
             bearing = math.degrees(math.atan2(east_m, north_m)) % 360.0
-            candidates.append((a.path, b.path, bearing))
-        if not candidates:
-            return None
+            candidates.append((a.path, b.path, bearing, a.heading_deg))
 
-        step = max(1, len(candidates) // ORIENTATION_SAMPLE_PAIRS)
+        step = max(1, len(candidates) // ORIENTATION_SAMPLE_PAIRS) if candidates else 1
         samples = []
-        for path_a, path_b, bearing in candidates[::step][:ORIENTATION_SAMPLE_PAIRS]:
+        for path_a, path_b, bearing, heading in candidates[::step][:ORIENTATION_SAMPLE_PAIRS]:
             result = self._pair_orientation_sample(path_a, path_b, bearing)
             if result is not None:
-                samples.append(result)
-        if len(samples) < 2:
-            return None
-        mean_deg, spread_deg = self._circular_stats(
-            [s[0] for s in samples], [s[1] for s in samples])
-        return mean_deg, spread_deg, len(samples)
+                image_up, inliers = result
+                samples.append((image_up, heading, float(inliers)))
+        return samples
 
-    def measure_image_up_bearing(self, records: List["WaldoImageRecord"],
-                                 cam_idx: int) -> Optional[float]:
-        """Return a measured image-top bearing ONLY when it refutes the model.
+    def measure_image_up_orientation(self, records: List["WaldoImageRecord"],
+                                     cam_idx: int) -> Optional[Tuple[str, float]]:
+        """Measure the stored image orientation; report ONLY refutations.
 
         The inter-frame-motion measurement is too noisy on tilted fixed-wing
         imagery over relief to fine-tune the mounting model, but a dataset
-        whose frames were re-oriented by post-flight software reads far away
-        from the model (typically ~180 deg) - far beyond measurement noise.
-        So: measure, and return the measurement only when it is confident
-        AND disagrees with the model by more than ORIENTATION_OVERRIDE_DEG.
-        Returns None otherwise (caller stamps the mounting model).
+        whose frames were re-oriented reads far from the model (typically
+        ~180 deg) - far beyond measurement noise.
+
+        Samples are aggregated in TWO spaces and the tighter one wins:
+        - track-RELATIVE (image_up minus plane heading): normal WALDO
+          storage, where the orientation follows the flight direction. A
+          plain absolute mean would blend opposite serpentine lanes into
+          garbage statistics - exactly how the v5..v8 cam-1 fault stayed
+          invisible.
+        - ABSOLUTE compass: post-flight software that normalizes frames
+          (e.g. north-up) gives a constant absolute orientation, which the
+          relative space would scramble on serpentine flights.
+
+        Returns:
+            ('offset', deg) or ('absolute', deg) when the confident winner
+            contradicts the mounting model by more than
+            ORIENTATION_OVERRIDE_DEG; None otherwise (caller stamps the
+            model).
         """
         group = [r for r in records
                  if r.cam_idx == cam_idx and r.lat is not None and r.lon is not None]
@@ -373,37 +413,69 @@ class WaldoMetadataService:
         if not group:
             return None
 
-        motion = self._pair_motion_bearing(group)
-        if motion is None:
-            return None
-        mean_deg, spread_deg, count = motion
-        stderr_deg = spread_deg / math.sqrt(count)
-        if count < ORIENTATION_MIN_PAIRS or stderr_deg > ORIENTATION_MAX_STDERR_DEG:
+        samples = self._pair_motion_samples(group)
+        if len(samples) < ORIENTATION_MIN_PAIRS:
             self.logger.info(
                 f"WALDO cam {cam_idx}: orientation measurement inconclusive "
-                f"({count} pairs, stderr {stderr_deg:.1f} deg); using the mounting model"
+                f"({len(samples)} pairs); using the mounting model"
             )
             return None
 
-        headings = [r.heading_deg for r in group if r.heading_deg is not None]
-        if not headings:
+        weights = [s[2] for s in samples]
+        rel_mean, rel_spread = self._circular_stats(
+            [(s[0] - s[1]) % 360.0 for s in samples], weights)
+        abs_mean, abs_spread = self._circular_stats(
+            [s[0] for s in samples], weights)
+        count = len(samples)
+
+        headings = [s[1] for s in samples]
+        mean_heading, heading_spread = self._circular_stats(headings, weights)
+
+        if rel_spread <= abs_spread:
+            mode, mean_deg, spread_deg = 'offset', rel_mean, rel_spread
+            model_deg = MODEL_IMAGE_UP_OFFSET_DEG[cam_idx]
+        else:
+            mode, mean_deg, spread_deg = 'absolute', abs_mean, abs_spread
+            model_deg = (mean_heading + MODEL_IMAGE_UP_OFFSET_DEG[cam_idx]) % 360.0
+
+        stderr_deg = spread_deg / math.sqrt(count)
+        if stderr_deg > ORIENTATION_MAX_STDERR_DEG:
+            self.logger.info(
+                f"WALDO cam {cam_idx}: orientation measurement inconclusive "
+                f"({count} pairs, {mode} stderr {stderr_deg:.1f} deg); "
+                f"using the mounting model"
+            )
             return None
-        mean_heading, _ = self._circular_stats(headings, [1.0] * len(headings))
-        model_deg = (mean_heading + 180.0) % 360.0
+
+        if mode == 'absolute' and heading_spread > 45.0:
+            # A confident constant-ABSOLUTE orientation on a flight with
+            # mixed headings (serpentine) cannot come from any track-relative
+            # mounting: the frames were normalized by post-flight software.
+            # The mean-heading model comparison below would be degenerate, so
+            # this is a contradiction by construction.
+            self.logger.warning(
+                f"WALDO cam {cam_idx}: frames read a constant absolute "
+                f"orientation ({mean_deg:.1f} deg, {count} pairs, stderr "
+                f"{stderr_deg:.1f} deg) across mixed headings (spread "
+                f"{heading_spread:.0f} deg) - post-flight normalized imagery; "
+                f"stamping the measurement"
+            )
+            return ('absolute', mean_deg)
+
         gap = abs((mean_deg - model_deg + 180.0) % 360.0 - 180.0)
         if gap <= ORIENTATION_OVERRIDE_DEG:
             self.logger.info(
-                f"WALDO cam {cam_idx}: measured orientation {mean_deg:.1f} deg agrees "
-                f"with the mounting model {model_deg:.1f} deg (gap {gap:.1f} deg); "
+                f"WALDO cam {cam_idx}: measured orientation ({mode} {mean_deg:.1f} deg) "
+                f"agrees with the mounting model ({model_deg:.1f} deg, gap {gap:.1f}); "
                 f"stamping the model"
             )
             return None
         self.logger.warning(
-            f"WALDO cam {cam_idx}: measured orientation {mean_deg:.1f} deg "
-            f"({count} pairs, stderr {stderr_deg:.1f} deg) contradicts the mounting "
-            f"model {model_deg:.1f} deg (gap {gap:.1f} deg); stamping the measurement"
+            f"WALDO cam {cam_idx}: measured orientation ({mode} {mean_deg:.1f} deg, "
+            f"{count} pairs, stderr {stderr_deg:.1f} deg) contradicts the mounting "
+            f"model ({model_deg:.1f} deg, gap {gap:.1f} deg); stamping the measurement"
         )
-        return mean_deg
+        return (mode, mean_deg)
 
     # ------------------------------------------------------------------
     # Capture-time audit
@@ -687,6 +759,110 @@ class WaldoMetadataService:
                 )
             except Exception as e:
                 self.logger.warning(f"Clock-correction detection failed for {name}: {e}")
+        return None
+
+    @staticmethod
+    def get_correction_stamp_details(image_path: str) -> Optional[Tuple[float, str]]:
+        """(face_shift_h, tz_text) parsed from an image's correction stamp."""
+        try:
+            xmp = MetaDataHelper.get_xmp_data_merged(image_path) or {}
+        except Exception:
+            return None
+        shift_raw = None
+        tz_raw = None
+        for prefix in ('waldo:', '', 'XMP-waldo:'):
+            shift_raw = shift_raw or xmp.get(f'{prefix}{CLOCK_FACE_SHIFT_XMP}')
+            tz_raw = tz_raw or xmp.get(f'{prefix}{CLOCK_TIMEZONE_XMP}')
+        if shift_raw is None or tz_raw is None:
+            return None
+        try:
+            return float(str(shift_raw)), str(tz_raw)
+        except ValueError:
+            return None
+
+    def propose_amendment(self, paths: List[str]) -> Optional[ClockCorrectionProposal]:
+        """Build a proposal PRE-FILLED from an already-stamped correction.
+
+        Used when the operator wants to change an applied correction (the
+        normal detection deliberately goes quiet on corrected images).
+        Returns None when no sampled image carries a correction stamp.
+        """
+        for path in paths[:self.AUDIT_SAMPLE_FILES]:
+            name = os.path.basename(path)
+            try:
+                details = self.get_correction_stamp_details(path)
+                if details is None:
+                    continue
+                shift_h, tz_text = details
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                face_dt = self._parse_exif_face_time(exif)
+                if face_dt is None:
+                    continue
+                tz_name: Optional[str] = None
+                fixed_offset_h: Optional[float] = None
+                try:
+                    ZoneInfo(tz_text)
+                    tz_name = tz_text
+                except Exception:
+                    try:
+                        fixed_offset_h = float(tz_text.replace('UTC', '').strip())
+                    except ValueError:
+                        continue
+                corrected = self.compute_corrected_utc(
+                    face_dt, shift_h, tz_name, fixed_offset_h)
+                return ClockCorrectionProposal(
+                    face_shift_h=int(shift_h),
+                    tz_name=tz_name,
+                    fixed_offset_h=fixed_offset_h,
+                    evidence=[
+                        f"A capture-time correction is already stamped on these "
+                        f"images (face shift {shift_h:+.0f} h, zone {tz_text}). "
+                        f"Applying different values replaces it on every image."
+                    ],
+                    sample_name=name,
+                    sample_face=face_dt.strftime("%Y:%m:%d %H:%M:%S"),
+                    sample_corrected_utc=corrected.strftime("%Y-%m-%d %H:%M:%S UTC"),
+                )
+            except Exception as e:
+                self.logger.warning(f"Clock amendment proposal failed for {name}: {e}")
+        return None
+
+    def stamped_correction_suspect(self, paths: List[str]) -> Optional[str]:
+        """Detect an applied correction that is physically impossible.
+
+        A corrected capture time that puts the sun below the horizon while
+        the image is clearly daylight proves the correction is wrong (e.g.
+        a 12-hour shift applied to a camera whose clock face had already
+        been fixed). Returns a human-readable reason, or None.
+        """
+        for path in paths[:self.AUDIT_SAMPLE_FILES]:
+            name = os.path.basename(path)
+            try:
+                stamp = self.get_corrected_utc_stamp(path)
+                if not stamp:
+                    continue
+                corrected_utc = datetime.fromisoformat(stamp).astimezone(timezone.utc)
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                gps = LocationInfo.get_gps(exif_data=exif)
+                if gps is None:
+                    continue
+                elev, _az = get_solar_position(
+                    gps['latitude'], gps['longitude'], corrected_utc)
+                if elev >= -2.0:
+                    continue
+                img = cv2.imdecode(np.fromfile(path, dtype=np.uint8),
+                                   cv2.IMREAD_GRAYSCALE)
+                if img is None:
+                    continue
+                if float(img[::8, ::8].mean()) > self.AUDIT_DAYLIGHT_BRIGHTNESS:
+                    return (
+                        f"{name}: the stamped clock correction puts the capture at "
+                        f"{corrected_utc.strftime('%Y-%m-%d %H:%M UTC')}, when the sun "
+                        f"was below the horizon - but the image is clearly daylight. "
+                        f"The applied correction is wrong."
+                    )
+            except Exception as e:
+                self.logger.warning(f"Correction sanity check failed for {name}: {e}")
         return None
 
     def apply_clock_correction(
@@ -1118,17 +1294,16 @@ class WaldoMetadataService:
         self._apply_trigger_log_headings(records, result)
 
         # 3b. Measure the stored image orientation per camera by comparing
-        #     inter-frame content motion against the GPS track. Post-flight
-        #     software may normalize frames (field data showed north-up
-        #     imagery ~41 deg away from the mounting model), so measurement
-        #     always wins; the model is only the fallback.
-        image_up_by_cam: Dict[int, Optional[float]] = {}
+        #     inter-frame content motion against the GPS track. The mounting
+        #     model is stamped unless the measurement confidently refutes it
+        #     (catches post-flight software that re-orients frames).
+        orientation_by_cam: Dict[int, Optional[Tuple[str, float]]] = {}
         for cam_idx in sorted({r.cam_idx for r in records}):
             if cancel_cb():
                 result.cancelled = True
                 return result
             emit(0, 0, f"Measuring image orientation (cam {cam_idx})...")
-            image_up_by_cam[cam_idx] = self.measure_image_up_bearing(records, cam_idx)
+            orientation_by_cam[cam_idx] = self.measure_image_up_orientation(records, cam_idx)
 
         # 4. Per-image XMP synthesis
         total = len(records)
@@ -1162,7 +1337,7 @@ class WaldoMetadataService:
 
             angles = self.compute_optical_axis_angles(
                 rec.heading_deg, rec.cam_idx,
-                image_up_deg=image_up_by_cam.get(rec.cam_idx)
+                measured_orientation=orientation_by_cam.get(rec.cam_idx)
             )
 
             try:
@@ -1184,9 +1359,9 @@ class WaldoMetadataService:
         """Write the synthesised drone-dji + waldo:Processed fields in one batch.
 
         FlightYawDegree carries the plane's true heading (drone-body direction).
-        GimbalYawDegree carries the per-camera body orientation, which differs
-        from FlightYaw by 180° for cam 1 because that pod is mounted with its
-        body top facing the tail.
+        GimbalYawDegree carries the stored image-top bearing per camera:
+        image-top = plane backward for cam 0, plane FORWARD for cam 1 (the
+        opposed body mounting; see MODEL_IMAGE_UP_OFFSET_DEG).
         """
         flight_yaw = float(plane_heading_deg) % 360.0
         fields = [

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -363,6 +363,13 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.sun_label.setWordWrap(True)
         self.sun_label.setStyleSheet("QLabel { color: gray; }")
 
+        # WALDO imagery: the camera clock is corrected via stamped metadata;
+        # when the rendered shadow reveals a wrong correction, this is the
+        # place the operator notices - offer the amendment right here.
+        # (Visibility is decided in _update_sun_label, after the image loads.)
+        self.adjust_clock_button = QPushButton(self.tr("Adjust camera clock..."))
+        self.adjust_clock_button.setVisible(False)
+
         instructions = QLabel(self.tr(
             "Drag the white handle to position the reference person. "
             "Silhouettes are drawn at true ground scale for this image's "
@@ -375,6 +382,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.recenter_button = QPushButton(self.tr("Recenter"))
         self.close_button = QPushButton(self.tr("Close"))
         button_row.addWidget(self.recenter_button)
+        button_row.addWidget(self.adjust_clock_button)
         button_row.addStretch()
         button_row.addWidget(self.close_button)
 
@@ -400,7 +408,58 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.rotation_spin.valueChanged.connect(self._on_rotation_changed)
         self.color_button.clicked.connect(self._on_color_button_clicked)
         self.recenter_button.clicked.connect(self._recenter)
+        self.adjust_clock_button.clicked.connect(self._on_adjust_clock)
         self.close_button.clicked.connect(self.close)
+
+    def _is_waldo_image(self) -> bool:
+        try:
+            from core.services.waldo import WaldoMetadataService
+            return (self.image_path is not None
+                    and WaldoMetadataService.is_waldo_image(self.image_path) is not None)
+        except Exception:
+            return False
+
+    def _on_adjust_clock(self):
+        """Open the clock-correction dialog for this image's folder.
+
+        Prefilled from the currently stamped correction when one exists,
+        else from fresh fault detection. After an apply, the sun position
+        and shadows re-render with the corrected time.
+        """
+        import glob as _glob
+        import os as _os
+        from core.services.waldo import WaldoMetadataService, WaldoClockDecisions
+        from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import (
+            WaldoClockCorrectionDialog,
+        )
+        try:
+            folder = _os.path.dirname(self.image_path)
+            paths = [p for p in sorted(_glob.glob(_os.path.join(folder, '*.jpg')))
+                     if WaldoMetadataService.is_waldo_image(p) is not None]
+            if not paths:
+                return
+            service = WaldoMetadataService(terrain_service=None)
+            proposal = (service.propose_amendment(paths)
+                        or service.propose_clock_correction(paths))
+            if proposal is None:
+                self.sun_label.setText(self.tr(
+                    "No camera clock fault or applied correction was found "
+                    "for this folder."))
+                return
+            dialog = WaldoClockCorrectionDialog(self, service, paths, proposal)
+            dialog.exec()
+            if dialog.applied:
+                if dialog.remember_choice:
+                    WaldoClockDecisions.store_decision(
+                        WaldoClockDecisions.folder_key_for(paths[0]),
+                        {'decision': 'accepted',
+                         'face_shift_h': dialog.accepted_face_shift_h,
+                         'tz_text': dialog.accepted_tz_text})
+                self._resolve_sun()
+                self._update_sun_label()
+                self._on_params_changed()
+        except Exception as e:
+            LoggerService().error(f"PersonReferenceDialog: clock adjustment failed - {e}")
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -533,6 +592,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
 
     def _update_sun_label(self):
         """Refresh the sun-info line and enable/disable the shadow toggle."""
+        self.adjust_clock_button.setVisible(self._is_waldo_image())
         if self.sun_elev is not None and self.sun_elev > 0:
             text = self.tr(
                 "Sun at capture: {elev:.0f}° above horizon, "

--- a/app/core/views/images/viewer/widgets/GPSMapView.py
+++ b/app/core/views/images/viewer/widgets/GPSMapView.py
@@ -1517,6 +1517,10 @@ class GPSMapView(TranslationMixin, QGraphicsView):
             roll = image_service.get_gimbal_roll() or 0.0
             if abs(roll) > 90.0:
                 roll = 0.0
+            # WALDO v6+ expresses roll about the FLIGHT axis, not the camera
+            # yaw axis - rolling about the wrong axis mirrors the footprint
+            # to the opposite side of the track (matches AOIService).
+            roll_axis = image_service.get_roll_axis_azimuth() if roll else None
 
             # Match AOIService.estimate_aoi_gps altitude determination exactly
             if custom_alt and custom_alt > 0:
@@ -1591,7 +1595,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                     result = AOIService._calculate_ground_position(
                         image_lat, image_lon, u, v, cx, cy,
                         width, height, focal_mm, sensor_w_mm, sensor_h_mm,
-                        effective_agl, pitch, yaw, roll
+                        effective_agl, pitch, yaw, roll,
+                        roll_axis_azimuth_deg=roll_axis
                     )
                     if result is None:
                         raycast_ok = False
@@ -1614,7 +1619,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                                 refined = AOIService._calculate_ground_position(
                                     image_lat, image_lon, u, v, cx, cy,
                                     width, height, focal_mm, sensor_w_mm, sensor_h_mm,
-                                    pt_agl, pitch, yaw, roll
+                                    pt_agl, pitch, yaw, roll,
+                                    roll_axis_azimuth_deg=roll_axis
                                 )
                                 if refined is None:
                                     break
@@ -1642,6 +1648,7 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                         'pitch': pitch,
                         'yaw': yaw,
                         'roll': roll,
+                        'roll_axis': roll_axis,
                         'effective_agl': effective_agl,
                         'drone_absolute_elev': drone_absolute_elev,
                         'terrain_res_m': terrain_res_m,
@@ -1799,6 +1806,7 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                 edge_gps = []
                 raycast_ok = True
                 roll_cached = cache.get('roll', 0.0)
+                roll_axis_cached = cache.get('roll_axis')
                 for u, v in edge_pixels:
                     result = AOIService._calculate_ground_position(
                         image_lat, image_lon, u, v,
@@ -1806,7 +1814,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                         imgWidth, imgHeight,
                         cache['focal_mm'], cache['sensor_w_mm'], cache['sensor_h_mm'],
                         cache['effective_agl'], cache['pitch'], cache['yaw'],
-                        roll_cached
+                        roll_cached,
+                        roll_axis_azimuth_deg=roll_axis_cached
                     )
                     if result is None:
                         raycast_ok = False
@@ -1841,7 +1850,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                                             imgWidth, imgHeight,
                                             cache['focal_mm'], cache['sensor_w_mm'], cache['sensor_h_mm'],
                                             pt_agl, cache['pitch'], cache['yaw'],
-                                            roll_cached
+                                            roll_cached,
+                                            roll_axis_azimuth_deg=roll_axis_cached
                                         )
                                         if refined is None:
                                             break

--- a/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
+++ b/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
@@ -122,3 +122,51 @@ def test_decline_without_remember_is_not_persisted(monkeypatch, tmp_path):
     controller._offer_clock_correction(
         [str(tmp_path / "0_a.jpg")], _proposal(), service=_StubService())
     assert CLOCK_DECISIONS_SETTING not in controller.settings_service.values
+
+
+class _AmendStubService:
+    """No live fault, but a stamped correction that fails the sanity check."""
+
+    def __init__(self, suspect_reason, amend_proposal):
+        self.suspect_reason = suspect_reason
+        self.amend_proposal = amend_proposal
+
+    def stamped_correction_suspect(self, paths):
+        return self.suspect_reason
+
+    def propose_amendment(self, paths):
+        return self.amend_proposal
+
+
+def test_suspect_stamp_triggers_amendment_despite_stored_acceptance(monkeypatch, tmp_path):
+    """A physically impossible applied correction must re-ask, not silently
+    re-apply the remembered (wrong) values."""
+    controller = _make_controller(monkeypatch)
+    paths = [str(tmp_path / "0_a.jpg")]
+    import os
+    folder_key = os.path.normcase(os.path.abspath(str(tmp_path)))
+    controller.settings_service.values[CLOCK_DECISIONS_SETTING] = json.dumps({
+        folder_key: {'decision': 'accepted', 'face_shift_h': -12,
+                     'tz_text': 'America/Los_Angeles'}})
+    _FakeDialog.script = {'applied': True, 'remember': True,
+                          'face_shift': 0, 'tz_text': 'UTC'}
+    service = _AmendStubService("0_a.jpg: sun below horizon on daylight image",
+                                _proposal())
+    controller._offer_clock_correction(paths, None, service=service)
+
+    assert len(_FakeDialog.instances) == 1
+    dlg = _FakeDialog.instances[0]
+    assert dlg.auto_apply is False  # never silently re-apply suspect values
+    assert "sun below horizon" in dlg.proposal.evidence[0]
+    # The new choice replaces the stored decision.
+    stored = json.loads(controller.settings_service.values[CLOCK_DECISIONS_SETTING])
+    assert stored[folder_key] == {'decision': 'accepted', 'face_shift_h': 0,
+                                  'tz_text': 'UTC'}
+
+
+def test_no_proposal_and_healthy_stamp_stays_quiet(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    service = _AmendStubService(None, None)
+    controller._offer_clock_correction(
+        [str(tmp_path / "0_a.jpg")], None, service=service)
+    assert _FakeDialog.instances == []

--- a/app/tests/core/services/coverage/_kernel_helpers.py
+++ b/app/tests/core/services/coverage/_kernel_helpers.py
@@ -19,3 +19,14 @@ def metric_spec(width_m, height_m, cell):
     """A north-up EPSG:3857 GridSpec whose units equal true meters (use
     meters_per_unit=1.0), snapped so the origin sits at (0, 0)."""
     return make_lattice_spec((0.0, 0.0, float(width_m), float(height_m)), float(cell))
+
+
+def make_fg_roll_axis(pitch, yaw, roll, roll_axis, agl=120.0, focal=8.8,
+                      sensor=(13.2, 8.8), size=(4000, 3000)):
+    """FrameGeometry with a WALDO v6+ style flight-axis roll."""
+    return FrameGeometry(
+        lat=38.7, lon=-120.5, agl_m=agl, yaw_deg=yaw, pitch_deg=pitch, roll_deg=roll,
+        focal_mm=focal, sensor_mm=sensor, image_size=size, principal_point_mm=None,
+        yaw_source='gimbal', bearing_confidence=1.0, asl_alt_m=None, cam_elev_m=None,
+        roll_axis_deg=roll_axis,
+    )

--- a/app/tests/core/services/coverage/test_kernel_flat_plane.py
+++ b/app/tests/core/services/coverage/test_kernel_flat_plane.py
@@ -58,3 +58,39 @@ def test_rotated_yaw_preserves_area():
     a0 = int(mask0.sum()) * cell * cell
     a37 = int(mask37.sum()) * cell * cell
     assert a37 == pytest.approx(a0, rel=0.01)
+
+
+def test_footprint_flight_axis_roll_lands_plane_right():
+    """WALDO cam0 v6+ stamp (heading 319.7, image-top backward, roll -22.5
+    about the FLIGHT axis): the footprint centroid must land plane-RIGHT of
+    the track (NE quadrant). Rolling about the camera-yaw axis instead
+    mirrors it to the SW - the map-footprint bug reported from the field."""
+    import math
+    from core.services.coverage.kernel import project_footprint_corners
+    from ._kernel_helpers import make_fg, make_fg_roll_axis
+
+    class _P:
+        max_range_m = 10000.0
+
+    heading = 319.7
+    yaw = (heading + 180.0) % 360.0
+
+    fg_waldo = make_fg_roll_axis(-90.0, yaw, -22.5, heading, agl=776.0,
+                                 focal=50.0, sensor=(36.0, 24.0), size=(8688, 5792))
+    corners = project_footprint_corners(fg_waldo, _P())
+    east = sum(c[0] for c in corners) / 4.0
+    north = sum(c[1] for c in corners) / 4.0
+    # Plane-right of 319.7 = bearing 49.7: east and north both positive,
+    # and the centroid direction matches (the projective corner average
+    # sits farther out than the axis hit, so only direction is asserted).
+    assert east > 100.0 and north > 100.0
+    centroid_bearing = math.degrees(math.atan2(east, north)) % 360.0
+    assert abs(centroid_bearing - 49.7) < 5.0
+
+    # Same numbers WITHOUT the roll axis (legacy stamps): opposite side.
+    fg_legacy = make_fg(-90.0, yaw=yaw, roll=-22.5, agl=776.0,
+                        focal=50.0, sensor=(36.0, 24.0), size=(8688, 5792))
+    corners = project_footprint_corners(fg_legacy, _P())
+    east_l = sum(c[0] for c in corners) / 4.0
+    north_l = sum(c[1] for c in corners) / 4.0
+    assert east_l < -100.0 and north_l < -100.0

--- a/app/tests/core/services/image/test_coverage_extent_service.py
+++ b/app/tests/core/services/image/test_coverage_extent_service.py
@@ -219,3 +219,59 @@ def test_fov_polygon_falls_back_to_flat_when_terrain_unavailable():
     assert len(fake.compute_calls) == 1  # terrain was attempted
     assert len(fake.average_calls) == 1  # then fell back
     assert _span_east_m(corners) == pytest.approx(160.0, rel=0.01)
+
+
+class _WaldoFakeImageService(_FakeImageService):
+    """Fake with WALDO v6+ stamps: roll expressed about the FLIGHT axis."""
+
+    def __init__(self, roll_axis_deg, **kwargs):
+        super().__init__(**kwargs)
+        self.roll_axis_deg = roll_axis_deg
+
+    def get_roll_axis_azimuth(self):
+        return self.roll_axis_deg
+
+
+def test_fov_polygon_waldo_flight_axis_roll_lands_plane_right():
+    """WALDO cam0 v6+ stamp: heading 319.7 (NW), image-top backward
+    (yaw 139.7), roll -22.5 about the FLIGHT axis => footprint plane-RIGHT
+    of the track (NE). Interpreting the roll about the camera axis instead
+    mirrored the blue footprint to the SW - the field-reported bug."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    import math
+    heading = 319.7
+    fake = _WaldoFakeImageService(
+        roll_axis_deg=heading, yaw_deg=(heading + 180.0) % 360.0,
+        roll_deg=-22.5, flat_gsd_cm=4.0, reported_agl_m=776.0)
+    service = CoverageExtentService(use_terrain=False)
+    corners = _fov_corners_with(service, fake)
+
+    assert corners is not None and len(corners) == 4
+    # Offset direction: plane-right of 319.7 = bearing 49.7 (northeast).
+    offset_m = 776.0 * math.tan(math.radians(22.5))
+    expected_east = offset_m * math.sin(math.radians(heading + 90.0))
+    assert expected_east > 0  # sanity: NE means east-positive
+    assert _centroid_east_m(corners) == pytest.approx(expected_east, rel=0.02)
+
+
+def test_fov_polygon_legacy_camera_axis_roll_unchanged():
+    """Without a roll axis (DJI / WALDO v5 stamps) the old camera-axis
+    interpretation must be preserved: same yaw/roll numbers land the
+    footprint on the OPPOSITE side of the WALDO case above."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    import math
+    heading = 319.7
+    fake = _FakeImageService(
+        yaw_deg=(heading + 180.0) % 360.0, roll_deg=-22.5,
+        flat_gsd_cm=4.0, reported_agl_m=776.0)
+    service = CoverageExtentService(use_terrain=False)
+    corners = _fov_corners_with(service, fake)
+
+    assert corners is not None and len(corners) == 4
+    # Legacy: offset -h*tan(roll) along camera-X (yaw+90 = 229.7, SW).
+    offset_m = -776.0 * math.tan(math.radians(-22.5))
+    expected_east = offset_m * math.sin(math.radians(((heading + 180.0) % 360.0) + 90.0))
+    assert expected_east < 0  # sanity: SW means east-negative
+    assert _centroid_east_m(corners) == pytest.approx(expected_east, rel=0.02)

--- a/app/tests/core/services/image/test_frame_geometry.py
+++ b/app/tests/core/services/image/test_frame_geometry.py
@@ -154,8 +154,9 @@ def synthetic_service():
 
 PROJ_CTX_KEYS = {
     'drone_lat', 'drone_lon', 'img_w', 'img_h', 'cx', 'cy', 'focal_mm',
-    'sensor_w_mm', 'sensor_h_mm', 'pitch', 'yaw', 'roll', 'reported_agl',
-    'drone_terrain_elev_m', 'drone_absolute_elev_m', 'terrain_service',
+    'sensor_w_mm', 'sensor_h_mm', 'pitch', 'yaw', 'roll', 'roll_axis',
+    'reported_agl', 'drone_terrain_elev_m', 'drone_absolute_elev_m',
+    'terrain_service',
 }
 
 

--- a/app/tests/core/services/waldo/test_waldo_clock_correction.py
+++ b/app/tests/core/services/waldo/test_waldo_clock_correction.py
@@ -260,3 +260,87 @@ def test_audit_still_warns_without_correction(fault_setup):
     svc = WaldoMetadataService(terrain_service=None)
     warnings = svc.audit_capture_times([fault_setup])
     assert warnings  # timezone mismatch + AM/PM flip both present
+
+
+# --------------------------------------------------------------------------
+# Amendment: propose_amendment / stamped_correction_suspect
+# --------------------------------------------------------------------------
+
+def test_propose_amendment_prefills_from_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(WaldoMetadataService, 'get_correction_stamp_details',
+                        staticmethod(lambda p: (-12.0, 'America/Los_Angeles')))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_amendment([path])
+    assert proposal is not None
+    assert proposal.face_shift_h == -12
+    assert proposal.tz_name == 'America/Los_Angeles'
+    assert "already stamped" in proposal.evidence[0]
+    assert proposal.sample_corrected_utc == "2026-07-23 13:49:37 UTC"
+
+
+def test_propose_amendment_fixed_offset_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(WaldoMetadataService, 'get_correction_stamp_details',
+                        staticmethod(lambda p: (0.0, 'UTC+0.0')))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_amendment([path])
+    assert proposal is not None
+    assert proposal.face_shift_h == 0
+    assert proposal.tz_name is None
+    assert proposal.fixed_offset_h == pytest.approx(0.0)
+    # face 18:49:37 interpreted as UTC with no shift
+    assert proposal.sample_corrected_utc == "2026-07-23 18:49:37 UTC"
+
+
+def test_propose_amendment_none_without_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(WaldoMetadataService, 'get_correction_stamp_details',
+                        staticmethod(lambda p: None))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.propose_amendment([path]) is None
+
+
+def test_suspect_flags_below_horizon_daylight(tmp_path, monkeypatch):
+    """A stamped correction placing a bright image before sunrise is wrong."""
+    import numpy as np
+    path = _make_image(tmp_path)
+    # 04:21 PDT = 11:21 UTC on Aug 7 at Inyo: sun well below the horizon.
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-08-07T11:21:28+00:00"))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        staticmethod(lambda exif_data: {'latitude': 37.04, 'longitude': -117.63}))
+    monkeypatch.setattr(waldo_module.cv2, 'imdecode',
+                        lambda buf, flags: np.full((400, 500), 150, dtype=np.uint8))
+    svc = WaldoMetadataService(terrain_service=None)
+    reason = svc.stamped_correction_suspect([path])
+    assert reason is not None
+    assert "below the horizon" in reason
+
+
+def test_suspect_quiet_on_plausible_correction(tmp_path, monkeypatch):
+    """A corrected time with the sun up is not second-guessed."""
+    path = _make_image(tmp_path)
+    # 09:21 PDT = 16:21 UTC: sun up.
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-08-07T16:21:28+00:00"))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        staticmethod(lambda exif_data: {'latitude': 37.04, 'longitude': -117.63}))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.stamped_correction_suspect([path]) is None
+
+
+def test_suspect_quiet_without_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: None))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.stamped_correction_suspect([path]) is None

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -53,30 +53,51 @@ def test_optical_axis_cam_0_fallback_yaw_and_flight_axis_roll():
 
 
 def test_optical_axis_cam_1_fallback_yaw_and_flight_axis_roll():
-    # `1_*` = LEFT pod: tilt to plane LEFT = positive roll about the
-    # forward flight axis.
+    # `1_*` = LEFT pod, body mounted opposed to cam 0: its stored image-top
+    # faces plane FORWARD (v9 fix - v5..v8 wrongly stamped it backward).
+    # Tilt to plane LEFT = positive roll about the forward flight axis.
     angles = WaldoMetadataService.compute_optical_axis_angles(0.0, 1)
     assert angles['pitch'] == -90.0
-    assert angles['yaw'] == 180.0
+    assert angles['yaw'] == 0.0  # image-top = heading for cam 1
     assert angles['roll'] == +OUTWARD_ROLL_DEG
 
 
+def test_optical_axis_cam_1_yaw_follows_heading():
+    angles = WaldoMetadataService.compute_optical_axis_angles(270.0, 1)
+    assert angles['yaw'] == 270.0
+    angles = WaldoMetadataService.compute_optical_axis_angles(319.67, 1)
+    assert pytest.approx(angles['yaw'], abs=1e-6) == 319.67
+
+
 def test_optical_axis_measured_orientation_wins_over_model():
-    # A measured image-top bearing overrides the mounting model entirely;
-    # the roll stays anchored to the flight axis so the physical tilt is
+    # A measured orientation overrides the mounting model entirely; the
+    # roll stays anchored to the flight axis so the physical tilt is
     # unchanged by whatever orientation the frames are stored in.
-    angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 0, image_up_deg=1.5)
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        45.0, 0, measured_orientation=('absolute', 1.5))
     assert angles['yaw'] == 1.5
     assert angles['roll'] == -OUTWARD_ROLL_DEG
-    angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 1, image_up_deg=359.0)
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        45.0, 1, measured_orientation=('absolute', 359.0))
     assert angles['yaw'] == 359.0
     assert angles['roll'] == +OUTWARD_ROLL_DEG
 
 
-def test_optical_axis_cam_1_yaw_wraps_past_360():
-    # heading 270°, cam 1 → 270 + 180 = 450 → 90° after mod-360 normalisation.
-    angles = WaldoMetadataService.compute_optical_axis_angles(270.0, 1)
-    assert angles['yaw'] == 90.0
+def test_optical_axis_measured_offset_is_track_relative():
+    # ('offset', d) stamps heading + d per image - serpentine-safe: the
+    # same offset yields opposite absolute yaws on opposite lanes.
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        10.0, 0, measured_orientation=('offset', 175.0))
+    assert pytest.approx(angles['yaw'], abs=1e-6) == 185.0
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        190.0, 0, measured_orientation=('offset', 175.0))
+    assert pytest.approx(angles['yaw'], abs=1e-6) == 5.0
+
+
+def test_optical_axis_invalid_orientation_mode_raises():
+    with pytest.raises(ValueError):
+        WaldoMetadataService.compute_optical_axis_angles(
+            0.0, 0, measured_orientation=('sideways', 1.0))
 
 
 def test_optical_axis_yaw_normalised_to_360():
@@ -278,7 +299,7 @@ def test_flight_axis_roll_reproduces_v5_tilt_direction():
 
         # v6: measured yaw (north-up here), roll about the flight axis
         angles = WaldoMetadataService.compute_optical_axis_angles(
-            heading, cam_idx, image_up_deg=0.0)
+            heading, cam_idx, measured_orientation=('absolute', 0.0))
         v6 = AOIService._calculate_ground_position(
             lat0, lon0, 2000.0, 1500.0,
             altitude_m=1000.0, pitch_deg=angles['pitch'],
@@ -366,24 +387,26 @@ def _motion_records(tmp_path, heading_deg):
 def test_measurement_overrides_model_only_on_clear_contradiction(tmp_path):
     """North-up frames with a model saying 'south-up' trip the override."""
     service = WaldoMetadataService()
-    # heading 0 -> model image-top = 180; measurement reads ~0 -> gap ~180
+    # heading 0 -> cam0 model offset = 180; measurement reads offset ~0
     records = _motion_records(tmp_path, heading_deg=0.0)
 
-    measured = service.measure_image_up_bearing(records, cam_idx=0)
+    measured = service.measure_image_up_orientation(records, cam_idx=0)
     assert measured is not None
-    assert min(measured, 360.0 - measured) < 8.0
+    mode, value = measured
+    assert mode == 'offset'
+    assert min(value, 360.0 - value) < 8.0
 
 
 def test_measurement_agreeing_with_model_defers_to_it(tmp_path):
     """When measurement and model roughly agree, the model is stamped."""
     service = WaldoMetadataService()
-    # heading 180 -> model image-top = 0; measurement reads ~0 -> gap ~0
+    # heading 180 -> frames read offset (0-180)=180 = cam0 model -> agree
     records = _motion_records(tmp_path, heading_deg=180.0)
 
-    assert service.measure_image_up_bearing(records, cam_idx=0) is None
+    assert service.measure_image_up_orientation(records, cam_idx=0) is None
 
 
-def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
+def test_measurement_rejects_unmatchable(tmp_path):
     """Unrelated noise frames must fail closed (fall back to the model)."""
     service = WaldoMetadataService()
     rng = np.random.default_rng(9)
@@ -393,10 +416,84 @@ def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
         p = str(tmp_path / f'0_000_00_{i:03d}.jpg')
         cv2.imwrite(p, rng.integers(0, 255, (400, 500), dtype=np.uint8))
         records.append(WaldoImageRecord(path=p, name=f'0_000_00_{i:03d}.jpg',
-                                        cam_idx=0, lat=lat, lon=-122.0))
+                                        cam_idx=0, lat=lat, lon=-122.0,
+                                        heading_deg=0.0))
         lat += 0.0018
 
-    assert service.measure_image_up_bearing(records, cam_idx=0) is None
+    assert service.measure_image_up_orientation(records, cam_idx=0) is None
+
+
+def _serpentine_records(tmp_path, cam, lane_specs, seed0=0):
+    """Records for a multi-lane flight; lane_specs = [(heading, north?, dy)].
+
+    Each lane contributes 3 synthetic frame pairs. dy is the crop shift of
+    the pair's second frame: +dy makes the camera appear to move toward the
+    image BOTTOM between frames, -dy toward the image TOP.
+    """
+    records = []
+    idx = 0
+    lat = 41.0
+    for lane_no, (heading, north, dy) in enumerate(lane_specs):
+        dlat = 0.0018 if north else -0.0018
+        for i in range(3):
+            pa, pb = _write_shifted_frames(
+                tmp_path / f'l{lane_no}p{i}', (0, dy), seed=seed0 + idx)
+            for p in (pa, pb):
+                records.append(WaldoImageRecord(
+                    path=p, name=f'{cam}_000_00_{idx:03d}.jpg', cam_idx=cam,
+                    lat=lat, lon=-122.0, heading_deg=heading))
+                lat += dlat
+                idx += 1
+    return records
+
+
+def test_measurement_serpentine_track_relative_defers_to_model(tmp_path):
+    """Serpentine cam0 storage (image-top follows the track) must NOT trip
+    the override, even though the ABSOLUTE orientations alternate 0/180.
+
+    This is the exact failure mode that hid the cam-1 bug in v5..v8: the
+    absolute circular mean of alternating lanes was garbage, so the
+    measurement returned None instead of validating the model.
+    """
+    service = WaldoMetadataService()
+    # cam0 stores image-top = heading+180. Northbound lane (heading 0):
+    # top faces south -> northward motion reads motion_img 180 -> dy +280.
+    # Southbound lane (heading 180): top faces north -> dy +280 as well.
+    records = _serpentine_records(tmp_path, 0, [
+        (0.0, True, +280),
+        (180.0, False, +280),
+    ])
+    assert service.measure_image_up_orientation(records, cam_idx=0) is None
+
+
+def test_measurement_detects_normalized_absolute_on_serpentine(tmp_path):
+    """North-up-normalized frames on a serpentine flight: the relative space
+    scrambles (offsets 0/180) but the absolute space is tight at ~0, and a
+    constant absolute orientation across mixed headings contradicts ANY
+    mounting model - the override must fire in absolute mode."""
+    service = WaldoMetadataService()
+    records = _serpentine_records(tmp_path, 0, [
+        (0.0, True, -280),    # northbound, north-up: motion toward image top
+        (180.0, False, +280),  # southbound, north-up: motion toward image bottom
+    ])
+    measured = service.measure_image_up_orientation(records, cam_idx=0)
+    assert measured is not None
+    mode, value = measured
+    assert mode == 'absolute'
+    assert min(value, 360.0 - value) < 8.0
+
+
+def test_measurement_cam1_forward_storage_matches_v9_model(tmp_path):
+    """cam1 frames stored image-top = plane FORWARD (the real WALDO output,
+    field-verified on two flights) must agree with the v9 model and stamp
+    it. Under the v5..v8 model (top = backward) this same data was a 180 deg
+    contradiction that the old absolute aggregation failed to report."""
+    service = WaldoMetadataService()
+    records = _serpentine_records(tmp_path, 1, [
+        (0.0, True, -280),     # northbound, top=forward(north): motion toward top
+        (180.0, False, -280),  # southbound, top=forward(south): motion toward top
+    ])
+    assert service.measure_image_up_orientation(records, cam_idx=1) is None
 
 
 # --------------------------------------------------------------------------

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -5736,8 +5736,8 @@ The map will continue to work with cached tiles where available.</translation>
         <translation>Copy Data</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>Zoom FOV</translation>
     </message>
@@ -10299,97 +10299,107 @@ Expected to find files named:
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Recenter</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>no image loaded</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>image metadata could not be read</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>image has no GPS coordinates</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>capture time / timezone not in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>sun position could not be computed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Capture time zone estimated from GPS location.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>the sun was below the horizon at capture</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>sun position unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Shadow unavailable: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Place the person and shadow on the DEM terrain surface</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terrain (DEM) data is not available for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Choose Overlay Color</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -5736,8 +5736,8 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
         <translation>Copiar datos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>FOV de zoom</translation>
     </message>
@@ -10299,97 +10299,107 @@ Se esperaba encontrar archivos con estos nombres:
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Arrastre el controlador blanco para colocar a la persona de referencia. Las siluetas se dibujan a escala real del terreno según la altitud y el ángulo de cámara de esta imagen.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Centrar de nuevo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Superposición de perspectiva no disponible: a esta imagen le faltan los metadatos de altitud o lente necesarios para proyectar una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>no hay imagen cargada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>no se pudieron leer los metadatos de la imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>la imagen no tiene coordenadas GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>la hora de captura / zona horaria no está en los metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>no se pudo calcular la posición del sol</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sol durante la captura: {elev:.0f}° sobre el horizonte, acimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Zona horaria de captura estimada a partir de la ubicación GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>el sol estaba por debajo del horizonte durante la captura</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>posición del sol no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Sombra no disponible: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Colocar la persona y la sombra sobre la superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Los datos de terreno (DEM) no están disponibles para esta imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Elegir color de superposición</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -5736,8 +5736,8 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
         <translation>Copia Dati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>Zoom FOV</translation>
     </message>
@@ -10299,97 +10299,107 @@ Nomi dei file cercati:
         <translation>Colore:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Trascina la maniglia bianca per posizionare la persona di riferimento. Le sagome sono disegnate in scala reale al suolo per l&apos;altitudine e l&apos;angolo della fotocamera di questa immagine.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Ricentra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Sovrapposizione prospettica non disponibile: a questa immagine mancano i metadati di quota o obiettivo necessari per proiettare una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>nessuna immagine caricata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>impossibile leggere i metadati dell&apos;immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>l&apos;immagine non ha coordinate GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>ora di scatto / fuso orario non presenti nei metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>impossibile calcolare la posizione del sole</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sole allo scatto: {elev:.0f}° sopra l&apos;orizzonte, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Fuso orario dello scatto stimato dalla posizione GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>il sole era sotto l&apos;orizzonte al momento dello scatto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>posizione del sole non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Ombra non disponibile: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Posiziona la persona e l&apos;ombra sulla superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>I dati del terreno (DEM) non sono disponibili per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Scegli colore sovrapposizione</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -5736,8 +5736,8 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
         <translation>Gegevens kopiëren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>Zoom-gezichtsveld</translation>
     </message>
@@ -10299,97 +10299,107 @@ Verwachte bestandsnamen:
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Sleep de witte greep om de referentiepersoon te plaatsen. Silhouetten worden op ware terreinschaal getekend voor de hoogte en camerahoek van deze afbeelding.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Centreren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspectiefoverlay niet beschikbaar: deze afbeelding mist de hoogte- of lensmetadata die nodig zijn om een persoon te projecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>geen afbeelding geladen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>afbeeldingsmetadata konden niet worden gelezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>afbeelding heeft geen GPS-coördinaten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>opnametijd / tijdzone ontbreekt in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>zonnestand kon niet worden berekend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Zon bij opname: {elev:.0f}° boven de horizon, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Tijdzone van opname geschat op basis van GPS-locatie.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>de zon stond tijdens de opname onder de horizon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>zonnestand niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Schaduw niet beschikbaar: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Plaats de persoon en schaduw op het DEM-terreinoppervlak</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terreingegevens (DEM) zijn niet beschikbaar voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Overlaykleur kiezen</translation>
     </message>


### PR DESCRIPTION
Follow-up to #131/#132 (#132 was merged while this commit was in flight, so it is resubmitted here). Three field-verified fixes, discovered by cross-referencing image content against adjacent-lane imagery and satellite views:

## 1. cam 1 was stamped 180° off — in every WALDO dataset (processor v9)

The two DSLR bodies are mounted opposed and each keeps its native orientation through the ground software: cam 0 (`0_*`) comes out image-top = plane **backward**, cam 1 (`1_*`) image-top = plane **forward**. v5–v8 stamped both cameras backward, so every `1_*` image had its pixel→ground mapping rotated 180° (AOI positions off by hundreds of meters). Confirmed by inter-frame content motion vs the GPS track on two independent flights (~324° measured vs 139.7° stamped on a 319.7° track; same on a second flight).

Why the v7 safety net missed it: it averaged **absolute** image-top bearings across serpentine lanes pointing 0°/180° apart — garbage statistics → "inconclusive" → silent fallback to the (wrong) model. The measurement now aggregates per-pair samples in **track-relative** space, still detects post-flight-normalized (constant-absolute) imagery via a dual-space contest, and stamps per-image yaw. Version bump 8→9 restamps existing datasets on next open.

## 2. Footprint renderers ignored the v6 flight-axis roll convention

The v6 convention (roll about FlightYaw) was only ever consumed by the AOI path. The map FOV raycast (4 call sites in `GPSMapView`), the flat-footprint fallback in `CoverageExtentService`, and the coverage-pod kernel all still applied roll about the **camera-yaw axis** — for WALDO stamps (image-top = backward) that mirrors the drawn footprint to the **opposite side of the flight track**. Field report that exposed it: the blue map footprint sat on the wrong side while the stamps (verified against image content via cross-lane feature matching) were correct. `FrameGeometry` now carries `roll_axis_deg`; `build_camera_rotation` accepts the axis override; legacy (no roll axis) behaviour is byte-identical.

## 3. Applied clock corrections can now be amended

Once #132's correction was stamped and remembered, there was no path to change it. Now: a stamped correction that puts the sun below the horizon on daylight imagery re-opens the dialog on folder open (overriding the remembered decision — never silently re-applying suspect values), and the Person Reference dialog gains an **Adjust camera clock…** button for WALDO imagery — the place a wrong correction is actually noticed. Decision persistence moved to a shared `WaldoClockDecisions` module.

Also fixes the stale projection-context golden-key test (`roll_axis` was added to the context by #129 but the golden set predated it — failing on clean dev).

## Validation

22 new/updated tests (serpentine + normalized-absolute + cam1 measurement cases, renderer side regression tests against the field scenario, amendment/sanity flows); 488 green across affected suites (5 pre-existing PROJ-environment failures unrelated); flake8 clean; translations extracted.