### PR TITLE
feat(map): drag the AOI marker to correct its GPS position

### DIFF
--- a/app/core/controllers/images/viewer/GPSMapController.py
+++ b/app/core/controllers/images/viewer/GPSMapController.py
@@ -118,6 +118,8 @@ class GPSMapController(QObject):
             self.map_dialog = GPSMapDialog(self.parent, self.gps_data, current_gps_index, offline_only=offline_only)
             self.map_dialog.image_selected.connect(self.on_map_image_selected)
             self.map_dialog.gps_right_clicked.connect(self.on_map_gps_clicked)
+            self.map_dialog.aoi_marker_moved.connect(self.on_aoi_marker_moved)
+            self.map_dialog.aoi_reset_requested.connect(self.on_aoi_reset_requested)
             if hasattr(self.map_dialog, 'pod_display_changed'):
                 self.map_dialog.pod_display_changed.connect(self.on_pod_display_changed)
             if hasattr(self.map_dialog, 'canopy_download_requested'):
@@ -1206,3 +1208,92 @@ class GPSMapController(QObject):
             identifier_color = self.parent.settings.get('identifier_color', [255, 255, 0])
 
             self.map_dialog.update_aoi_marker(aoi_gps, identifier_color)
+
+    def _resolve_marker_aoi(self):
+        """Return the AOI dict behind the displayed marker, or None.
+
+        Resolves through the marker's own metadata (image_index/aoi_index)
+        rather than live viewer state, so a selection change racing the drag
+        cannot corrupt a different AOI.
+        """
+        view = self.map_dialog.map_view if self.map_dialog else None
+        aoi_data = getattr(view, 'aoi_data', None)
+        if not aoi_data:
+            return None
+        image_index = aoi_data.get('image_index', self.parent.current_image)
+        aoi_index = aoi_data.get('aoi_index', -1)
+        if aoi_index is None or aoi_index < 0:
+            return None
+        try:
+            image = self.parent.images[image_index]
+            return image['areas_of_interest'][aoi_index]
+        except (IndexError, KeyError, TypeError):
+            return None
+
+    def _store_user_aoi_position(self, aoi, lat, lon):
+        """Write (or clear, when lat/lon are None) an AOI's user-corrected
+        GPS position on the dict and its backing XML element, save the result
+        file, and redraw the marker from the stored state."""
+        xml_element = aoi.get('xml')
+        if lat is None or lon is None:
+            aoi.pop('user_latitude', None)
+            aoi.pop('user_longitude', None)
+            if xml_element is not None:
+                xml_element.attrib.pop('user_latitude', None)
+                xml_element.attrib.pop('user_longitude', None)
+        else:
+            aoi['user_latitude'] = lat
+            aoi['user_longitude'] = lon
+            if xml_element is not None:
+                xml_element.set('user_latitude', str(lat))
+                xml_element.set('user_longitude', str(lon))
+        try:
+            self.parent.xml_service.save_xml_file(self.parent.xml_path)
+        except Exception as e:
+            self.logger.error(f"Failed to save AOI position correction: {e}")
+        self.update_aoi_on_map()
+
+    def on_aoi_marker_moved(self, lat, lon):
+        """Confirm and persist an AOI position the user dragged on the map.
+
+        Declining snaps the marker back to where it was; accepting stores
+        the position on the AOI so the marker, viewer labels, and exports
+        all use the corrected coordinates from then on.
+        """
+        view = self.map_dialog.map_view if self.map_dialog else None
+        aoi = self._resolve_marker_aoi()
+        if view is None or view.aoi_data is None:
+            return
+        if aoi is None:
+            view.reset_aoi_marker_position()
+            return
+        old = view.aoi_data
+        dlat_m = (lat - old['latitude']) * 111320
+        dlon_m = (lon - old['longitude']) * 111320 * math.cos(math.radians(lat))
+        dist_m = math.sqrt(dlat_m * dlat_m + dlon_m * dlon_m)
+        resp = QMessageBox.question(
+            self.map_dialog,
+            self.tr("Update AOI Location?"),
+            self.tr("Move this AOI to {lat:.6f}, {lon:.6f}?\n\n"
+                    "That is {dist:.1f} m from its previous position. The "
+                    "corrected location is saved with the results and used "
+                    "for exports.").format(lat=lat, lon=lon, dist=dist_m),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.Yes)
+        if resp != QMessageBox.StandardButton.Yes:
+            view.reset_aoi_marker_position()
+            return
+        self._store_user_aoi_position(aoi, float(lat), float(lon))
+        if hasattr(self.parent, 'status_controller'):
+            self.parent.status_controller.show_toast(
+                self.tr("AOI location updated"), 3000)
+
+    def on_aoi_reset_requested(self):
+        """Clear a user-corrected AOI position back to the computed estimate."""
+        aoi = self._resolve_marker_aoi()
+        if aoi is None:
+            return
+        self._store_user_aoi_position(aoi, None, None)
+        if hasattr(self.parent, 'status_controller'):
+            self.parent.status_controller.show_toast(
+                self.tr("AOI location reset to the computed estimate"), 3000)

