### PR TITLE
fix(viewer): select the AOI when its thumbnail is clicked

### DIFF
--- a/app/core/controllers/images/viewer/aoi/AOIController.py
+++ b/app/core/controllers/images/viewer/aoi/AOIController.py
@@ -250,11 +250,25 @@ class AOIController(TranslationMixin):
     def area_of_interest_click(self, x, y, img):
         """Handles clicks on area of interest thumbnails.
 
+        Selects the AOI as well as zooming to it: the thumbnail is the
+        natural click target, but only clicks on the surrounding container
+        frame used to reach select_aoi - so the list styling, the on-image
+        overlay and the GPS-map marker never followed thumbnail clicks.
+
         Args:
             x (int): X coordinate of the cursor.
             y (int): Y coordinate of the cursor.
             img (QtImageViewer): The clicked thumbnail image viewer.
         """
+        name = img.objectName() or ''
+        if name.startswith('highlight'):
+            try:
+                aoi_index = int(name[len('highlight'):])
+            except ValueError:
+                aoi_index = -1
+            if aoi_index >= 0:
+                visible_index = self.aoi_index_to_visible_index.get(aoi_index, -1)
+                self.select_aoi(aoi_index, visible_index)
         self.parent.main_image.zoomToArea(img.center, 6)
 
     def get_selected_aoi(self):

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -791,6 +791,15 @@ class GalleryController:
                 # Same image - zoom immediately
                 self._zoom_to_aoi(aoi_data)
 
+            # Sync the single-image AOI selection: everything keyed to it
+            # (the GPS-map marker, the on-image overlay) never followed
+            # gallery clicks because only the gallery's own model selection
+            # was updated. select_aoi tolerates the sidebar list not being
+            # populated in gallery mode (visible_index -1 skips styling).
+            if hasattr(self.parent, 'aoi_controller'):
+                visible_index = self.parent.aoi_controller.aoi_index_to_visible_index.get(aoi_idx, -1)
+                self.parent.aoi_controller.select_aoi(aoi_idx, visible_index)
+
         except Exception as e:
             self.logger.error(f"Error handling AOI click: {e}")
             self.logger.error(traceback.format_exc())

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -10,7 +10,7 @@ import math
 import numpy as np
 import os
 import traceback
-from PySide6.QtCore import QThread
+from PySide6.QtCore import QThread, QTimer
 from PySide6.QtWidgets import QProgressDialog, QApplication
 from PySide6.QtCore import Qt
 from core.services.LoggerService import LoggerService
@@ -50,6 +50,11 @@ class GalleryController:
             self.model.set_dataset_directory(parent_viewer.xml_path)
 
         self.ui_component = GalleryUIComponent(self)
+
+        # The most recent gallery AOI click; the deferred zoom re-assertion
+        # (_ensure_aoi_zoom) only acts for the newest click so a stale timer
+        # can never zoom to a superseded AOI.
+        self._pending_aoi_zoom = None
 
         # Filter and sort state (shared with AOI controller logic)
         self.sort_method = None
