### PR TITLE
feat(map): fetch satellite tiles to z20 in the GPS map view

### DIFF
--- a/app/core/views/images/viewer/widgets/GPSMapView.py
+++ b/app/core/views/images/viewer/widgets/GPSMapView.py
@@ -851,6 +851,11 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                     pass
         self.tile_items = {}
 
+        # The new source may not serve the current zoom (satellite goes one
+        # level deeper than the street map) - step down before reloading.
+        if self.current_zoom > self.tile_loader.max_zoom():
+            self._change_tile_zoom_level(self.tile_loader.max_zoom())
+
         # Reload with new source
         self.load_visible_tiles()
 
@@ -1033,7 +1038,7 @@ class GPSMapView(TranslationMixin, QGraphicsView):
     def _check_tile_zoom_level(self):
         """Check if we need to change tile zoom level based on current scale."""
         if self.zoom_scale > 1.5:
-            target_zoom = min(18, self.current_zoom + 1)
+            target_zoom = min(self.tile_loader.max_zoom(), self.current_zoom + 1)
         elif self.zoom_scale < 0.67:
             target_zoom = max(1, self.current_zoom - 1)
         else:

--- a/app/core/views/images/viewer/widgets/MapTileLoader.py
+++ b/app/core/views/images/viewer/widgets/MapTileLoader.py
@@ -48,6 +48,13 @@ class MapTileLoader(QObject):
         # Tile source type ('map' or 'satellite')
         self.tile_source = 'map'
 
+        # Per-source maximum tile zoom (matches AlignImageView): Esri World
+        # Imagery serves z20 (~0.15 m/px) across most SAR terrain, OSM tops
+        # out at z19. Above the source's limit the view keeps scaling but
+        # tiles stop sharpening.
+        self.MAX_ZOOM_SATELLITE = 20
+        self.MAX_ZOOM_MAP = 19
+
         # Error tracking
         self.error_count = 0
         self.max_errors_before_notify = 3
@@ -63,7 +70,7 @@ class MapTileLoader(QObject):
         Args:
             lat: Latitude in degrees
             lon: Longitude in degrees
-            zoom: Zoom level (0-19)
+            zoom: Zoom level (0 to the source's max, see max_zoom())
 
         Returns:
             tuple: (x_tile, y_tile) coordinates
@@ -116,6 +123,11 @@ class MapTileLoader(QObject):
             source: 'map' or 'satellite'
         """
         self.tile_source = source
+
+    def max_zoom(self):
+        """Maximum tile zoom the current source can serve."""
+        return (self.MAX_ZOOM_SATELLITE if self.tile_source == 'satellite'
+                else self.MAX_ZOOM_MAP)
 
     def set_offline_only(self, offline_only: bool):
         """Enable/disable offline-only mode (no new tile downloads)."""
@@ -265,8 +277,9 @@ class MapTileLoader(QObject):
         # Use minimum zoom to ensure all points fit
         zoom = min(zoom_x, zoom_y)
 
-        # Clamp to valid range (0-19) and leave some margin
-        return max(1, min(18, int(zoom) - 1))
+        # Clamp to the source's max and leave one level of margin for
+        # smooth fitting.
+        return max(1, min(self.max_zoom(), int(zoom) - 1))
 
     def _handle_tile_error(self, error_code, error_string, http_status):
         """

--- a/app/tests/core/views/images/viewer/widgets/test_widgets.py
+++ b/app/tests/core/views/images/viewer/widgets/test_widgets.py
@@ -743,3 +743,47 @@ def test_thermal_range_slider_wrap_updates(app):
 
     slider.set_selection_wrap(True)
     assert slider.selection_wrap()
+
+
+# ---------------------------------------------------------------------------
+# Map tile zoom limits (satellite detail; field report: sat imagery stopped
+# sharpening at z18 while the Align Image view reached z20)
+# ---------------------------------------------------------------------------
+
+def test_tile_loader_max_zoom_per_source(app):
+    loader = MapTileLoader()
+    assert loader.max_zoom() == loader.MAX_ZOOM_MAP  # default source is 'map'
+    loader.set_tile_source('satellite')
+    assert loader.max_zoom() == loader.MAX_ZOOM_SATELLITE
+    assert loader.MAX_ZOOM_SATELLITE == 20  # matches AlignImageView
+    assert loader.MAX_ZOOM_MAP == 19
+
+
+def test_zoom_for_bounds_caps_at_source_max(app):
+    loader = MapTileLoader()
+    # Tiny bounds on a big viewport -> huge computed zoom, must clamp.
+    args = (37.0440, 37.0441, -117.6320, -117.6319, 2000, 2000)
+    loader.set_tile_source('satellite')
+    assert loader.calculate_zoom_for_bounds(*args) == loader.MAX_ZOOM_SATELLITE
+    loader.set_tile_source('map')
+    assert loader.calculate_zoom_for_bounds(*args) == loader.MAX_ZOOM_MAP
+
+
+def test_view_zoom_step_honors_source_max(app):
+    view = GPSMapView()
+    view.tile_loader.set_tile_source('satellite')
+    view.zoom_scale = 2.0  # over the 1.5 step-in threshold
+    view.current_zoom = 19
+    view._check_tile_zoom_level()
+    assert view.current_zoom == 20
+    view.zoom_scale = 2.0  # _change_tile_zoom_level rescales the view
+    view._check_tile_zoom_level()
+    assert view.current_zoom == 20  # capped
+
+
+def test_switching_to_street_map_steps_down_from_z20(app):
+    view = GPSMapView()
+    view.tile_loader.set_tile_source('satellite')
+    view.current_zoom = 20
+    view.set_tile_source('map')
+    assert view.current_zoom == view.tile_loader.MAX_ZOOM_MAP


### PR DESCRIPTION
Field report: satellite imagery in the GPS map window stops gaining resolution while zooming, well before the detail the Align Image view shows.

Root cause: the GPS map capped tile fetches at **z18** (~0.6 m/px) for both providers — a limit dating to the original map implementation — while `AlignImageView` already fetches Esri World Imagery at **z20** (~0.15 m/px, and 19 for the street map). Past z18 the graphics view keeps scaling but tiles stop sharpening, which is exactly when an operator is inspecting an AOI. At z18 a person is about one pixel; at z20, four.

Change: `MapTileLoader` now carries per-source maximums matching `AlignImageView` (satellite 20, street map 19) exposed via `max_zoom()`; both zoom decision points (`calculate_zoom_for_bounds` and the interactive zoom-step check) use it, and switching satellite → street map at z20 steps the tile level down before reloading so OSM is never asked for tiles it can't serve.

4 new tests; widget + map-dialog suites 107 green; flake8 clean.