--- a/app/core/services/XmlService.py
+++ b/app/core/services/XmlService.py
@@ -234,6 +234,16 @@ class XmlService:
                     team_value = area_of_interest_xml.get('team', '')
                     if team_value:
                         area_of_interest['team'] = team_value
+                    # Load a user-corrected GPS position if present (set by
+                    # dragging the AOI marker on the GPS map). Old builds
+                    # ignore unknown attributes, so this stays read-compatible.
+                    if (area_of_interest_xml.get('user_latitude')
+                            and area_of_interest_xml.get('user_longitude')):
+                        try:
+                            area_of_interest['user_latitude'] = float(area_of_interest_xml.get('user_latitude'))
+                            area_of_interest['user_longitude'] = float(area_of_interest_xml.get('user_longitude'))
+                        except (ValueError, TypeError):
+                            pass
 
                     areas_of_interest.append(area_of_interest)
                 image['areas_of_interest'] = areas_of_interest
@@ -375,6 +385,11 @@ class XmlService:
             # Save user comment if present
             if 'user_comment' in area and area['user_comment']:
                 area_xml.set('user_comment', str(area['user_comment']))
+            # Save a user-corrected GPS position if present
+            if (area.get('user_latitude') is not None
+                    and area.get('user_longitude') is not None):
+                area_xml.set('user_latitude', str(area['user_latitude']))
+                area_xml.set('user_longitude', str(area['user_longitude']))
             # Save confidence scoring data if present
             if 'confidence' in area:
                 area_xml.set('confidence', str(area['confidence']))

--- a/app/core/services/image/AOIService.py
+++ b/app/core/services/image/AOIService.py
@@ -50,7 +50,7 @@ class AOIGPSResult:
     """Result of AOI GPS calculation with metadata."""
     latitude: float
     longitude: float
-    elevation_source: str  # 'terrain', 'flat', 'refined', 'refined_terrain', or 'error'
+    elevation_source: str  # 'terrain', 'flat', 'refined', 'refined_terrain', 'user', or 'error'
     terrain_elevation_m: Optional[float] = None
     effective_agl_m: Optional[float] = None
     geoid_correction_m: Optional[float] = None