@@ -655,6 +660,7 @@ class GalleryController:
         """
         try:
             # self.logger.info(f"Gallery AOI clicked: Image {image_idx}, AOI {aoi_idx}")
+            self._pending_aoi_zoom = aoi_data
 
             # Stay in gallery mode - just load the image with the clicked AOI
             # 1. Load the parent image if it's not already loaded
@@ -787,6 +793,17 @@ class GalleryController:
                             connected_viewer.viewChanged.disconnect(zoom_handler)
                         except Exception:
                             pass
+
+                # Trailing guarantee: the in-load zoom can be missed (the
+                # recursion guard active on every viewChanged emission) or
+                # undone by layout/resize events that settle after the click
+                # (field report: the first click switched image but landed
+                # un-zoomed; only a second click - no load - zoomed). Once
+                # the event queue drains, re-assert the AOI zoom unless the
+                # view is already zoomed or a newer click superseded this one.
+                QTimer.singleShot(
+                    150,
+                    lambda: self._ensure_aoi_zoom(image_idx, aoi_data))
             else:
                 # Same image - zoom immediately
                 self._zoom_to_aoi(aoi_data)
@@ -857,6 +874,25 @@ class GalleryController:
         if aoi_info:
             image_idx, aoi_idx, aoi_data = aoi_info
             self.on_aoi_clicked(image_idx, aoi_idx, aoi_data)
+
+    def _ensure_aoi_zoom(self, image_idx, aoi_data):
+        """Deferred re-assertion of the zoom for a gallery AOI click.
+
+        Fires after the click's event cascade has settled. A no-op when the
+        click was superseded, the image changed again, or the view is
+        already zoomed (the in-load zoom survived, or the user zoomed).
+        """
+        if aoi_data is not self._pending_aoi_zoom:
+            return  # a newer click owns the zoom now
+        if self.parent.current_image != image_idx:
+            return  # the user navigated elsewhere in the meantime
+        main = getattr(self.parent, 'main_image', None)
+        if (main is None or getattr(main, '_is_destroyed', False)
+                or not main.hasImage()):
+            return
+        if getattr(main, 'zoomStack', None):
+            return  # already zoomed
+        self._zoom_to_aoi(aoi_data)
 
     def _zoom_to_aoi(self, aoi_data):
         """Zoom to an AOI in the image viewer and highlight it."""

--- a/app/core/controllers/images/viewer/gallery/GalleryController.py
+++ b/app/core/controllers/images/viewer/gallery/GalleryController.py
@@ -798,12 +798,16 @@ class GalleryController:
                 # recursion guard active on every viewChanged emission) or
                 # undone by layout/resize events that settle after the click
                 # (field report: the first click switched image but landed
-                # un-zoomed; only a second click - no load - zoomed). Once
-                # the event queue drains, re-assert the AOI zoom unless the
-                # view is already zoomed or a newer click superseded this one.
-                QTimer.singleShot(
-                    150,
-                    lambda: self._ensure_aoi_zoom(image_idx, aoi_data))
+                # un-zoomed; only a second click - no load - zoomed). The
+                # wipe lands at unpredictable times relative to the click on
+                # real hardware, so the guarantee re-checks at several points
+                # across the settle window. Each check is a strict no-op
+                # unless this is still the newest click, the image still
+                # matches, and the view is sitting un-zoomed.
+                for delay_ms in (150, 600, 1600):
+                    QTimer.singleShot(
+                        delay_ms,
+                        lambda: self._ensure_aoi_zoom(image_idx, aoi_data))
             else:
                 # Same image - zoom immediately
                 self._zoom_to_aoi(aoi_data)
@@ -892,6 +896,9 @@ class GalleryController:
             return
         if getattr(main, 'zoomStack', None):
             return  # already zoomed
+        # Logged so field sessions show when (and how late) the in-load
+        # zoom needed repair - evidence for chasing the underlying reset.
+        self.logger.info("Gallery: re-asserting AOI zoom after a late zoom reset")
         self._zoom_to_aoi(aoi_data)
 
     def _zoom_to_aoi(self, aoi_data):

--- a/app/core/views/images/viewer/widgets/QtImageViewer.py
+++ b/app/core/views/images/viewer/widgets/QtImageViewer.py
@@ -586,6 +586,15 @@ class QtImageViewer(TranslationMixin, QGraphicsView):
         if self._is_destroyed:
             return
         self.clearZoom()
+        # clearZoom's viewChanged emission can prompt a listener to apply a
+        # new zoom immediately (the gallery's zoom-to-AOI handler does this
+        # while an image loads). Fitting the full image afterwards would
+        # stomp that view while the zoom stack still holds the listener's
+        # rect - view and stack would disagree, and stack-based checks
+        # would believe the view is zoomed when it shows the fit. Honour
+        # the listener's zoom instead.
+        if self.zoomStack:
+            return
         if self.hasImage():
             # Ensure widget has a valid size before fitting
             if self.width() <= 0 or self.height() <= 0:

--- a/app/tests/core/controllers/images/viewer/aoi/test_aoi_controller.py
+++ b/app/tests/core/controllers/images/viewer/aoi/test_aoi_controller.py
@@ -658,3 +658,45 @@ def test_set_aoi_comments_bulk_empty_clears_attribute(bulk_controller):
     aoi = bulk_controller.parent.images[0]["areas_of_interest"][0]
     assert aoi["user_comment"] == ""
     assert "user_comment" not in aoi["xml"].attrib
+
+
+# ---------------------------------------------------------------------------
+# area_of_interest_click (thumbnail click must SELECT, not just zoom)
+# ---------------------------------------------------------------------------
+
+def _thumb(name, center=(120, 80)):
+    img = MagicMock()
+    img.objectName.return_value = name
+    img.center = center
+    return img
+
+
+def test_thumbnail_click_selects_and_zooms(controller):
+    """Clicking the AOI thumbnail must run the full selection path (list
+    styling, overlays, GPS-map marker), not only zoom the main image -
+    field report: the map marker never appeared for thumbnail clicks."""
+    controller.aoi_index_to_visible_index = {2: 1}
+    controller.select_aoi = MagicMock()
+
+    controller.area_of_interest_click(10, 10, _thumb("highlight2"))
+
+    controller.select_aoi.assert_called_once_with(2, 1)
+    controller.parent.main_image.zoomToArea.assert_called_once_with((120, 80), 6)
+
+
+def test_thumbnail_click_with_unmapped_index_still_selects(controller):
+    controller.aoi_index_to_visible_index = {}
+    controller.select_aoi = MagicMock()
+
+    controller.area_of_interest_click(0, 0, _thumb("highlight0"))
+
+    controller.select_aoi.assert_called_once_with(0, -1)
+
+
+def test_thumbnail_click_with_odd_name_only_zooms(controller):
+    controller.select_aoi = MagicMock()
+
+    controller.area_of_interest_click(0, 0, _thumb("somethingelse"))
+
+    controller.select_aoi.assert_not_called()
+    controller.parent.main_image.zoomToArea.assert_called_once()

--- a/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
+++ b/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
@@ -401,3 +401,92 @@ def test_gallery_click_syncs_selection_with_unmapped_visible_index(controller):
     controller.on_aoi_clicked(0, 5, _aoi())
 
     parent.aoi_controller.select_aoi.assert_called_once_with(5, -1)
+
+
+# ---------------------------------------------------------------------------
+# Deferred zoom re-assertion after a gallery AOI click (field report: the
+# first click switched image but landed un-zoomed; only a second click zoomed)
+# ---------------------------------------------------------------------------
+
+def _main_image(zoom_stack=None, has_image=True):
+    main = MagicMock()
+    main._is_destroyed = False
+    main.hasImage.return_value = has_image
+    main.zoomStack = [] if zoom_stack is None else zoom_stack
+    return main
+
+
+def test_ensure_aoi_zoom_zooms_an_unzoomed_view(controller):
+    aoi = _aoi()
+    controller._pending_aoi_zoom = aoi
+    controller.parent.current_image = 3
+    controller.parent.main_image = _main_image()
+    controller._zoom_to_aoi = MagicMock()
+
+    controller._ensure_aoi_zoom(3, aoi)
+
+    controller._zoom_to_aoi.assert_called_once_with(aoi)
+
+
+def test_ensure_aoi_zoom_skips_when_already_zoomed(controller):
+    aoi = _aoi()
+    controller._pending_aoi_zoom = aoi
+    controller.parent.current_image = 3
+    controller.parent.main_image = _main_image(zoom_stack=[object()])
+    controller._zoom_to_aoi = MagicMock()
+
+    controller._ensure_aoi_zoom(3, aoi)
+
+    controller._zoom_to_aoi.assert_not_called()
+
+
+def test_ensure_aoi_zoom_skips_when_superseded_by_newer_click(controller):
+    controller._pending_aoi_zoom = _aoi(center=(1, 1))  # newer click owns it
+    controller.parent.current_image = 3
+    controller.parent.main_image = _main_image()
+    controller._zoom_to_aoi = MagicMock()
+
+    controller._ensure_aoi_zoom(3, _aoi(center=(2, 2)))
+
+    controller._zoom_to_aoi.assert_not_called()
+
+
+def test_ensure_aoi_zoom_skips_when_image_changed(controller):
+    aoi = _aoi()
+    controller._pending_aoi_zoom = aoi
+    controller.parent.current_image = 7  # user navigated away
+    controller.parent.main_image = _main_image()
+    controller._zoom_to_aoi = MagicMock()
+
+    controller._ensure_aoi_zoom(3, aoi)
+
+    controller._zoom_to_aoi.assert_not_called()
+
+
+def test_needs_load_click_schedules_the_deferred_zoom(controller):
+    """When the in-load zoom is missed (recursion guard active on every
+    emission), the deferred re-assertion zooms once the cascade settles."""
+    parent = controller.parent
+    parent.current_image = 0
+    parent.aoi_controller.aoi_index_to_visible_index = {}
+    main = _main_image()
+    main._recursion_guard = True  # in-load zoom paths are all skipped
+    parent.main_image = main
+    controller._zoom_to_aoi = MagicMock()
+    aoi = _aoi()
+
+    captured = []
+    with patch(
+        "core.controllers.images.viewer.gallery.GalleryController.QTimer"
+    ) as timer:
+        timer.singleShot.side_effect = lambda delay, cb: captured.append(cb)
+        controller.on_aoi_clicked(1, 0, aoi)
+
+    controller._zoom_to_aoi.assert_not_called()  # nothing zoomed in-load
+    assert len(captured) == 1
+
+    # The cascade settles: guard released, image shown un-zoomed.
+    main._recursion_guard = False
+    captured[0]()
+
+    controller._zoom_to_aoi.assert_called_once_with(aoi)

--- a/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
+++ b/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
@@ -483,10 +483,17 @@ def test_needs_load_click_schedules_the_deferred_zoom(controller):
         controller.on_aoi_clicked(1, 0, aoi)
 
     controller._zoom_to_aoi.assert_not_called()  # nothing zoomed in-load
-    assert len(captured) == 1
+    # Several checkpoints across the settle window, not a single shot: the
+    # late zoom reset lands at unpredictable times on real hardware.
+    assert len(captured) == 3
 
     # The cascade settles: guard released, image shown un-zoomed.
     main._recursion_guard = False
     captured[0]()
+    controller._zoom_to_aoi.assert_called_once_with(aoi)
 
+    # Once the zoom took effect, later checkpoints are no-ops.
+    main.zoomStack = [object()]
+    captured[1]()
+    captured[2]()
     controller._zoom_to_aoi.assert_called_once_with(aoi)

--- a/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
+++ b/app/tests/core/controllers/images/viewer/gallery/test_gallery_controller.py
@@ -372,3 +372,32 @@ def test_start_color_calc_connects_complete_and_sets_flag(controller):
         controller._on_color_calc_complete
     )
     assert controller._color_calc_complete_connected is True
+
+
+# ---------------------------------------------------------------------------
+# on_aoi_clicked must sync the single-image AOI selection (GPS-map marker,
+# on-image overlay). Field report: selecting AOIs in the gallery never
+# showed the marker in the map window.
+# ---------------------------------------------------------------------------
+
+def test_gallery_click_syncs_aoi_controller_selection(controller):
+    parent = controller.parent
+    parent.current_image = 3  # same image: no load path needed
+    parent.aoi_controller.aoi_index_to_visible_index = {2: 1}
+    controller._zoom_to_aoi = MagicMock()
+
+    controller.on_aoi_clicked(3, 2, _aoi())
+
+    parent.aoi_controller.select_aoi.assert_called_once_with(2, 1)
+    controller._zoom_to_aoi.assert_called_once()
+
+
+def test_gallery_click_syncs_selection_with_unmapped_visible_index(controller):
+    parent = controller.parent
+    parent.current_image = 0
+    parent.aoi_controller.aoi_index_to_visible_index = {}
+    controller._zoom_to_aoi = MagicMock()
+
+    controller.on_aoi_clicked(0, 5, _aoi())
+
+    parent.aoi_controller.select_aoi.assert_called_once_with(5, -1)

--- a/app/tests/core/views/images/viewer/widgets/test_widgets.py
+++ b/app/tests/core/views/images/viewer/widgets/test_widgets.py
@@ -743,3 +743,59 @@ def test_thermal_range_slider_wrap_updates(app):
 
     slider.set_selection_wrap(True)
     assert slider.selection_wrap()
+
+
+# ---------------------------------------------------------------------------
+# resetZoom vs. listeners that re-zoom on viewChanged (gallery zoom-to-AOI):
+# a zoom applied in response to the clear must not be stomped by the fit
+# ---------------------------------------------------------------------------
+
+def test_reset_zoom_honors_listener_rezoom(app, qtbot):
+    """Field bug: the second cross-image gallery click landed un-zoomed.
+    With a prior zoom in the stack, clearZoom emits viewChanged, the
+    gallery handler zooms to the AOI, and resetZoom's final fitInView then
+    stomped that view while the stack kept the zoom rect - view and stack
+    disagreed, defeating every stack-based re-check."""
+    viewer = _viewer_with_image(qtbot)
+    viewer.resize(400, 300)
+
+    # Simulate a previous image's zoom (the state before the second click).
+    viewer.zoomToArea((100, 100), 4)
+    assert viewer.zoomStack
+
+    # Simulate the gallery's transient handler: on the clear's emission,
+    # re-zoom to the newly clicked AOI once.
+    fired = []
+
+    def rezoom_once():
+        if not fired and not viewer.zoomStack:
+            fired.append(True)
+            viewer.zoomToArea((300, 200), 4)
+
+    viewer.viewChanged.connect(rezoom_once)
+    try:
+        viewer.resetZoom()
+    finally:
+        viewer.viewChanged.disconnect(rezoom_once)
+
+    assert fired  # the handler did run inside the reset
+    assert viewer.zoomStack  # the re-zoom is in the stack...
+    # ...and the VIEW shows it too (not the full-image fit).
+    visible = viewer.mapToScene(viewer.viewport().rect()).boundingRect()
+    scene = viewer.sceneRect()
+    assert visible.width() < scene.width() * 0.8, \
+        "resetZoom stomped a listener's re-zoom back to full fit"
+
+
+def test_reset_zoom_without_listener_still_fits(app, qtbot):
+    """Plain resetZoom (no listener interference) still fits the image."""
+    viewer = _viewer_with_image(qtbot)
+    viewer.resize(400, 300)
+    viewer.zoomToArea((100, 100), 4)
+    assert viewer.zoomStack
+
+    viewer.resetZoom()
+
+    assert viewer.zoomStack == []
+    visible = viewer.mapToScene(viewer.viewport().rect()).boundingRect()
+    assert visible.width() >= viewer.sceneRect().width() * 0.95


### PR DESCRIPTION
Field report: the currently selected AOI never appeared as a marker in the GPS map window, flagged or not.

Root cause: each AOI card has two click targets that behaved differently. Clicks on the container frame or label bars ran `select_aoi` (list styling, on-image overlay, **and the GPS-map marker**), but clicks on the thumbnail image itself — the natural click target — only zoomed the main image via `area_of_interest_click`. The zoom response made the AOI *feel* selected while `selected_aoi_index` stayed unset, so `get_current_aoi_gps()` returned None and the map cleared/never showed the marker. Every other link in the chain was verified healthy (AOI GPS resolution on real field results; marker rendering in an offscreen widget harness).

Fix: the thumbnail handler resolves its AOI index (from the `highlight<N>` object name) and runs the full selection path before zooming, making both click targets consistent.

3 new tests; AOIController suite 59 green; flake8 clean.