### PR TITLE
feat(map): keep last-good imagery when a tile zoom level is unavailable

### DIFF
--- a/app/core/views/images/viewer/widgets/GPSMapView.py
+++ b/app/core/views/images/viewer/widgets/GPSMapView.py
@@ -851,6 +851,11 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                     pass
         self.tile_items = {}
 
+        # The new source may not serve the current zoom (satellite goes one
+        # level deeper than the street map) - step down before reloading.
+        if self.current_zoom > self.tile_loader.max_zoom():
+            self._change_tile_zoom_level(self.tile_loader.max_zoom())
+
         # Reload with new source
         self.load_visible_tiles()
 
@@ -1033,7 +1038,7 @@ class GPSMapView(TranslationMixin, QGraphicsView):
     def _check_tile_zoom_level(self):
         """Check if we need to change tile zoom level based on current scale."""
         if self.zoom_scale > 1.5:
-            target_zoom = min(18, self.current_zoom + 1)
+            target_zoom = min(self.tile_loader.max_zoom(), self.current_zoom + 1)
         elif self.zoom_scale < 0.67:
             target_zoom = max(1, self.current_zoom - 1)
         else:

--- a/app/core/views/images/viewer/widgets/MapTileLoader.py
+++ b/app/core/views/images/viewer/widgets/MapTileLoader.py
@@ -48,6 +48,13 @@ class MapTileLoader(QObject):
         # Tile source type ('map' or 'satellite')
         self.tile_source = 'map'
 
+        # Per-source maximum tile zoom (matches AlignImageView): Esri World
+        # Imagery serves z20 (~0.15 m/px) across most SAR terrain, OSM tops
+        # out at z19. Above the source's limit the view keeps scaling but
+        # tiles stop sharpening.
+        self.MAX_ZOOM_SATELLITE = 20
+        self.MAX_ZOOM_MAP = 19
+
         # Error tracking
         self.error_count = 0
         self.max_errors_before_notify = 3
@@ -63,7 +70,7 @@ class MapTileLoader(QObject):
         Args:
             lat: Latitude in degrees
             lon: Longitude in degrees