@@ -121,6 +121,21 @@ class AOIService:
             AOIGPSResult or None: Result with coordinates and metadata, or None if not calculable.
         """
         try:
+            # --- User-corrected path: a hand-placed position wins outright ---
+            # The user dragged this AOI's marker to its true location on the
+            # map (satellite imagery), which overrides any computed estimate.
+            user_lat = aoi.get('user_latitude')
+            user_lon = aoi.get('user_longitude')
+            if user_lat is not None and user_lon is not None:
+                try:
+                    return AOIGPSResult(
+                        latitude=float(user_lat),
+                        longitude=float(user_lon),
+                        elevation_source='user',
+                    )
+                except (TypeError, ValueError):
+                    pass  # malformed override - fall through to the estimate
+
             # --- Refined path: user-aligned FOV corners bypass the metadata ---
             # When the user has manually aligned the image to satellite imagery,
             # the alignment is independent of the (possibly wrong) gimbal/GPS

--- a/app/core/views/images/viewer/dialogs/GPSMapDialog.py
+++ b/app/core/views/images/viewer/dialogs/GPSMapDialog.py
@@ -28,6 +28,12 @@ class GPSMapDialog(TranslationMixin, QDialog):
     # Signal emitted when user right-clicks on the map (lat, lon)
     gps_right_clicked = Signal(float, float)
 
+    # Signal emitted when the AOI marker is dragged to a new position (lat, lon)
+    aoi_marker_moved = Signal(float, float)
+
+    # Signal emitted when the user asks to clear a user-corrected AOI position
+    aoi_reset_requested = Signal()
+
     # Signal emitted when the POD overlay display changes (enabled, mode, opacity 0-100)
     pod_display_changed = Signal(bool, str, int)
 
@@ -84,6 +90,8 @@ class GPSMapDialog(TranslationMixin, QDialog):
         self.map_view = GPSMapView(self, offline_only=self.offline_only)
         self.map_view.point_clicked.connect(self.on_point_clicked)
         self.map_view.gps_right_clicked.connect(self.gps_right_clicked.emit)
+        self.map_view.aoi_marker_moved.connect(self.aoi_marker_moved.emit)
+        self.map_view.aoi_reset_requested.connect(self.aoi_reset_requested.emit)
 
         # Connect to tile error signals
         self.map_view.tile_loader.tile_error.connect(self.on_tile_error)
@@ -176,7 +184,9 @@ class GPSMapDialog(TranslationMixin, QDialog):
         controls_layout.addStretch()
 
         # Help text
-        help_label = QLabel(self.tr("Click point to select • Drag to pan • Scroll to zoom"))
+        help_label = QLabel(self.tr(
+            "Click point to select • Drag to pan • Scroll to zoom • "
+            "Drag AOI marker to correct its location"))
         help_label.setStyleSheet("font-size: 10px; color: gray;")
         controls_layout.addWidget(help_label)
 

--- a/app/core/views/images/viewer/widgets/GPSMapView.py
+++ b/app/core/views/images/viewer/widgets/GPSMapView.py
@@ -40,6 +40,12 @@ class GPSMapView(TranslationMixin, QGraphicsView):
     # Signal emitted when user right-clicks on the map (lat, lon)
     gps_right_clicked = Signal(float, float)
 
+    # Signal emitted when the AOI marker is dragged to a new position (lat, lon)
+    aoi_marker_moved = Signal(float, float)
+
+    # Signal emitted when the user asks to clear a user-corrected AOI position
+    aoi_reset_requested = Signal()
+
     def __init__(self, parent=None, offline_only=False):
         """Initialize the GPS map view."""
         super().__init__(parent)
@@ -78,6 +84,12 @@ class GPSMapView(TranslationMixin, QGraphicsView):
         # AOI marker storage
         self.aoi_marker = None  # Current AOI marker
         self.aoi_data = None  # Current AOI metadata
+
+        # AOI marker drag state: view position of the arming press (None when
+        # no press is active) and whether the press became a drag.
+        self._aoi_press_view_pos = None
+        self._aoi_dragging = False
+        self._saved_viewport_cursor = None
 
         # FOV (Field of View) box for current image
         self.fov_box = None
@@ -1162,13 +1174,16 @@ class GPSMapView(TranslationMixin, QGraphicsView):
             return
 
         if event.button() == Qt.MouseButton.LeftButton:
-            # Check AOI marker click
+            # Check AOI marker press: arm a possible drag. A press that never
+            # moves past the drag threshold shows the data popup on release.
             if self.aoi_marker:
                 aoi_view_pos = self.mapFromScene(self.aoi_marker.pos())
                 dx = event.pos().x() - aoi_view_pos.x()
                 dy = event.pos().y() - aoi_view_pos.y()
                 if math.sqrt(dx * dx + dy * dy) <= 10:
-                    self.show_aoi_popup(event.globalPos())
+                    self._aoi_press_view_pos = event.pos()
+                    self._aoi_dragging = False
+                    event.accept()
                     return
 
             # Check point click
@@ -1184,6 +1199,47 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                         return
 
         super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event: QMouseEvent):
+        """Drag the AOI marker while a press on it is active."""
+        if self._aoi_press_view_pos is not None and self.aoi_marker:
+            delta = event.pos() - self._aoi_press_view_pos
+            if (not self._aoi_dragging
+                    and delta.manhattanLength() > QApplication.startDragDistance()):
+                self._aoi_dragging = True
+                self._saved_viewport_cursor = self.viewport().cursor()
+                self.viewport().setCursor(Qt.CursorShape.ClosedHandCursor)
+            if self._aoi_dragging:
+                self.aoi_marker.setPos(self.mapToScene(event.pos()))
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event: QMouseEvent):
+        """Finish an AOI-marker press: a drag emits the new GPS position for
+        confirmation; a stationary press opens the marker's data popup."""
+        if self._aoi_press_view_pos is not None:
+            was_dragging = self._aoi_dragging
+            self._aoi_press_view_pos = None
+            self._aoi_dragging = False
+            if self._saved_viewport_cursor is not None:
+                self.viewport().setCursor(self._saved_viewport_cursor)
+                self._saved_viewport_cursor = None
+            if was_dragging and self.aoi_marker:
+                pos = self.aoi_marker.pos()
+                lat, lon = self.scene_to_lat_lon(pos.x(), pos.y())
+                self.aoi_marker_moved.emit(lat, lon)
+            else:
+                self.show_aoi_popup(event.globalPos())
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+    def reset_aoi_marker_position(self):
+        """Snap the AOI marker back to its stored GPS position (drag declined)."""
+        if self.aoi_marker and self.aoi_data:
+            self.aoi_marker.setPos(self.lat_lon_to_scene(
+                self.aoi_data['latitude'], self.aoi_data['longitude']))
 
     def show_aoi_popup(self, global_pos):
         """
@@ -1215,6 +1271,10 @@ class GPSMapView(TranslationMixin, QGraphicsView):
 
         copy_action = menu.addAction(self.tr("Copy Data"))
         copy_action.triggered.connect(self.copy_aoi_data)
+        # A user-corrected position can be cleared back to the estimate.
+        if self.aoi_data.get('elevation_source') == 'user':
+            reset_action = menu.addAction(self.tr("Reset to estimated position"))
+            reset_action.triggered.connect(self.aoi_reset_requested.emit)
         menu.exec(global_pos)
 
     def copy_aoi_data(self):
@@ -1352,6 +1412,9 @@ class GPSMapView(TranslationMixin, QGraphicsView):
         if aoi_gps_data.get('avg_info'):
             tooltip += f"{aoi_gps_data['avg_info']}\n"
         tooltip += f"GPS: {aoi_gps_data['latitude']:.6f}, {aoi_gps_data['longitude']:.6f}"
+        if aoi_gps_data.get('elevation_source') == 'user':
+            tooltip += "\n" + self.tr("Position corrected by user")
+        tooltip += "\n" + self.tr("Drag to correct the location")
         self.aoi_marker.setToolTip(tooltip)
 
         self.scene.addItem(self.aoi_marker)

--- a/app/tests/core/controllers/images/viewer/test_gps_map_controller.py
+++ b/app/tests/core/controllers/images/viewer/test_gps_map_controller.py
@@ -136,3 +136,80 @@ def test_closing_dialog_cancels_pending_fov_redraw():
     dialog.update_zoom_fov.reset_mock()
     controller._flush_zoom_fov()
     dialog.update_zoom_fov.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Draggable AOI marker: confirm + persist a user-corrected AOI position
+# ---------------------------------------------------------------------------
+
+import xml.etree.ElementTree as ET  # noqa: E402
+
+
+def _controller_with_marker():
+    """Controller wired to a stub dialog showing a marker for image 0, AOI 0."""
+    from core.controllers.images.viewer.GPSMapController import GPSMapController
+    parent = _Parent()
+    xml_element = ET.Element('areas_of_interest')
+    aoi = {'center': (10, 20), 'xml': xml_element}
+    parent.images = [{'name': 'img1.jpg', 'areas_of_interest': [aoi]}]
+    parent.xml_service = MagicMock()
+    parent.xml_path = 'results/ADIAT_Data.xml'
+    controller = GPSMapController(parent)
+    dialog = MagicMock()
+    dialog.isVisible.return_value = True
+    view = MagicMock()
+    view.aoi_data = {'latitude': 37.0, 'longitude': -117.0,
+                     'aoi_index': 0, 'image_index': 0}
+    dialog.map_view = view
+    controller.map_dialog = dialog
+    controller.update_aoi_on_map = MagicMock()  # marker redraw not under test
+    return controller, parent, aoi, xml_element, view
+
+
+def test_marker_drag_accept_persists_user_position():
+    controller, parent, aoi, xml_element, view = _controller_with_marker()
+    with patch('core.controllers.images.viewer.GPSMapController.QMessageBox') as box:
+        box.question.return_value = box.StandardButton.Yes
+        controller.on_aoi_marker_moved(37.001, -117.002)
+    assert aoi['user_latitude'] == pytest.approx(37.001)
+    assert aoi['user_longitude'] == pytest.approx(-117.002)
+    assert float(xml_element.get('user_latitude')) == pytest.approx(37.001)
+    assert float(xml_element.get('user_longitude')) == pytest.approx(-117.002)
+    parent.xml_service.save_xml_file.assert_called_once_with(parent.xml_path)
+    controller.update_aoi_on_map.assert_called_once()
+
+
+def test_marker_drag_decline_restores_marker():
+    controller, parent, aoi, xml_element, view = _controller_with_marker()
+    with patch('core.controllers.images.viewer.GPSMapController.QMessageBox') as box:
+        box.question.return_value = box.StandardButton.No
+        controller.on_aoi_marker_moved(37.001, -117.002)
+    view.reset_aoi_marker_position.assert_called_once()
+    assert 'user_latitude' not in aoi
+    assert xml_element.get('user_latitude') is None
+    parent.xml_service.save_xml_file.assert_not_called()
+
+
+def test_marker_reset_clears_user_position():
+    controller, parent, aoi, xml_element, view = _controller_with_marker()
+    aoi['user_latitude'] = 37.001
+    aoi['user_longitude'] = -117.002
+    xml_element.set('user_latitude', '37.001')
+    xml_element.set('user_longitude', '-117.002')
+    controller.on_aoi_reset_requested()
+    assert 'user_latitude' not in aoi
+    assert 'user_longitude' not in aoi
+    assert xml_element.get('user_latitude') is None
+    assert xml_element.get('user_longitude') is None
+    parent.xml_service.save_xml_file.assert_called_once_with(parent.xml_path)
+
+
+def test_marker_drag_with_stale_marker_metadata_is_safe():
+    """A marker whose indices no longer resolve must not corrupt anything."""
+    controller, parent, aoi, xml_element, view = _controller_with_marker()
+    view.aoi_data = {'latitude': 37.0, 'longitude': -117.0,
+                     'aoi_index': 5, 'image_index': 0}  # out of range
+    controller.on_aoi_marker_moved(37.001, -117.002)
+    view.reset_aoi_marker_position.assert_called_once()
+    assert 'user_latitude' not in aoi
+    parent.xml_service.save_xml_file.assert_not_called()

--- a/app/tests/core/services/image/test_aoi_service.py
+++ b/app/tests/core/services/image/test_aoi_service.py
@@ -100,6 +100,31 @@ def test_estimate_aoi_gps(sample_image_data, sample_aoi):
             assert hasattr(result, 'elevation_source')
 
 
+def test_estimate_aoi_gps_prefers_user_corrected_position(sample_image_data, sample_aoi):
+    """A user-corrected position (dragged marker) overrides every estimate
+    without touching metadata, terrain, or the image itself."""
+    with patch('core.services.image.AOIService.ImageService'):
+        service = AOIService(sample_image_data)
+        aoi = dict(sample_aoi, user_latitude=36.123456, user_longitude=-118.654321)
+        result = service.estimate_aoi_gps(sample_image_data, aoi)
+        assert result is not None
+        assert result.latitude == pytest.approx(36.123456)
+        assert result.longitude == pytest.approx(-118.654321)
+        assert result.elevation_source == 'user'
+
+
+def test_estimate_aoi_gps_ignores_malformed_user_position(sample_image_data, sample_aoi):
+    """A malformed override falls through to the normal estimate path."""
+    with patch('core.services.image.AOIService.ImageService'), \
+            patch('helpers.MetaDataHelper.MetaDataHelper.get_exif_data_piexif') as mock_exif, \
+            patch('helpers.LocationInfo.LocationInfo.get_gps') as mock_gps:
+        mock_exif.return_value = {}
+        mock_gps.return_value = None  # normal path bails out with None
+        service = AOIService(sample_image_data)
+        aoi = dict(sample_aoi, user_latitude='not-a-number', user_longitude='nope')
+        assert service.estimate_aoi_gps(sample_image_data, aoi) is None
+
+
 def test_get_aoi_representative_color(sample_image_data, sample_aoi):
     """Test getting representative color for an AOI."""
     test_img = np.zeros((200, 200, 3), dtype=np.uint8)

--- a/app/tests/core/services/test_xml_service.py
+++ b/app/tests/core/services/test_xml_service.py
@@ -98,6 +98,53 @@ def test_save_xml_file(tmp_path):
     assert os.path.exists(path)
 
 
+def test_user_corrected_aoi_position_round_trip(tmp_path, sample_xml):
+    """A user-corrected AOI position (dragged map marker) persists through
+    save/reload, and files without one parse exactly as before."""
+    service = XmlService(sample_xml)
+    images = service.get_images()
+    aoi = images[0]["areas_of_interest"][0]
+    assert "user_latitude" not in aoi  # legacy files stay untouched
+
+    aoi["xml"].set("user_latitude", "36.123456")
+    aoi["xml"].set("user_longitude", "-118.654321")
+    out_path = tmp_path / "saved.xml"
+    service.save_xml_file(out_path)
+
+    reloaded = XmlService(out_path).get_images()
+    aoi2 = reloaded[0]["areas_of_interest"][0]
+    assert aoi2["user_latitude"] == pytest.approx(36.123456)
+    assert aoi2["user_longitude"] == pytest.approx(-118.654321)
+    # The untouched AOI on the second image must not gain an override.
+    assert "user_latitude" not in reloaded[1]["areas_of_interest"][0]
+
+
+def test_add_image_to_xml_writes_user_corrected_position():
+    service = XmlService()
+    service.add_image_to_xml({
+        "path": "new_image.jpg",
+        "aois": [{"center": (25, 25), "radius": 5, "area": 50,
+                  "user_latitude": 36.5, "user_longitude": -118.25}],
+    })
+    aoi = service.get_images()[0]["areas_of_interest"][0]
+    assert aoi["user_latitude"] == pytest.approx(36.5)
+    assert aoi["user_longitude"] == pytest.approx(-118.25)
+
+
+def test_malformed_user_corrected_position_is_ignored(tmp_path):
+    xml_content = (
+        '<data><images><image path="image1.jpg">'
+        '<areas_of_interest center="(50,50)" radius="10" area="150" '
+        'user_latitude="garbage" user_longitude="1.0"/>'
+        '</image></images></data>'
+    )
+    path = tmp_path / "bad.xml"
+    path.write_text(xml_content)
+    aoi = XmlService(path).get_images()[0]["areas_of_interest"][0]
+    assert "user_latitude" not in aoi
+    assert "user_longitude" not in aoi
+
+
 @pytest.fixture
 def fov_corners():
     return [

--- a/app/tests/core/views/images/viewer/widgets/test_widgets.py
+++ b/app/tests/core/views/images/viewer/widgets/test_widgets.py
@@ -743,3 +743,67 @@ def test_thermal_range_slider_wrap_updates(app):
 
     slider.set_selection_wrap(True)
     assert slider.selection_wrap()
+
+
+# ---------------------------------------------------------------------------
+# Draggable AOI marker (drag to correct the AOI's GPS position)
+# ---------------------------------------------------------------------------
+
+def _view_with_marker(app):
+    view = GPSMapView()
+    view.current_zoom = 15
+    aoi_data = {'latitude': 37.0, 'longitude': -117.0, 'image_name': 'x.jpg',
+                'center_pixels': (10, 10), 'pixel_area': 100.0,
+                'aoi_index': 0, 'image_index': 0}
+    view.set_aoi_marker(aoi_data, [255, 255, 0])
+    return view
+
+
+def test_aoi_marker_drag_emits_moved_signal(app):
+    view = _view_with_marker(app)
+    moved = []
+    view.aoi_marker_moved.connect(lambda lat, lon: moved.append((lat, lon)))
+
+    press_pos = view.mapFromScene(view.aoi_marker.pos())
+    target_pos = press_pos + type(press_pos)(60, -40)
+
+    view.mousePressEvent(_mouse_event(
+        QEvent.Type.MouseButtonPress, press_pos.x(), press_pos.y(),
+        Qt.MouseButton.LeftButton, Qt.MouseButton.LeftButton))
+    view.mouseMoveEvent(_mouse_event(
+        QEvent.Type.MouseMove, target_pos.x(), target_pos.y(),
+        Qt.MouseButton.NoButton, Qt.MouseButton.LeftButton))
+    view.mouseReleaseEvent(_mouse_event(
+        QEvent.Type.MouseButtonRelease, target_pos.x(), target_pos.y(),
+        Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton))
+
+    assert len(moved) == 1
+    expected_scene = view.mapToScene(target_pos)
+    expected = view.scene_to_lat_lon(expected_scene.x(), expected_scene.y())
+    assert moved[0][0] == pytest.approx(expected[0], abs=1e-9)
+    assert moved[0][1] == pytest.approx(expected[1], abs=1e-9)
+
+    # Declining the move puts the marker back at the stored GPS position.
+    view.reset_aoi_marker_position()
+    restored = view.aoi_marker.pos()
+    original = view.lat_lon_to_scene(37.0, -117.0)
+    assert restored.x() == pytest.approx(original.x(), abs=1e-6)
+    assert restored.y() == pytest.approx(original.y(), abs=1e-6)
+
+
+def test_aoi_marker_stationary_press_opens_popup(app):
+    view = _view_with_marker(app)
+    view.show_aoi_popup = MagicMock()
+    moved = []
+    view.aoi_marker_moved.connect(lambda lat, lon: moved.append((lat, lon)))
+
+    press_pos = view.mapFromScene(view.aoi_marker.pos())
+    view.mousePressEvent(_mouse_event(
+        QEvent.Type.MouseButtonPress, press_pos.x(), press_pos.y(),
+        Qt.MouseButton.LeftButton, Qt.MouseButton.LeftButton))
+    view.mouseReleaseEvent(_mouse_event(
+        QEvent.Type.MouseButtonRelease, press_pos.x(), press_pos.y(),
+        Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton))
+
+    view.show_aoi_popup.assert_called_once()
+    assert moved == []


### PR DESCRIPTION
## Summary

The computed AOI GPS estimate can be off (altitude error, terrain, orientation), and until now there was no way to fix it. This PR lets the operator **drag the selected-AOI marker on the GPS map** to where the find actually is — typically against satellite imagery — and persist the corrected coordinates.

## Behaviour

- Press-and-drag the AOI marker to a new spot; on drop a confirmation shows the new coordinates and the distance moved.
- **No** snaps the marker straight back. **Yes** stores the corrected position on the AOI and saves the result file.
- A corrected AOI reports `elevation_source='user'`, its tooltip says "Position corrected by user", and the marker popup gains **Reset to estimated position** to clear the correction.
- A stationary click still opens the existing data popup (now on release instead of press — required to disambiguate click from drag).

## Where the correction applies

The override lives at the bottom of the stack — `AOIService.estimate_aoi_gps` returns the user position before any refined/ray-cast/terrain path — so the map marker, the viewer's AOI labels, and every export (KML, CalTopo, CSV…) automatically use the corrected coordinates.

## Persistence & compatibility

Stored as `user_latitude`/`user_longitude` attributes on the AOI's `<areas_of_interest>` element in `ADIAT_Data.xml`. Old builds ignore unknown attributes, so files stay fully read-compatible both ways; malformed values are ignored and fall back to the computed estimate.

## Testing

- `AOIService`: override preferred, malformed override falls through (2 tests)
- `XmlService`: save/reload round-trip, legacy files untouched, writer support, malformed-value guard (3 tests)
- `GPSMapView`: drag emits the new GPS + decline restores position; stationary press still opens the popup (2 tests)
- `GPSMapController`: accept persists dict+XML+save, decline restores, reset clears, stale marker metadata is safe (4 tests)
- Touched suites: 112 passed. `flake8` clean.