-            zoom: Zoom level (0-19)
+            zoom: Zoom level (0 to the source's max, see max_zoom())
 
         Returns:
             tuple: (x_tile, y_tile) coordinates
@@ -116,6 +123,11 @@ class MapTileLoader(QObject):
             source: 'map' or 'satellite'
         """
         self.tile_source = source
+
+    def max_zoom(self):
+        """Maximum tile zoom the current source can serve."""
+        return (self.MAX_ZOOM_SATELLITE if self.tile_source == 'satellite'
+                else self.MAX_ZOOM_MAP)
 
     def set_offline_only(self, offline_only: bool):
         """Enable/disable offline-only mode (no new tile downloads)."""
@@ -265,8 +277,9 @@ class MapTileLoader(QObject):
         # Use minimum zoom to ensure all points fit
         zoom = min(zoom_x, zoom_y)
 
-        # Clamp to valid range (0-19) and leave some margin
-        return max(1, min(18, int(zoom) - 1))
+        # Clamp to the source's max and leave one level of margin for
+        # smooth fitting.
+        return max(1, min(self.max_zoom(), int(zoom) - 1))
 
     def _handle_tile_error(self, error_code, error_string, http_status):
         """

--- a/app/core/views/images/viewer/widgets/MapTileLoader.py
+++ b/app/core/views/images/viewer/widgets/MapTileLoader.py
@@ -8,9 +8,9 @@ import os
 import math
 import hashlib
 from pathlib import Path
-from PySide6.QtCore import QObject, Signal, QThread, QUrl, QTimer
+from PySide6.QtCore import QObject, Signal, QThread, QUrl, QTimer, Qt
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
-from PySide6.QtGui import QPixmap, QImage, QColor
+from PySide6.QtGui import QPixmap, QImage, QColor, qGray
 import tempfile
 
 
@@ -54,6 +54,28 @@ class MapTileLoader(QObject):
         # tiles stop sharpening.
         self.MAX_ZOOM_SATELLITE = 20
         self.MAX_ZOOM_MAP = 19
+
+        # Ancestor fallback: when a tile is missing (404 / network error) or
+        # is a "no imagery at this zoom" placeholder, serve an upscaled crop
+        # of the nearest usable ancestor tile instead, so zooming past the
+        # source's real coverage keeps showing the last good imagery rather
+        # than a wall of gray/placeholder tiles. This is how far up the
+        # pyramid we will climb (5 levels = a 32x upscale at worst).
+        self.MAX_FALLBACK_LEVELS = 5
+        # Placeholder detection: fraction of sampled pixels that must share
+        # one luminance bucket for a tile to count as a "no imagery"
+        # placeholder. Genuinely uniform imagery (open water) can trip this
+        # too, but its ancestor crop shows the same pixels, so a false
+        # positive is visually harmless.
+        self.PLACEHOLDER_UNIFORM_FRACTION = 0.90
+
+        # Pending fallback resolutions: (x, y, zoom, source) of an ancestor
+        # download -> list of (x, y, zoom) descendant tiles waiting on it.
+        self.fallback_waiters = {}
+        # Ancestor downloads that errored this session; the fallback walk
+        # climbs past them instead of re-requesting a dead tile forever.
+        # Cleared with the error counter so a recovered network gets retried.
+        self._fallback_failed = set()
 
         # Error tracking
         self.error_count = 0
@@ -149,10 +171,18 @@ class MapTileLoader(QObject):
             # Load from cache
             pixmap = QPixmap(str(cache_path))
             if not pixmap.isNull():
+                # A cached "no imagery at this zoom" placeholder is worth
+                # less than an upscaled crop of real imagery from a lower
+                # zoom - prefer the ancestor when one is usable.
+                if self._looks_unavailable(pixmap) and self._emit_fallback_tile(x_tile, y_tile, zoom):
+                    return
                 self.tile_loaded.emit(x_tile, y_tile, zoom, pixmap)
                 return
-        # If offline, don't attempt network and show placeholder/error
+        # If offline, don't attempt network: fall back to a cached ancestor
+        # crop when possible, gray placeholder otherwise.
         if self.offline_only:
+            if self._emit_fallback_tile(x_tile, y_tile, zoom):
+                return
             self.tile_error.emit("Offline mode: map tiles unavailable")
             pixmap = QPixmap(self.tile_size, self.tile_size)
             pixmap.fill(QColor(200, 200, 200))
@@ -223,7 +253,16 @@ class MapTileLoader(QObject):
             pixmap.loadFromData(data)
 
             if not pixmap.isNull():
-                self.tile_loaded.emit(x_tile, y_tile, zoom, pixmap)
+                # Some servers answer 200 with a "no imagery at this zoom"
+                # placeholder image; replace it with an upscaled ancestor
+                # crop when one is available (or arriving).
+                if self._looks_unavailable(pixmap) and self._emit_fallback_tile(x_tile, y_tile, zoom):
+                    pass
+                else:
+                    self.tile_loaded.emit(x_tile, y_tile, zoom, pixmap)
+            # Descendant tiles may be waiting on this download to build
+            # their fallback crops.
+            self._serve_fallback_waiters(x_tile, y_tile, zoom)
         else:
             # Handle error
             error_code = reply.error()
@@ -236,18 +275,150 @@ class MapTileLoader(QObject):
                 pixmap = QPixmap(str(cache_path))
                 if not pixmap.isNull():
                     self.tile_loaded.emit(x_tile, y_tile, zoom, pixmap)
+                    self._serve_fallback_waiters(x_tile, y_tile, zoom)
                     # Don't count as error if we have cache
                     return
+
+            # Remember the failure so fallback walks climb past this tile
+            # instead of re-requesting it in a loop while the network is down.
+            self._fallback_failed.add((x_tile, y_tile, zoom, self.tile_source))
 
             # Track errors and notify user if necessary
             self._handle_tile_error(error_code, error_string, http_status)
 
-            # Only show gray tile if no cache exists
-            pixmap = QPixmap(self.tile_size, self.tile_size)
-            pixmap.fill(QColor(200, 200, 200))
-            self.tile_loaded.emit(x_tile, y_tile, zoom, pixmap)
+            # Prefer an upscaled ancestor crop over a blank gray tile so the
+            # user keeps context of where they are in the imagery.
+            if not self._emit_fallback_tile(x_tile, y_tile, zoom):
+                pixmap = QPixmap(self.tile_size, self.tile_size)
+                pixmap.fill(QColor(200, 200, 200))
+                self.tile_loaded.emit(x_tile, y_tile, zoom, pixmap)
+
+            # Resolve any descendants waiting on this (failed) ancestor: their
+            # walk will now skip it and climb further up.
+            self._serve_fallback_waiters(x_tile, y_tile, zoom)
 
         reply.deleteLater()
+
+    def _looks_unavailable(self, pixmap):
+        """
+        Heuristic check for a "no imagery at this zoom" placeholder tile.
+
+        Real placeholder tiles (e.g. Esri's "Map data not yet available")
+        are a near-uniform background with at most a little text, so almost
+        every sampled pixel shares one luminance bucket. Sampling uses
+        FastTransformation (nearest pixel, no blending) so anti-aliased text
+        does not smear into the background statistics.
+
+        Args:
+            pixmap: The tile QPixmap to inspect.
+
+        Returns:
+            bool: True when the tile is uniform enough to be a placeholder.
+        """
+        if pixmap.isNull():
+            return True
+        image = pixmap.toImage().scaled(
+            24, 24,
+            Qt.AspectRatioMode.IgnoreAspectRatio,
+            Qt.TransformationMode.FastTransformation)
+        counts = [0] * 16
+        total = image.width() * image.height()
+        if total <= 0:
+            return True
+        for y in range(image.height()):
+            for x in range(image.width()):
+                gray = qGray(image.pixel(x, y))
+                counts[gray >> 4] += 1
+        # Merge adjacent buckets so sensor noise straddling a bucket edge
+        # doesn't hide a uniform tile.
+        best = max(counts[i] + counts[i + 1] for i in range(15))
+        return (best / total) >= self.PLACEHOLDER_UNIFORM_FRACTION
+
+    def _crop_from_ancestor(self, ancestor_pixmap, x_tile, y_tile, dz):
+        """
+        Cut the region of an ancestor tile covering (x_tile, y_tile) and
+        upscale it to a full tile.
+
+        Args:
+            ancestor_pixmap: Pixmap of the ancestor tile (dz levels up).
+            x_tile, y_tile: Tile coordinates of the descendant being served.
+            dz: Zoom level difference (>= 1).
+
+        Returns:
+            QPixmap: A tile_size x tile_size upscaled crop.
+        """
+        n = 1 << dz
+        sub = self.tile_size / n
+        sx = int((x_tile % n) * sub)
+        sy = int((y_tile % n) * sub)
+        side = max(1, int(sub))
+        region = ancestor_pixmap.copy(sx, sy, side, side)
+        return region.scaled(
+            self.tile_size, self.tile_size,
+            Qt.AspectRatioMode.IgnoreAspectRatio,
+            Qt.TransformationMode.SmoothTransformation)
+
+    def _emit_fallback_tile(self, x_tile, y_tile, zoom):
+        """
+        Serve (x_tile, y_tile, zoom) from the nearest usable ancestor tile.
+
+        Walks up the pyramid: a cached, non-placeholder ancestor is cropped
+        and emitted immediately. The first ancestor that is neither cached
+        nor known-failed is downloaded (when online) and the tile is queued
+        on it; the fallback then completes in on_tile_downloaded.
+
+        Returns:
+            bool: True when a crop was emitted or a download was scheduled;
+                False when every ancestor up to MAX_FALLBACK_LEVELS is
+                exhausted (caller should emit its own last-resort tile).
+        """
+        for dz in range(1, self.MAX_FALLBACK_LEVELS + 1):
+            ancestor_zoom = zoom - dz
+            if ancestor_zoom < 1:
+                break
+            ax = x_tile >> dz
+            ay = y_tile >> dz
+            cache_path = self.cache_dir / f"{self.tile_source}_{ancestor_zoom}_{ax}_{ay}.png"
+            if cache_path.exists():
+                pixmap = QPixmap(str(cache_path))
+                if not pixmap.isNull() and not self._looks_unavailable(pixmap):
+                    self.tile_loaded.emit(
+                        x_tile, y_tile, zoom,
+                        self._crop_from_ancestor(pixmap, x_tile, y_tile, dz))
+                    return True
+                continue  # cached but unusable - climb further
+            key = (ax, ay, ancestor_zoom, self.tile_source)
+            if self.offline_only or key in self._fallback_failed:
+                continue  # can't/shouldn't fetch this one - climb further
+            self.fallback_waiters.setdefault(key, []).append((x_tile, y_tile, zoom))
+            self.download_tile(ax, ay, ancestor_zoom)
+            return True
+        return False
+
+    def _serve_fallback_waiters(self, x_tile, y_tile, zoom):
+        """
+        Re-run the fallback walk for tiles queued on a finished download.
+
+        Called from on_tile_downloaded for both outcomes: on success the
+        walk finds the fresh cache entry and emits crops; on failure (or a
+        placeholder) it climbs past this ancestor. Waiters whose walk is
+        fully exhausted get their own cached tile back, or gray.
+        """
+        key = (x_tile, y_tile, zoom, self.tile_source)
+        waiters = self.fallback_waiters.pop(key, None)
+        if not waiters:
+            return
+        for wx, wy, wz in waiters:
+            if self._emit_fallback_tile(wx, wy, wz):
+                continue
+            # Exhausted: fall back to the tile's own cached content (the
+            # placeholder we suppressed earlier) or a gray tile.
+            own_cache = self.cache_dir / f"{self.tile_source}_{wz}_{wx}_{wy}.png"
+            pixmap = QPixmap(str(own_cache)) if own_cache.exists() else QPixmap()
+            if pixmap.isNull():
+                pixmap = QPixmap(self.tile_size, self.tile_size)
+                pixmap.fill(QColor(200, 200, 200))
+            self.tile_loaded.emit(wx, wy, wz, pixmap)
 
     def calculate_zoom_for_bounds(self, min_lat, max_lat, min_lon, max_lon, map_width, map_height):
         """
@@ -328,3 +499,6 @@ class MapTileLoader(QObject):
         """Reset the error count after a period of successful operations."""
         self.error_count = 0
         self.last_error_message = None
+        # A quiet 30s means the network may have recovered - let fallback
+        # walks retry ancestors that previously failed to download.
+        self._fallback_failed.clear()

--- a/app/tests/core/views/images/viewer/widgets/test_widgets.py
+++ b/app/tests/core/views/images/viewer/widgets/test_widgets.py
@@ -743,3 +743,47 @@ def test_thermal_range_slider_wrap_updates(app):
 
     slider.set_selection_wrap(True)
     assert slider.selection_wrap()
+
+
+# ---------------------------------------------------------------------------
+# Map tile zoom limits (satellite detail; field report: sat imagery stopped
+# sharpening at z18 while the Align Image view reached z20)
+# ---------------------------------------------------------------------------
+
+def test_tile_loader_max_zoom_per_source(app):
+    loader = MapTileLoader()
+    assert loader.max_zoom() == loader.MAX_ZOOM_MAP  # default source is 'map'
+    loader.set_tile_source('satellite')
+    assert loader.max_zoom() == loader.MAX_ZOOM_SATELLITE
+    assert loader.MAX_ZOOM_SATELLITE == 20  # matches AlignImageView
+    assert loader.MAX_ZOOM_MAP == 19
+
+
+def test_zoom_for_bounds_caps_at_source_max(app):
+    loader = MapTileLoader()
+    # Tiny bounds on a big viewport -> huge computed zoom, must clamp.
+    args = (37.0440, 37.0441, -117.6320, -117.6319, 2000, 2000)
+    loader.set_tile_source('satellite')
+    assert loader.calculate_zoom_for_bounds(*args) == loader.MAX_ZOOM_SATELLITE
+    loader.set_tile_source('map')
+    assert loader.calculate_zoom_for_bounds(*args) == loader.MAX_ZOOM_MAP
+
+
+def test_view_zoom_step_honors_source_max(app):
+    view = GPSMapView()
+    view.tile_loader.set_tile_source('satellite')
+    view.zoom_scale = 2.0  # over the 1.5 step-in threshold
+    view.current_zoom = 19
+    view._check_tile_zoom_level()
+    assert view.current_zoom == 20
+    view.zoom_scale = 2.0  # _change_tile_zoom_level rescales the view
+    view._check_tile_zoom_level()
+    assert view.current_zoom == 20  # capped
+
+
+def test_switching_to_street_map_steps_down_from_z20(app):
+    view = GPSMapView()
+    view.tile_loader.set_tile_source('satellite')
+    view.current_zoom = 20
+    view.set_tile_source('map')
+    assert view.current_zoom == view.tile_loader.MAX_ZOOM_MAP

--- a/app/tests/core/views/images/viewer/widgets/test_widgets.py
+++ b/app/tests/core/views/images/viewer/widgets/test_widgets.py
@@ -787,3 +787,145 @@ def test_switching_to_street_map_steps_down_from_z20(app):
     view.current_zoom = 20
     view.set_tile_source('map')
     assert view.current_zoom == view.tile_loader.MAX_ZOOM_MAP
+
+
+# ---------------------------------------------------------------------------
+# Map tile ancestor fallback (missing / "no imagery" tiles keep showing the
+# last good zoom level's imagery instead of gray or placeholder tiles)
+# ---------------------------------------------------------------------------
+
+def _uniform_tile(color):
+    """A 256x256 single-color tile pixmap."""
+    pixmap = QPixmap(256, 256)
+    pixmap.fill(color)
+    return pixmap
+
+
+def _checker_tile(colors=None):
+    """A 256x256 tile with a 32px checkerboard - clearly real imagery."""
+    from PySide6.QtGui import QPainter, QColor
+    colors = colors or [QColor(30, 90, 30), QColor(200, 180, 120),
+                        QColor(60, 60, 160), QColor(240, 240, 240)]
+    pixmap = QPixmap(256, 256)
+    painter = QPainter(pixmap)
+    for row in range(8):
+        for col in range(8):
+            painter.fillRect(col * 32, row * 32, 32, 32,
+                             colors[(row + col) % len(colors)])
+    painter.end()
+    return pixmap
+
+
+def _quadrant_tile():
+    """A 256x256 tile with four distinct solid quadrants (TL/TR/BL/BR)."""
+    from PySide6.QtGui import QPainter, QColor
+    pixmap = QPixmap(256, 256)
+    painter = QPainter(pixmap)
+    painter.fillRect(0, 0, 128, 128, QColor(255, 0, 0))       # TL
+    painter.fillRect(128, 0, 128, 128, QColor(0, 255, 0))     # TR
+    painter.fillRect(0, 128, 128, 128, QColor(0, 0, 255))     # BL
+    painter.fillRect(128, 128, 128, 128, QColor(255, 255, 0))  # BR
+    painter.end()
+    return pixmap
+
+
+@pytest.fixture
+def fallback_loader(app, tmp_path):
+    """A MapTileLoader with an isolated cache dir and captured emissions."""
+    loader = MapTileLoader()
+    loader.cache_dir = tmp_path
+    loader.set_tile_source('satellite')
+    emitted = []
+    loader.tile_loaded.connect(lambda x, y, z, pm: emitted.append((x, y, z, pm)))
+    return loader, emitted, tmp_path
+
+
+def _cache(loader_dir, source, zoom, x, y, pixmap):
+    pixmap.save(str(loader_dir / f"{source}_{zoom}_{x}_{y}.png"))
+
+
+def test_placeholder_detection(app):
+    from PySide6.QtGui import QColor, QPainter
+    loader = MapTileLoader()
+    assert loader._looks_unavailable(_uniform_tile(QColor(230, 230, 230)))
+    # A placeholder with a little text is still near-uniform.
+    texty = _uniform_tile(QColor(255, 255, 255))
+    painter = QPainter(texty)
+    painter.setPen(QColor(140, 140, 140))
+    painter.drawText(60, 128, "Map data not yet available")
+    painter.end()
+    assert loader._looks_unavailable(texty)
+    # Real imagery is not.
+    assert not loader._looks_unavailable(_checker_tile())
+
+
+def test_crop_from_ancestor_picks_the_right_quadrant(app):
+    from PySide6.QtGui import qGray
+    loader = MapTileLoader()
+    parent = _quadrant_tile()
+    # Child tile at odd x, even y sits in the parent's top-right quadrant.
+    crop = loader._crop_from_ancestor(parent, 5, 4, 1)
+    assert crop.width() == 256 and crop.height() == 256
+    image = crop.toImage()
+    for px, py in ((10, 10), (128, 128), (245, 245)):
+        pixel = image.pixelColor(px, py)
+        assert pixel.green() > 200 and pixel.red() < 60, \
+            f"expected TR-quadrant green at {px},{py}, got {pixel.name()}"
+
+
+def test_cached_placeholder_replaced_by_parent_crop(fallback_loader):
+    from PySide6.QtGui import QColor
+    loader, emitted, cache = fallback_loader
+    _cache(cache, 'satellite', 20, 10, 10, _uniform_tile(QColor(235, 235, 235)))
+    _cache(cache, 'satellite', 19, 5, 5, _checker_tile())
+    loader.load_tile(10, 10, 20)
+    assert len(emitted) == 1
+    x, y, z, pixmap = emitted[0]
+    assert (x, y, z) == (10, 10, 20)
+    # The emitted tile is the upscaled checkerboard, not the placeholder.
+    assert not loader._looks_unavailable(pixmap)
+
+
+def test_offline_missing_tile_uses_cached_ancestor(fallback_loader):
+    loader, emitted, cache = fallback_loader
+    loader.set_offline_only(True)
+    # Grandparent (dz=2) is the nearest cached ancestor.
+    _cache(cache, 'satellite', 18, 2, 2, _checker_tile())
+    loader.load_tile(10, 10, 20)
+    assert len(emitted) == 1
+    assert not loader._looks_unavailable(emitted[0][3])
+
+
+def test_offline_with_no_ancestor_emits_gray(fallback_loader):
+    loader, emitted, cache = fallback_loader
+    loader.set_offline_only(True)
+    loader.load_tile(10, 10, 20)
+    assert len(emitted) == 1
+    pixel = emitted[0][3].toImage().pixelColor(5, 5)
+    assert (pixel.red(), pixel.green(), pixel.blue()) == (200, 200, 200)
+
+
+def test_waiters_resolve_from_freshly_cached_ancestor(fallback_loader):
+    """A queued descendant is served once its ancestor download lands."""
+    loader, emitted, cache = fallback_loader
+    loader.fallback_waiters[(5, 5, 19, 'satellite')] = [(10, 10, 20)]
+    _cache(cache, 'satellite', 19, 5, 5, _checker_tile())
+    loader._serve_fallback_waiters(5, 5, 19)
+    assert len(emitted) == 1
+    assert emitted[0][:3] == (10, 10, 20)
+    assert not loader._looks_unavailable(emitted[0][3])
+    assert loader.fallback_waiters == {}
+
+
+def test_waiters_climb_past_placeholder_ancestor(fallback_loader):
+    """When the awaited parent is itself a placeholder, the walk continues
+    to the grandparent instead of surfacing the placeholder."""
+    from PySide6.QtGui import QColor
+    loader, emitted, cache = fallback_loader
+    loader.set_offline_only(True)  # keep the walk from scheduling downloads
+    loader.fallback_waiters[(5, 5, 19, 'satellite')] = [(10, 10, 20)]
+    _cache(cache, 'satellite', 19, 5, 5, _uniform_tile(QColor(240, 240, 240)))
+    _cache(cache, 'satellite', 18, 2, 2, _checker_tile())
+    loader._serve_fallback_waiters(5, 5, 19)
+    assert len(emitted) == 1
+    assert not loader._looks_unavailable(emitted[0][3])


### PR DESCRIPTION
## Summary

When the GPS map is zoomed past the tile source's real coverage, tiles today come back as gray squares or the server's "no imagery at this zoom" placeholder, and the operator loses all context of where they are. This PR makes `MapTileLoader` serve an **upscaled crop of the nearest usable ancestor tile** instead, so zooming in past the deepest available level keeps showing the last good imagery (progressively softer, but always oriented).

## How it works

- **Missing tiles** (404 / network error): before painting the gray placeholder, the loader walks up the tile pyramid (up to 5 levels) looking for a usable cached ancestor, crops the quadrant covering the requested tile, and upscales it. If no ancestor is cached and the app is online, the nearest un-cached ancestor is downloaded and the tile is served when it lands.
- **HTTP-200 placeholders** (e.g. Esri "Map data not yet available" images): detected by luminance uniformity — almost every sampled pixel in one bucket. A genuinely uniform real tile (open water) can trip the check, but its ancestor crop shows the same pixels, so a false positive is visually harmless.
- **Failed ancestor downloads** are remembered and skipped by later walks (no retry loops offline); the memory clears with the existing 30s error-reset timer so a recovered network gets retried.
- Fallback crops are never written to the disk cache — only genuine server responses are cached.

## Stacking

Based on #135 (`fix/map-satellite-zoom-depth`) and includes its commit — the two share `MapTileLoader`. Merging #135 first makes this a one-commit diff; merging this PR alone also lands #135's change.

## Testing

- 7 new tests in `test_widgets.py`: placeholder detection (uniform / text-placeholder / real imagery), quadrant crop correctness, cached-placeholder replacement, offline ancestor fallback, offline gray last-resort, async waiter resolution, and climbing past a placeholder ancestor.
- Full widgets suite: 46 passed. `flake8` clean.