### PR TITLE
feat(person-ref): trace a shadow to recover the true capture time

### DIFF
--- a/app/core/controllers/images/viewer/WaldoPrePassController.py
+++ b/app/core/controllers/images/viewer/WaldoPrePassController.py
@@ -13,17 +13,16 @@ non-destructive corrected capture time (stamped in the waldo XMP namespace).
 The per-folder decision is remembered in settings.
 """
 
-import json
 import os
 from typing import List, Optional
 
 from core.services.LoggerService import LoggerService
 from core.services.SettingsService import SettingsService
 from core.services.waldo import WaldoMetadataService
+from core.services.waldo import WaldoClockDecisions
+from core.services.waldo.WaldoClockDecisions import CLOCK_DECISIONS_SETTING
 from core.views.images.viewer.dialogs.WaldoPrePassDialog import WaldoPrePassDialog
 from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import WaldoClockCorrectionDialog
-
-CLOCK_DECISIONS_SETTING = 'WaldoClockCorrections'
 
 
 class WaldoPrePassController:
@@ -104,19 +103,10 @@ class WaldoPrePassController:
     # ------------------------------------------------------------------
 
     def _clock_decisions(self) -> dict:
-        raw = self.settings_service.get_setting(CLOCK_DECISIONS_SETTING)
-        if not raw:
-            return {}
-        try:
-            decisions = json.loads(raw)
-            return decisions if isinstance(decisions, dict) else {}
-        except (TypeError, ValueError):
-            return {}
+        return WaldoClockDecisions.get_decisions(self.settings_service)
 
     def _store_clock_decision(self, folder_key: str, decision: dict):
-        decisions = self._clock_decisions()
-        decisions[folder_key] = decision
-        self.settings_service.set_setting(CLOCK_DECISIONS_SETTING, json.dumps(decisions))
+        WaldoClockDecisions.store_decision(folder_key, decision, self.settings_service)
 
     def _offer_clock_correction(self, waldo_paths: List[str], proposal,
                                 service: Optional[WaldoMetadataService] = None):
@@ -127,22 +117,40 @@ class WaldoPrePassController:
         'declined' suppresses the offer; a remembered acceptance re-applies
         silently (progress only) so images added to the folder later get
         corrected without re-asking.
+
+        When no fault proposal exists but an APPLIED correction fails the
+        physical sanity check (sun below the horizon on daylight imagery),
+        an amendment prefilled from the stamped values is offered instead -
+        overriding any remembered decision, since the evidence contradicts
+        it.
         """
-        if not waldo_paths or proposal is None:
+        if not waldo_paths:
             return
         try:
             if service is None:
                 service = WaldoMetadataService(terrain_service=None)
 
+            amend_reason = None
+            if proposal is None:
+                amend_reason = service.stamped_correction_suspect(waldo_paths)
+                if amend_reason is None:
+                    return
+                proposal = service.propose_amendment(waldo_paths)
+                if proposal is None:
+                    return
+                proposal.evidence.insert(0, amend_reason)
+
             folder_key = os.path.normcase(os.path.abspath(os.path.dirname(waldo_paths[0])))
             decision = self._clock_decisions().get(folder_key)
-            if decision and decision.get('decision') == 'declined':
+            if amend_reason is None and decision and decision.get('decision') == 'declined':
                 self.logger.info(
                     "WaldoPrePassController: clock fault detected but correction "
                     "was previously declined for this folder.")
                 return
 
-            auto = bool(decision and decision.get('decision') == 'accepted')
+            # A failed sanity check always re-asks; never silently re-applies.
+            auto = (amend_reason is None
+                    and bool(decision and decision.get('decision') == 'accepted'))
             if auto:
                 proposal.face_shift_h = int(decision.get('face_shift_h', proposal.face_shift_h))
                 tz_text = decision.get('tz_text')

--- a/app/core/services/coverage/kernel.py
+++ b/app/core/services/coverage/kernel.py
@@ -37,11 +37,16 @@ from core.services.coverage.contracts import (
 )
 
 
-def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float) -> np.ndarray:
+def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float,
+                          roll_axis_deg: Optional[float] = None) -> np.ndarray:
     """3x3 rotation from camera frame (X=right, Y=down, Z=optical) to NED.
 
-    Mirrors ``AOIService._calculate_ground_position`` step 2 (+ Rodrigues roll
-    about the heading axis) so this kernel and the viewer FOV stay consistent.
+    Mirrors ``AOIService._calculate_ground_position`` step 2 (+ Rodrigues
+    roll) so this kernel and the viewer FOV stay consistent. The roll
+    rotates about the camera-yaw azimuth by default; ``roll_axis_deg``
+    overrides the axis azimuth for stamps that express roll about the
+    FLIGHT axis (WALDO processor version >= 6) - using the wrong axis
+    mirrors the footprint to the opposite side of the track.
     """
     opt_elevation = math.radians(pitch_deg)
     opt_azimuth = math.radians(yaw_deg)
@@ -64,7 +69,9 @@ def build_camera_rotation(pitch_deg: float, yaw_deg: float, roll_deg: float) -> 
 
     if roll_deg != 0.0:
         roll_rad = math.radians(roll_deg)
-        heading_axis = np.array([math.cos(opt_azimuth), math.sin(opt_azimuth), 0.0])
+        axis_azimuth = (math.radians(roll_axis_deg)
+                        if roll_axis_deg is not None else opt_azimuth)
+        heading_axis = np.array([math.cos(axis_azimuth), math.sin(axis_azimuth), 0.0])
         kx, ky, kz = heading_axis
         K = np.array([
             [0.0, -kz, ky],
@@ -92,7 +99,8 @@ def project_footprint_corners(fg, params) -> List[Tuple[float, float]]:
     Used only to size the frame bbox.
     """
     hw, hh = _frustum_half_extents(fg)
-    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg)
+    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg,
+                              roll_axis_deg=getattr(fg, 'roll_axis_deg', None))
     corners = []
     for sx in (-hw, hw):
         for sy in (-hh, hh):
@@ -156,7 +164,8 @@ def compute_target_mask_and_gsd(dem: np.ndarray, spec: GridSpec, fg,
     dn = (ys[:, np.newaxis] - cam_y) * meters_per_unit      # (H, 1) north meters
     dd = cam_z - dem                                        # (H, W) down meters
 
-    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg)
+    R = build_camera_rotation(fg.pitch_deg, fg.yaw_deg, fg.roll_deg,
+                              roll_axis_deg=getattr(fg, 'roll_axis_deg', None))
     Rt = R.T  # camera <- NED
     # p_cam = R^T @ [north, east, down]
     px = Rt[0, 0] * dn + Rt[0, 1] * de + Rt[0, 2] * dd

--- a/app/core/services/image/CoverageExtentService.py
+++ b/app/core/services/image/CoverageExtentService.py
@@ -276,9 +276,14 @@ class CoverageExtentService:
             # Calculate the four corners of the image in GPS coordinates
             # Corners in image space (centered at the drone-nadir point on the
             # ground plane). Outward roll shifts that center cross-track by
-            # h*tan(roll); positive roll points the optical axis to the LEFT
-            # of heading (matches AOIService convention), so the centroid
-            # offset along the camera-X (right) axis is -h*tan(roll).
+            # h*tan(roll). The AXIS the roll rotates about depends on the
+            # stamping convention: WALDO processor version >= 6 expresses it
+            # about the FLIGHT axis (positive roll tilts LEFT of the flight
+            # direction), older stamps about the camera-yaw axis (positive
+            # roll tilts LEFT of the image-up bearing). Using the wrong axis
+            # mirrors the footprint to the opposite side of the track, so the
+            # shift is computed in earth (east/north) space and added after
+            # the corner rotation.
             agl_m = effective_agl_m  # DEM-corrected AGL when terrain resolved
             if agl_m is None or agl_m <= 0:
                 agl_m = image_service.get_relative_altitude('m')
@@ -288,13 +293,29 @@ class CoverageExtentService:
                     agl_m = self.custom_altitude_ft / 3.28084
                 else:
                     agl_m = 0.0
-            roll_offset_x = -agl_m * math.tan(math.radians(gimbal_roll))
+
+            roll_east_m = 0.0
+            roll_north_m = 0.0
+            if gimbal_roll:
+                roll_axis = None
+                try:
+                    axis_raw = image_service.get_roll_axis_azimuth()
+                    roll_axis = float(axis_raw) if axis_raw is not None else None
+                except Exception:
+                    roll_axis = None
+                # Positive roll points the optical axis LEFT of the axis
+                # bearing (AOIService Rodrigues convention).
+                axis_bearing = roll_axis if roll_axis is not None else bearing
+                left_bearing = math.radians(axis_bearing - 90.0)
+                offset_m = agl_m * math.tan(math.radians(gimbal_roll))
+                roll_east_m = offset_m * math.sin(left_bearing)
+                roll_north_m = offset_m * math.cos(left_bearing)
 
             corners_image = [
-                (roll_offset_x - width_m / 2, -height_m / 2),  # Top-left
-                (roll_offset_x + width_m / 2, -height_m / 2),  # Top-right
-                (roll_offset_x + width_m / 2, height_m / 2),   # Bottom-right
-                (roll_offset_x - width_m / 2, height_m / 2)    # Bottom-left
+                (-width_m / 2, -height_m / 2),  # Top-left
+                (width_m / 2, -height_m / 2),   # Top-right
+                (width_m / 2, height_m / 2),    # Bottom-right
+                (-width_m / 2, height_m / 2)    # Bottom-left
             ]
 
             # Rotate corners by bearing and convert to GPS
@@ -308,6 +329,10 @@ class CoverageExtentService:
                 # Rotate
                 x_rot = x * cos_b - y * sin_b
                 y_rot = x * sin_b + y * cos_b
+
+                # Apply the cross-track roll shift in earth space
+                x_rot += roll_east_m
+                y_rot += roll_north_m
 
                 # Convert to lat/lon offset
                 delta_lat = y_rot / self.earth_radius * (180 / math.pi)

--- a/app/core/services/image/FrameGeometry.py
+++ b/app/core/services/image/FrameGeometry.py
@@ -53,6 +53,10 @@ class FrameGeometry:
     bearing_confidence: float                    # 1.0 for gimbal/flight; mapped for 'calculated'; 0.25 for 'default'
     asl_alt_m: Optional[float] = None            # raw EXIF ASL altitude (datum fallback only)
     cam_elev_m: Optional[float] = None           # filled by the caller: DEM(nadir) + agl_m
+    # Azimuth of the axis roll_deg rotates about; None = camera-yaw axis.
+    # WALDO processor version >= 6 expresses roll about the FLIGHT axis -
+    # rolling about the wrong axis mirrors the footprint across the track.
+    roll_axis_deg: Optional[float] = None
 
     @classmethod
     def from_image_service(cls, image_service: "ImageService",
@@ -105,6 +109,14 @@ class FrameGeometry:
             if abs(roll_deg) > 90.0:
                 roll_deg = 0.0
 
+            roll_axis_deg = None
+            if roll_deg:
+                try:
+                    axis_raw = image_service.get_roll_axis_azimuth()
+                    roll_axis_deg = float(axis_raw) if axis_raw is not None else None
+                except Exception:
+                    roll_axis_deg = None
+
             return cls(
                 lat=lat,
                 lon=lon,
@@ -120,6 +132,7 @@ class FrameGeometry:
                 bearing_confidence=cls._confidence_for(yaw_source, bearing_quality),
                 asl_alt_m=image_service.get_asl_altitude('m'),
                 cam_elev_m=None,
+                roll_axis_deg=roll_axis_deg,
             )
         except Exception:
             return None

--- a/app/core/services/shadow/ShadowTimeSolver.py
+++ b/app/core/services/shadow/ShadowTimeSolver.py
@@ -1,0 +1,142 @@
+"""ShadowTimeSolver - infer the capture time of day from a traced shadow.
+
+Given the world azimuth a shadow points along (from the shadow caster's
+base toward the shadow tip), find the moment on the capture date when the
+sun would cast a shadow at exactly that azimuth. A shadow points directly
+away from the sun, so the target sun azimuth is the shadow azimuth + 180°.
+Through daylight hours the sun's azimuth sweeps (near-)monotonically, so
+the inversion is well-posed; the solver still detects and reports the rare
+ambiguous geometries (tropics / high latitudes) instead of guessing.
+
+Used by the Person Size Reference tool: tracing a real shadow in the image
+recovers the true time of day even when the camera clock is wrong, and the
+recovered time drives the sun-based shadow rendering.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import List, Optional, Tuple
+
+from core.services.shadow.SolarPosition import get_solar_position
+
+# Below this sun elevation the shadow direction is treated as unusable:
+# the sun is (nearly) set and shadows are indistinct.
+MIN_SUN_ELEVATION_DEG = 0.5
+
+# A candidate time only counts as a solution when the sun azimuth gets
+# within this many degrees of the target. Larger residuals mean the traced
+# direction cannot be produced by the sun that day.
+MAX_AZIMUTH_ERROR_DEG = 15.0
+
+# A second daylight minimum within this margin of the best one (and more
+# than an hour away) marks the solution as ambiguous.
+AMBIGUITY_MARGIN_DEG = 2.0
+AMBIGUITY_MIN_SEPARATION_MIN = 60
+
+
+@dataclass
+class ShadowTimeSolution:
+    """Result of inverting a traced shadow azimuth to a capture time."""
+    utc: datetime               # solved capture moment (UTC, tz-aware)
+    sun_elevation_deg: float    # sun elevation at the solved moment
+    sun_azimuth_deg: float      # sun azimuth at the solved moment
+    azimuth_error_deg: float    # residual |target - achieved| azimuth
+    direction_flipped: bool     # matched only with base/tip swapped
+    ambiguous: bool             # a second daylight time matched nearly as well
+
+
+def _circular_diff_deg(a: float, b: float) -> float:
+    """Smallest absolute angular difference between two azimuths."""
+    return abs((a - b + 180.0) % 360.0 - 180.0)
+
+
+def _daylight_samples(lat: float, lon: float, start: datetime,
+                      minutes: int, step_min: int) -> List[Tuple[datetime, float, float]]:
+    """(time, elevation, azimuth) samples with the sun above the horizon."""
+    samples = []
+    for m in range(0, minutes + 1, step_min):
+        dt = start + timedelta(minutes=m)
+        elev, az = get_solar_position(lat, lon, dt)
+        if elev >= MIN_SUN_ELEVATION_DEG:
+            samples.append((dt, elev, az))
+    return samples
+
+
+def _best_match(samples, target_az):
+    """(best_sample, error, ambiguous) for a target sun azimuth, or None."""
+    if not samples:
+        return None
+    errors = [(_circular_diff_deg(az, target_az), dt, elev, az)
+              for dt, elev, az in samples]
+    errors.sort(key=lambda e: e[0])
+    best_err, best_dt, best_elev, best_az = errors[0]
+    if best_err > MAX_AZIMUTH_ERROR_DEG:
+        return None
+    ambiguous = any(
+        err <= best_err + AMBIGUITY_MARGIN_DEG
+        and abs((dt - best_dt).total_seconds()) > AMBIGUITY_MIN_SEPARATION_MIN * 60
+        for err, dt, _elev, _az in errors[1:]
+    )
+    return (best_dt, best_elev, best_az), best_err, ambiguous
+
+
+def _refine(lat, lon, coarse_dt, target_az):
+    """Sharpen a coarse (1-minute) match with a 5-second local scan."""
+    best = None
+    for s in range(-90, 91, 5):
+        dt = coarse_dt + timedelta(seconds=s)
+        elev, az = get_solar_position(lat, lon, dt)
+        if elev < MIN_SUN_ELEVATION_DEG:
+            continue
+        err = _circular_diff_deg(az, target_az)
+        if best is None or err < best[0]:
+            best = (err, dt, elev, az)
+    return best
+
+
+def solve_time_for_shadow_azimuth(
+        lat: float, lon: float, capture_utc: datetime,
+        shadow_azimuth_deg: float) -> Optional[ShadowTimeSolution]:
+    """Find the time of day whose sun casts a shadow along a given azimuth.
+
+    Args:
+        lat, lon: Ground position of the shadow (degrees).
+        capture_utc: The claimed capture moment (tz-aware UTC). Only its
+            date matters - the scan covers the 24 h centred on it, so a
+            camera clock that is hours wrong still resolves onto the
+            correct solar day.
+        shadow_azimuth_deg: World azimuth the shadow points along, from
+            the caster's base toward the shadow tip (0 = north, CW).
+
+    Returns:
+        ShadowTimeSolution, or None when no daylight sun position matches
+        the traced direction (in either orientation).
+    """
+    if capture_utc.tzinfo is None:
+        raise ValueError("capture_utc must be timezone-aware")
+
+    start = capture_utc - timedelta(hours=12)
+    samples = _daylight_samples(lat, lon, start, 24 * 60, 1)
+
+    # The shadow points away from the sun. If the traced direction has no
+    # daylight match, try the reverse - users click tip-first often enough
+    # that silently failing would be worse than saying "flipped".
+    for flipped in (False, True):
+        offset = 0.0 if flipped else 180.0
+        target_az = (shadow_azimuth_deg + offset) % 360.0
+        match = _best_match(samples, target_az)
+        if match is None:
+            continue
+        (coarse_dt, elev, az), err, ambiguous = match
+        refined = _refine(lat, lon, coarse_dt, target_az)
+        if refined is not None:
+            err, coarse_dt, elev, az = refined
+        return ShadowTimeSolution(
+            utc=coarse_dt,
+            sun_elevation_deg=elev,
+            sun_azimuth_deg=az,
+            azimuth_error_deg=err,
+            direction_flipped=flipped,
+            ambiguous=ambiguous,
+        )
+    return None

--- a/app/core/services/waldo/WaldoClockDecisions.py
+++ b/app/core/services/waldo/WaldoClockDecisions.py
@@ -1,0 +1,50 @@
+"""
+WaldoClockDecisions - Per-folder persistence of clock-correction choices.
+
+Stores the operator's accept/decline decision (and the accepted values) for
+each image folder in application settings, so the pre-pass neither re-asks
+on every open nor silently re-applies stale values after an amendment.
+Shared by WaldoPrePassController (folder-open flow) and the Person
+Reference dialog's manual "Adjust clock" flow.
+"""
+
+import json
+import os
+from typing import Optional
+
+from core.services.SettingsService import SettingsService
+
+CLOCK_DECISIONS_SETTING = 'WaldoClockCorrections'
+
+
+def folder_key_for(path: str) -> str:
+    """Canonical settings key for the folder containing an image path."""
+    return os.path.normcase(os.path.abspath(os.path.dirname(path)))
+
+
+def get_decisions(settings_service: Optional[SettingsService] = None) -> dict:
+    """All stored per-folder decisions ({folder_key: decision_dict})."""
+    settings_service = settings_service or SettingsService()
+    raw = settings_service.get_setting(CLOCK_DECISIONS_SETTING)
+    if not raw:
+        return {}
+    try:
+        decisions = json.loads(raw)
+        return decisions if isinstance(decisions, dict) else {}
+    except (TypeError, ValueError):
+        return {}
+
+
+def get_decision(folder_key: str,
+                 settings_service: Optional[SettingsService] = None) -> Optional[dict]:
+    """The stored decision for one folder, or None."""
+    return get_decisions(settings_service).get(folder_key)
+
+
+def store_decision(folder_key: str, decision: dict,
+                   settings_service: Optional[SettingsService] = None):
+    """Persist (or overwrite) the decision for one folder."""
+    settings_service = settings_service or SettingsService()
+    decisions = get_decisions(settings_service)
+    decisions[folder_key] = decision
+    settings_service.set_setting(CLOCK_DECISIONS_SETTING, json.dumps(decisions))

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -62,7 +62,16 @@ WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
 # heading - 15 of 1464 images on field data), and cannot handle frames
 # re-flown in the opposite direction. The bump restamps existing datasets
 # so those images get corrected on their next open.
-WALDO_PROCESSOR_VERSION = "8"
+# Version 9: cam 1 is stored with image-top = plane FORWARD, not backward.
+# Content-vs-GPS-motion measurement on two independent flights proved the
+# two cameras come out of the WALDO ground software rotated 180 deg from
+# each other (the pods are body-opposed); v5..v8 stamped both cams
+# image-top = backward, so every 1_* image had its pixel-to-ground mapping
+# rotated 180 deg. The orientation safety net also aggregates in
+# track-RELATIVE space now: the old absolute circular mean mixed opposite
+# serpentine lanes into meaningless statistics and silently fell back to
+# the (wrong, for cam 1) model.
+WALDO_PROCESSOR_VERSION = "9"
 
 DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 
@@ -77,6 +86,14 @@ CLOCK_TIMEZONE_XMP = "ClockTimeZone"
 STATIONARY_THRESHOLD_M = 5.0
 MAX_NEIGHBOR_DT_S = 30.0
 OUTWARD_ROLL_DEG = 22.5
+
+# Mounting-model image-top offset from the plane heading, per camera.
+# The two DSLR bodies are mounted opposed, and the ground software keeps
+# each body's native orientation: cam 0 (`0_*`, RIGHT pod) comes out with
+# image-top = plane BACKWARD, cam 1 (`1_*`, LEFT pod) with image-top =
+# plane FORWARD. Field-verified by inter-frame content motion vs the GPS
+# track on two independent flights (2026-07-25 and 2026-08-07).
+MODEL_IMAGE_UP_OFFSET_DEG = {0: 180.0, 1: 0.0}
 
 # Orientation-measurement tunables. Field imagery showed the mounting-model
 # yaw assumption off by ~41 degrees (post-flight software had normalized the
@@ -201,23 +218,25 @@ class WaldoMetadataService:
 
     @staticmethod
     def compute_optical_axis_angles(heading_deg: float, cam_idx: int,
-                                    image_up_deg: Optional[float] = None) -> Dict[str, float]:
+                                    measured_orientation: Optional[Tuple[str, float]] = None
+                                    ) -> Dict[str, float]:
         """Return drone-dji-style gimbal triple for a WALDO capture.
 
         Yaw — the compass bearing of the stored JPEG's top edge, which is
         what AOIService and the FOV-box renderer consume:
 
-        - When `image_up_deg` is given it is the *measured* orientation
-          (from inter-frame content motion vs the GPS track; see
-          measure_image_up_bearing) and is used directly. Field imagery
-          proved the mounting model below wrong by ~41° on flights whose
-          post-flight software had normalized frames north-up, so a
-          measurement always wins over the model.
-        - Fallback (no measurement): the pod-mounting model, per WALDO
-          operator 2026-05-04 + screenshot. Cam 0 (`0_*`, RIGHT pod) is
-          stored rotated 180° by post-flight software; cam 1 (`1_*`,
-          LEFT pod) has body top facing the tail. Both stored images then
-          share image-top = plane backward: `yaw = heading + 180°`.
+        - Default: the pod-mounting model. The two DSLR bodies are mounted
+          opposed and each keeps its native orientation through the ground
+          software, so the image-top offset from the plane heading is
+          per-camera (MODEL_IMAGE_UP_OFFSET_DEG): cam 0 backward, cam 1
+          FORWARD. v5..v8 wrongly stamped both cams backward — every 1_*
+          image was 180 deg off (field-verified 2026-08-07).
+        - `measured_orientation` overrides the model when the inter-frame
+          content-motion measurement confidently contradicts it (see
+          measure_image_up_orientation). It is ('offset', deg) for a
+          track-relative image-top offset (normal WALDO storage), or
+          ('absolute', deg) for a fixed compass image-top (post-flight
+          software that normalizes frames, e.g. north-up).
 
         Roll — the pods physically tilt ±OUTWARD_ROLL_DEG cross-track
         (cam 0 to plane RIGHT, cam 1 to plane LEFT). As of processor
@@ -232,10 +251,16 @@ class WaldoMetadataService:
         """
         if cam_idx not in (0, 1):
             raise ValueError(f"Invalid WALDO cam_idx {cam_idx}")
-        if image_up_deg is not None:
-            yaw = float(image_up_deg) % 360.0
+        if measured_orientation is not None:
+            mode, value = measured_orientation
+            if mode == 'absolute':
+                yaw = float(value) % 360.0
+            elif mode == 'offset':
+                yaw = (float(heading_deg) + float(value)) % 360.0
+            else:
+                raise ValueError(f"Invalid orientation mode {mode!r}")
         else:
-            yaw = (float(heading_deg) + 180.0) % 360.0
+            yaw = (float(heading_deg) + MODEL_IMAGE_UP_OFFSET_DEG[cam_idx]) % 360.0
         roll = (-OUTWARD_ROLL_DEG) if cam_idx == 0 else (+OUTWARD_ROLL_DEG)
         return {
             'pitch': -90.0,
@@ -325,47 +350,62 @@ class WaldoMetadataService:
         spread_deg = math.degrees(math.sqrt(-2.0 * math.log(resultant)))
         return mean_deg, spread_deg
 
-    def _pair_motion_bearing(self, group: List["WaldoImageRecord"]) -> Optional[Tuple[float, float, int]]:
-        """Coarse image-top bearing from inter-frame motion vs the GPS track.
+    def _pair_motion_samples(self, group: List["WaldoImageRecord"]) -> List[Tuple[float, float, float]]:
+        """Per-pair orientation samples from inter-frame motion vs the track.
+
+        Pairs are name-consecutive frames (spatially adjacent regardless of
+        capture order; the spatial displacement between two frames gives the
+        same absolute image-top either way). Each sample carries the pair's
+        plane heading so the caller can aggregate in track-relative space.
 
         Returns:
-            (mean_deg, spread_deg, sample_count), or None with no usable pairs.
+            list of (image_up_deg, pair_heading_deg, inlier_weight).
         """
         candidates = []
         for a, b in zip(group, group[1:]):
+            if a.heading_deg is None:
+                continue
             north_m = (b.lat - a.lat) * 111320.0
             east_m = (b.lon - a.lon) * 111320.0 * math.cos(math.radians(a.lat))
             dist = math.hypot(north_m, east_m)
             if dist < ORIENTATION_MIN_BASELINE_M:
                 continue
             bearing = math.degrees(math.atan2(east_m, north_m)) % 360.0
-            candidates.append((a.path, b.path, bearing))
-        if not candidates:
-            return None
+            candidates.append((a.path, b.path, bearing, a.heading_deg))
 
-        step = max(1, len(candidates) // ORIENTATION_SAMPLE_PAIRS)
+        step = max(1, len(candidates) // ORIENTATION_SAMPLE_PAIRS) if candidates else 1
         samples = []
-        for path_a, path_b, bearing in candidates[::step][:ORIENTATION_SAMPLE_PAIRS]:
+        for path_a, path_b, bearing, heading in candidates[::step][:ORIENTATION_SAMPLE_PAIRS]:
             result = self._pair_orientation_sample(path_a, path_b, bearing)
             if result is not None:
-                samples.append(result)
-        if len(samples) < 2:
-            return None
-        mean_deg, spread_deg = self._circular_stats(
-            [s[0] for s in samples], [s[1] for s in samples])
-        return mean_deg, spread_deg, len(samples)
+                image_up, inliers = result
+                samples.append((image_up, heading, float(inliers)))
+        return samples
 
-    def measure_image_up_bearing(self, records: List["WaldoImageRecord"],
-                                 cam_idx: int) -> Optional[float]:
-        """Return a measured image-top bearing ONLY when it refutes the model.
+    def measure_image_up_orientation(self, records: List["WaldoImageRecord"],
+                                     cam_idx: int) -> Optional[Tuple[str, float]]:
+        """Measure the stored image orientation; report ONLY refutations.
 
         The inter-frame-motion measurement is too noisy on tilted fixed-wing
         imagery over relief to fine-tune the mounting model, but a dataset
-        whose frames were re-oriented by post-flight software reads far away
-        from the model (typically ~180 deg) - far beyond measurement noise.
-        So: measure, and return the measurement only when it is confident
-        AND disagrees with the model by more than ORIENTATION_OVERRIDE_DEG.
-        Returns None otherwise (caller stamps the mounting model).
+        whose frames were re-oriented reads far from the model (typically
+        ~180 deg) - far beyond measurement noise.
+
+        Samples are aggregated in TWO spaces and the tighter one wins:
+        - track-RELATIVE (image_up minus plane heading): normal WALDO
+          storage, where the orientation follows the flight direction. A
+          plain absolute mean would blend opposite serpentine lanes into
+          garbage statistics - exactly how the v5..v8 cam-1 fault stayed
+          invisible.
+        - ABSOLUTE compass: post-flight software that normalizes frames
+          (e.g. north-up) gives a constant absolute orientation, which the
+          relative space would scramble on serpentine flights.
+
+        Returns:
+            ('offset', deg) or ('absolute', deg) when the confident winner
+            contradicts the mounting model by more than
+            ORIENTATION_OVERRIDE_DEG; None otherwise (caller stamps the
+            model).
         """
         group = [r for r in records
                  if r.cam_idx == cam_idx and r.lat is not None and r.lon is not None]
@@ -373,37 +413,69 @@ class WaldoMetadataService:
         if not group:
             return None
 
-        motion = self._pair_motion_bearing(group)
-        if motion is None:
-            return None
-        mean_deg, spread_deg, count = motion
-        stderr_deg = spread_deg / math.sqrt(count)
-        if count < ORIENTATION_MIN_PAIRS or stderr_deg > ORIENTATION_MAX_STDERR_DEG:
+        samples = self._pair_motion_samples(group)
+        if len(samples) < ORIENTATION_MIN_PAIRS:
             self.logger.info(
                 f"WALDO cam {cam_idx}: orientation measurement inconclusive "
-                f"({count} pairs, stderr {stderr_deg:.1f} deg); using the mounting model"
+                f"({len(samples)} pairs); using the mounting model"
             )
             return None
 
-        headings = [r.heading_deg for r in group if r.heading_deg is not None]
-        if not headings:
+        weights = [s[2] for s in samples]
+        rel_mean, rel_spread = self._circular_stats(
+            [(s[0] - s[1]) % 360.0 for s in samples], weights)
+        abs_mean, abs_spread = self._circular_stats(
+            [s[0] for s in samples], weights)
+        count = len(samples)
+
+        headings = [s[1] for s in samples]
+        mean_heading, heading_spread = self._circular_stats(headings, weights)
+
+        if rel_spread <= abs_spread:
+            mode, mean_deg, spread_deg = 'offset', rel_mean, rel_spread
+            model_deg = MODEL_IMAGE_UP_OFFSET_DEG[cam_idx]
+        else:
+            mode, mean_deg, spread_deg = 'absolute', abs_mean, abs_spread
+            model_deg = (mean_heading + MODEL_IMAGE_UP_OFFSET_DEG[cam_idx]) % 360.0
+
+        stderr_deg = spread_deg / math.sqrt(count)
+        if stderr_deg > ORIENTATION_MAX_STDERR_DEG:
+            self.logger.info(
+                f"WALDO cam {cam_idx}: orientation measurement inconclusive "
+                f"({count} pairs, {mode} stderr {stderr_deg:.1f} deg); "
+                f"using the mounting model"
+            )
             return None
-        mean_heading, _ = self._circular_stats(headings, [1.0] * len(headings))
-        model_deg = (mean_heading + 180.0) % 360.0
+
+        if mode == 'absolute' and heading_spread > 45.0:
+            # A confident constant-ABSOLUTE orientation on a flight with
+            # mixed headings (serpentine) cannot come from any track-relative
+            # mounting: the frames were normalized by post-flight software.
+            # The mean-heading model comparison below would be degenerate, so
+            # this is a contradiction by construction.
+            self.logger.warning(
+                f"WALDO cam {cam_idx}: frames read a constant absolute "
+                f"orientation ({mean_deg:.1f} deg, {count} pairs, stderr "
+                f"{stderr_deg:.1f} deg) across mixed headings (spread "
+                f"{heading_spread:.0f} deg) - post-flight normalized imagery; "
+                f"stamping the measurement"
+            )
+            return ('absolute', mean_deg)
+
         gap = abs((mean_deg - model_deg + 180.0) % 360.0 - 180.0)
         if gap <= ORIENTATION_OVERRIDE_DEG:
             self.logger.info(
-                f"WALDO cam {cam_idx}: measured orientation {mean_deg:.1f} deg agrees "
-                f"with the mounting model {model_deg:.1f} deg (gap {gap:.1f} deg); "
+                f"WALDO cam {cam_idx}: measured orientation ({mode} {mean_deg:.1f} deg) "
+                f"agrees with the mounting model ({model_deg:.1f} deg, gap {gap:.1f}); "
                 f"stamping the model"
             )
             return None
         self.logger.warning(
-            f"WALDO cam {cam_idx}: measured orientation {mean_deg:.1f} deg "
-            f"({count} pairs, stderr {stderr_deg:.1f} deg) contradicts the mounting "
-            f"model {model_deg:.1f} deg (gap {gap:.1f} deg); stamping the measurement"
+            f"WALDO cam {cam_idx}: measured orientation ({mode} {mean_deg:.1f} deg, "
+            f"{count} pairs, stderr {stderr_deg:.1f} deg) contradicts the mounting "
+            f"model ({model_deg:.1f} deg, gap {gap:.1f} deg); stamping the measurement"
         )
-        return mean_deg
+        return (mode, mean_deg)
 
     # ------------------------------------------------------------------
     # Capture-time audit
@@ -687,6 +759,110 @@ class WaldoMetadataService:
                 )
             except Exception as e:
                 self.logger.warning(f"Clock-correction detection failed for {name}: {e}")
+        return None
+
+    @staticmethod
+    def get_correction_stamp_details(image_path: str) -> Optional[Tuple[float, str]]:
+        """(face_shift_h, tz_text) parsed from an image's correction stamp."""
+        try:
+            xmp = MetaDataHelper.get_xmp_data_merged(image_path) or {}
+        except Exception:
+            return None
+        shift_raw = None
+        tz_raw = None
+        for prefix in ('waldo:', '', 'XMP-waldo:'):
+            shift_raw = shift_raw or xmp.get(f'{prefix}{CLOCK_FACE_SHIFT_XMP}')
+            tz_raw = tz_raw or xmp.get(f'{prefix}{CLOCK_TIMEZONE_XMP}')
+        if shift_raw is None or tz_raw is None:
+            return None
+        try:
+            return float(str(shift_raw)), str(tz_raw)
+        except ValueError:
+            return None
+
+    def propose_amendment(self, paths: List[str]) -> Optional[ClockCorrectionProposal]:
+        """Build a proposal PRE-FILLED from an already-stamped correction.
+
+        Used when the operator wants to change an applied correction (the
+        normal detection deliberately goes quiet on corrected images).
+        Returns None when no sampled image carries a correction stamp.
+        """
+        for path in paths[:self.AUDIT_SAMPLE_FILES]:
+            name = os.path.basename(path)
+            try:
+                details = self.get_correction_stamp_details(path)
+                if details is None:
+                    continue
+                shift_h, tz_text = details
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                face_dt = self._parse_exif_face_time(exif)
+                if face_dt is None:
+                    continue
+                tz_name: Optional[str] = None
+                fixed_offset_h: Optional[float] = None
+                try:
+                    ZoneInfo(tz_text)
+                    tz_name = tz_text
+                except Exception:
+                    try:
+                        fixed_offset_h = float(tz_text.replace('UTC', '').strip())
+                    except ValueError:
+                        continue
+                corrected = self.compute_corrected_utc(
+                    face_dt, shift_h, tz_name, fixed_offset_h)
+                return ClockCorrectionProposal(
+                    face_shift_h=int(shift_h),
+                    tz_name=tz_name,
+                    fixed_offset_h=fixed_offset_h,
+                    evidence=[
+                        f"A capture-time correction is already stamped on these "
+                        f"images (face shift {shift_h:+.0f} h, zone {tz_text}). "
+                        f"Applying different values replaces it on every image."
+                    ],
+                    sample_name=name,
+                    sample_face=face_dt.strftime("%Y:%m:%d %H:%M:%S"),
+                    sample_corrected_utc=corrected.strftime("%Y-%m-%d %H:%M:%S UTC"),
+                )
+            except Exception as e:
+                self.logger.warning(f"Clock amendment proposal failed for {name}: {e}")
+        return None
+
+    def stamped_correction_suspect(self, paths: List[str]) -> Optional[str]:
+        """Detect an applied correction that is physically impossible.
+
+        A corrected capture time that puts the sun below the horizon while
+        the image is clearly daylight proves the correction is wrong (e.g.
+        a 12-hour shift applied to a camera whose clock face had already
+        been fixed). Returns a human-readable reason, or None.
+        """
+        for path in paths[:self.AUDIT_SAMPLE_FILES]:
+            name = os.path.basename(path)
+            try:
+                stamp = self.get_corrected_utc_stamp(path)
+                if not stamp:
+                    continue
+                corrected_utc = datetime.fromisoformat(stamp).astimezone(timezone.utc)
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                gps = LocationInfo.get_gps(exif_data=exif)
+                if gps is None:
+                    continue
+                elev, _az = get_solar_position(
+                    gps['latitude'], gps['longitude'], corrected_utc)
+                if elev >= -2.0:
+                    continue
+                img = cv2.imdecode(np.fromfile(path, dtype=np.uint8),
+                                   cv2.IMREAD_GRAYSCALE)
+                if img is None:
+                    continue
+                if float(img[::8, ::8].mean()) > self.AUDIT_DAYLIGHT_BRIGHTNESS:
+                    return (
+                        f"{name}: the stamped clock correction puts the capture at "
+                        f"{corrected_utc.strftime('%Y-%m-%d %H:%M UTC')}, when the sun "
+                        f"was below the horizon - but the image is clearly daylight. "
+                        f"The applied correction is wrong."
+                    )
+            except Exception as e:
+                self.logger.warning(f"Correction sanity check failed for {name}: {e}")
         return None
 
     def apply_clock_correction(
@@ -1118,17 +1294,16 @@ class WaldoMetadataService:
         self._apply_trigger_log_headings(records, result)
 
         # 3b. Measure the stored image orientation per camera by comparing
-        #     inter-frame content motion against the GPS track. Post-flight
-        #     software may normalize frames (field data showed north-up
-        #     imagery ~41 deg away from the mounting model), so measurement
-        #     always wins; the model is only the fallback.
-        image_up_by_cam: Dict[int, Optional[float]] = {}
+        #     inter-frame content motion against the GPS track. The mounting
+        #     model is stamped unless the measurement confidently refutes it
+        #     (catches post-flight software that re-orients frames).
+        orientation_by_cam: Dict[int, Optional[Tuple[str, float]]] = {}
         for cam_idx in sorted({r.cam_idx for r in records}):
             if cancel_cb():
                 result.cancelled = True
                 return result
             emit(0, 0, f"Measuring image orientation (cam {cam_idx})...")
-            image_up_by_cam[cam_idx] = self.measure_image_up_bearing(records, cam_idx)
+            orientation_by_cam[cam_idx] = self.measure_image_up_orientation(records, cam_idx)
 
         # 4. Per-image XMP synthesis
         total = len(records)
@@ -1162,7 +1337,7 @@ class WaldoMetadataService:
 
             angles = self.compute_optical_axis_angles(
                 rec.heading_deg, rec.cam_idx,
-                image_up_deg=image_up_by_cam.get(rec.cam_idx)
+                measured_orientation=orientation_by_cam.get(rec.cam_idx)
             )
 
             try:
@@ -1184,9 +1359,9 @@ class WaldoMetadataService:
         """Write the synthesised drone-dji + waldo:Processed fields in one batch.
 
         FlightYawDegree carries the plane's true heading (drone-body direction).
-        GimbalYawDegree carries the per-camera body orientation, which differs
-        from FlightYaw by 180° for cam 1 because that pod is mounted with its
-        body top facing the tail.
+        GimbalYawDegree carries the stored image-top bearing per camera:
+        image-top = plane backward for cam 0, plane FORWARD for cam 1 (the
+        opposed body mounting; see MODEL_IMAGE_UP_OFFSET_DEG).
         """
         flight_yaw = float(plane_heading_deg) % 360.0
         fields = [

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -22,7 +22,7 @@ import math
 import cv2
 import numpy as np
 
-from PySide6.QtCore import Qt, QRectF, QPointF
+from PySide6.QtCore import Qt, QRectF, QPointF, QTimer
 from PySide6.QtGui import QPen, QColor, QBrush, QPainterPath, QPolygonF
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QWidget,
@@ -287,6 +287,14 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.pose_items = {}   # 'standing'|'recumbent'|'sitting' -> QGraphicsPathItem
         self.shadow_item = None
 
+        # Image-change rebuilds are deferred so in-flight navigation (e.g.
+        # a gallery AOI click that loads the image and then zooms to the
+        # AOI) lands before the person is placed - see update_for_image.
+        self._pending_image = None
+        self._image_change_timer = QTimer(self)
+        self._image_change_timer.setSingleShot(True)
+        self._image_change_timer.timeout.connect(self._apply_pending_image)
+
         self._setup_ui()
         self._connect_signals()
         self._apply_translations()
@@ -500,8 +508,15 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             self._position_adjusted = True
 
     # ---------------- image / camera / sun ----------------
-    def _load_image(self, image_service, image_path, agl_override_m):
-        """Build the camera model and sun position for an image, then render."""
+    def _load_image(self, image_service, image_path, agl_override_m,
+                    allow_auto_zoom=True):
+        """Build the camera model and sun position for an image, then render.
+
+        Args:
+            allow_auto_zoom: whether the legibility auto-zoom may run. It is
+                suppressed on image changes that land in an already-zoomed
+                view (the navigation's zoom must not be hijacked).
+        """
         self.image_path = image_path
         self.camera = CameraModel.from_image_service(image_service, agl_override_m)
         self._resolve_sun()
@@ -518,7 +533,8 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             ))
         else:
             self._show_status(None)
-            self._ensure_reference_visible()
+            if allow_auto_zoom:
+                self._ensure_reference_visible()
 
     def _reference_bounds_scene(self):
         """United scene-space bounding rect of the visible silhouettes, or None.
@@ -573,10 +589,36 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         ))
 
     def update_for_image(self, image_service, image_path, agl_override_m=None):
-        """Rebuild the camera/sun for a newly selected image (called by Viewer)."""
+        """Rebuild the camera/sun for a newly selected image (called by Viewer).
+
+        The rebuild is deferred one beat: an image change is often part of a
+        larger navigation - a gallery AOI click loads the image and then
+        zooms to the AOI through a transient viewChanged handler. Rebuilding
+        immediately would anchor the person at the pre-zoom view centre and
+        the legibility auto-zoom would stomp the AOI zoom (field report).
+        Waiting lets the navigation land; the person is then placed at the
+        final view centre (the AOI, for gallery clicks).
+        """
         self._reset_trace_state()
         self._clear_items()
-        self._load_image(image_service, image_path, agl_override_m)
+        self._pending_image = (image_service, image_path, agl_override_m)
+        self._image_change_timer.start(300)
+
+    def _apply_pending_image(self):
+        """Deferred tail of update_for_image.
+
+        The legibility auto-zoom is never run here: it exists so the tool
+        does not look inert on FIRST open, but once the dialog is up an
+        image change is part of the operator's own navigation (arrow keys,
+        gallery zoom-to-AOI) and the view must stay exactly where that
+        navigation put it. Recenter brings the person in on demand.
+        """
+        if self._pending_image is None:
+            return
+        image_service, image_path, agl_override_m = self._pending_image
+        self._pending_image = None
+        self._load_image(image_service, image_path, agl_override_m,
+                         allow_auto_zoom=False)
 
     def _resolve_sun(self):
         """Resolve the sun elevation/azimuth from the image capture metadata."""
@@ -1314,6 +1356,10 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
 
     # ---------------- close ----------------
     def closeEvent(self, event):
+        # A pending image-change rebuild must not fire into a closed dialog
+        # (it would re-add overlay items that nothing would ever remove).
+        self._image_change_timer.stop()
+        self._pending_image = None
         self._reset_trace_state()
         self._clear_items()
         super().closeEvent(event)

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -1032,13 +1032,31 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             return self.image_viewer.sceneRect().center()
 
     def _default_anchor_scene(self):
-        """Initial person placement: the ground point directly under the drone.
+        """Person placement for open and Recenter: the current view centre.
 
-        The nadir projects to a compact, upright silhouette, so the overlay
-        opens sensibly no matter how the image is zoomed when the tool is
-        triggered (previously it dropped the person at the zoomed viewport
-        centre, which lands off-nadir and looks like an elongated smear).
-        Falls back to the image centre, then the viewport centre.
+        Opening the tool must not yank the operator away from the area
+        they are inspecting (field report: opening while zoomed to an AOI
+        panned the view to the image centre) - the person appears where
+        they are already looking, clamped to the image bounds. Falls back
+        to the nadir placement when the view centre cannot be determined.
+        """
+        try:
+            point = self._viewport_center_scene()
+            x = float(point.x())
+            y = float(point.y())
+            if self.camera is not None:
+                x = min(max(x, 0.0), float(self.camera.width))
+                y = min(max(y, 0.0), float(self.camera.height))
+            return QPointF(x, y)
+        except Exception:
+            return self._nadir_anchor_scene()
+
+    def _nadir_anchor_scene(self):
+        """Fallback placement: the ground point directly under the drone.
+
+        The nadir projects to a compact, upright silhouette, so the
+        overlay still opens sensibly when the view centre is unusable.
+        Falls back further to the image centre.
         """
         if self.camera is not None:
             nadir = self.camera.project(0.0, 0.0, self.camera.agl_m)
@@ -1048,7 +1066,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
                         and 0.0 <= v <= self.camera.height):
                     return QPointF(u, v)
             return QPointF(self.camera.width / 2.0, self.camera.height / 2.0)
-        return self._viewport_center_scene()
+        return QPointF(0.0, 0.0)
 
     def _show_status(self, message):
         if message:
@@ -1080,28 +1098,12 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         """Bring the reference person into the user's current view.
 
         The user pans/zooms to the spot they are inspecting and hits
-        Recenter to pull the overlay there - not back to the full-image
-        default. (Initial placement on open still uses the nadir via
-        _default_anchor_scene.)
+        Recenter to pull the overlay there - the same placement rule the
+        tool uses when it opens.
         """
         if self.anchor_item is not None:
-            self.anchor_item.setPos(self._current_view_anchor_scene())
+            self.anchor_item.setPos(self._default_anchor_scene())
             self._render_all()
-
-    def _current_view_anchor_scene(self):
-        """Recenter target: the current viewport centre, clamped to the
-        image bounds; falls back to the default (nadir) placement when the
-        view centre cannot be determined."""
-        try:
-            point = self._viewport_center_scene()
-            x = float(point.x())
-            y = float(point.y())
-            if self.camera is not None:
-                x = min(max(x, 0.0), float(self.camera.width))
-                y = min(max(y, 0.0), float(self.camera.height))
-            return QPointF(x, y)
-        except Exception:
-            return self._default_anchor_scene()
 
     # ---------------- shadow trace ----------------
     def _on_trace_shadow_clicked(self):

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -91,6 +91,12 @@ RECUMBENT_THICKNESS_FRACTION = 0.12
 # and is projected instead.
 NADIR_PITCH_TOLERANCE_DEG = 15.0
 
+# Gap (image px) between the reference person's anchor and the edge of the
+# selected AOI: an anchor landing on the AOI is shifted aside by the AOI's
+# radius plus this clearance, so the overlay never covers the detection it
+# is being compared against.
+AOI_CLEARANCE_PX = 40.0
+
 
 def _build_recumbent_path(height_cm):
     """Top-down silhouette of a person lying flat.
@@ -1089,9 +1095,42 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             if self.camera is not None:
                 x = min(max(x, 0.0), float(self.camera.width))
                 y = min(max(y, 0.0), float(self.camera.height))
-            return QPointF(x, y)
+            return self._avoid_selected_aoi(QPointF(x, y))
         except Exception:
-            return self._nadir_anchor_scene()
+            return self._avoid_selected_aoi(self._nadir_anchor_scene())
+
+    def _avoid_selected_aoi(self, point):
+        """Nudge an anchor point off the currently selected AOI.
+
+        Clicking an AOI centres the view on it, so a view-centre placement
+        would sit the person exactly on top of the find. When the anchor
+        falls within the AOI's radius + AOI_CLEARANCE_PX, shift it level
+        with the AOI to its left; when that leaves the image, to its right.
+        """
+        try:
+            viewer = self._parent_viewer
+            aoi_index = viewer.aoi_controller.selected_aoi_index
+            if aoi_index is None or aoi_index < 0:
+                return point
+            image = viewer.images[viewer.current_image]
+            aoi = image['areas_of_interest'][aoi_index]
+            aoi_x = float(aoi['center'][0])
+            aoi_y = float(aoi['center'][1])
+            radius = float(aoi.get('radius', 0) or 0)
+        except Exception:
+            return point
+        clearance = radius + AOI_CLEARANCE_PX
+        dx = point.x() - aoi_x
+        dy = point.y() - aoi_y
+        if (dx * dx + dy * dy) > clearance * clearance:
+            return point  # anchor is not on the AOI - leave it alone
+        left_x = aoi_x - clearance
+        if left_x >= 0.0:
+            return QPointF(left_x, aoi_y)
+        right_x = aoi_x + clearance
+        if self.camera is not None:
+            right_x = min(right_x, float(self.camera.width))
+        return QPointF(right_x, aoi_y)
 
     def _nadir_anchor_scene(self):
         """Fallback placement: the ground point directly under the drone.

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -363,6 +363,13 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.sun_label.setWordWrap(True)
         self.sun_label.setStyleSheet("QLabel { color: gray; }")
 
+        # WALDO imagery: the camera clock is corrected via stamped metadata;
+        # when the rendered shadow reveals a wrong correction, this is the
+        # place the operator notices - offer the amendment right here.
+        # (Visibility is decided in _update_sun_label, after the image loads.)
+        self.adjust_clock_button = QPushButton(self.tr("Adjust camera clock..."))
+        self.adjust_clock_button.setVisible(False)
+
         instructions = QLabel(self.tr(
             "Drag the white handle to position the reference person. "
             "Silhouettes are drawn at true ground scale for this image's "
@@ -375,6 +382,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.recenter_button = QPushButton(self.tr("Recenter"))
         self.close_button = QPushButton(self.tr("Close"))
         button_row.addWidget(self.recenter_button)
+        button_row.addWidget(self.adjust_clock_button)
         button_row.addStretch()
         button_row.addWidget(self.close_button)
 
@@ -400,7 +408,58 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.rotation_spin.valueChanged.connect(self._on_rotation_changed)
         self.color_button.clicked.connect(self._on_color_button_clicked)
         self.recenter_button.clicked.connect(self._recenter)
+        self.adjust_clock_button.clicked.connect(self._on_adjust_clock)
         self.close_button.clicked.connect(self.close)
+
+    def _is_waldo_image(self) -> bool:
+        try:
+            from core.services.waldo import WaldoMetadataService
+            return (self.image_path is not None
+                    and WaldoMetadataService.is_waldo_image(self.image_path) is not None)
+        except Exception:
+            return False
+
+    def _on_adjust_clock(self):
+        """Open the clock-correction dialog for this image's folder.
+
+        Prefilled from the currently stamped correction when one exists,
+        else from fresh fault detection. After an apply, the sun position
+        and shadows re-render with the corrected time.
+        """
+        import glob as _glob
+        import os as _os
+        from core.services.waldo import WaldoMetadataService, WaldoClockDecisions
+        from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import (
+            WaldoClockCorrectionDialog,
+        )
+        try:
+            folder = _os.path.dirname(self.image_path)
+            paths = [p for p in sorted(_glob.glob(_os.path.join(folder, '*.jpg')))
+                     if WaldoMetadataService.is_waldo_image(p) is not None]
+            if not paths:
+                return
+            service = WaldoMetadataService(terrain_service=None)
+            proposal = (service.propose_amendment(paths)
+                        or service.propose_clock_correction(paths))
+            if proposal is None:
+                self.sun_label.setText(self.tr(
+                    "No camera clock fault or applied correction was found "
+                    "for this folder."))
+                return
+            dialog = WaldoClockCorrectionDialog(self, service, paths, proposal)
+            dialog.exec()
+            if dialog.applied:
+                if dialog.remember_choice:
+                    WaldoClockDecisions.store_decision(
+                        WaldoClockDecisions.folder_key_for(paths[0]),
+                        {'decision': 'accepted',
+                         'face_shift_h': dialog.accepted_face_shift_h,
+                         'tz_text': dialog.accepted_tz_text})
+                self._resolve_sun()
+                self._update_sun_label()
+                self._on_params_changed()
+        except Exception as e:
+            LoggerService().error(f"PersonReferenceDialog: clock adjustment failed - {e}")
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -533,6 +592,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
 
     def _update_sun_label(self):
         """Refresh the sun-info line and enable/disable the shadow toggle."""
+        self.adjust_clock_button.setVisible(self._is_waldo_image())
         if self.sun_elev is not None and self.sun_elev > 0:
             text = self.tr(
                 "Sun at capture: {elev:.0f}° above horizon, "

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -27,7 +27,8 @@ from PySide6.QtGui import QPen, QColor, QBrush, QPainterPath, QPolygonF
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QWidget,
     QGroupBox, QComboBox, QSpinBox, QFormLayout, QCheckBox, QGraphicsPathItem,
-    QGraphicsEllipseItem, QGraphicsItem, QColorDialog,
+    QGraphicsEllipseItem, QGraphicsItem, QGraphicsLineItem, QColorDialog,
+    QApplication,
 )
 
 from helpers.TranslationMixin import TranslationMixin
@@ -40,7 +41,9 @@ from core.services import PersonModel
 from core.services.shadow.PersonShadow import compute_shadow_ground_points
 from core.services.shadow.SolarPosition import (
     resolve_capture_utc, get_solar_position, SolarTimeUnresolvable,
+    timezone_name_for_position,
 )
+from core.services.shadow.ShadowTimeSolver import solve_time_for_shadow_azimuth
 
 # Persisted setting keys. The overlay is a recurring reference tool, so the
 # user's last choices (colour, size class, which poses/shadow/terrain are on)
@@ -259,6 +262,15 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.sun_error = None
         self.sun_time_source = None
 
+        # Shadow-trace state: the user can trace a real shadow on the image
+        # (base of the caster, then shadow tip) and the solved time of day
+        # overrides the - possibly wrong - camera clock for sun rendering.
+        self._capture_utc = None          # resolved capture moment (UTC)
+        self._trace_override_utc = None   # solved time from a traced shadow
+        self._trace_active = False
+        self._trace_points = []           # image-pixel clicks, base first
+        self._trace_items = []            # scene items visualising the trace
+
         # DEM terrain state for the current image.
         self.terrain_service = None
         self.terrain_nadir_elev = None
@@ -370,6 +382,15 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.adjust_clock_button = QPushButton(self.tr("Adjust camera clock..."))
         self.adjust_clock_button.setVisible(False)
 
+        # Trace a real shadow in the image to recover the true time of day
+        # (works even when the camera clock is wrong).
+        self.trace_shadow_button = QPushButton(self.tr("Trace shadow..."))
+        self.trace_shadow_button.setToolTip(self.tr(
+            "Derive the time of day from a real shadow: click the base of "
+            "an object casting a shadow (rock, tree, post), then the tip of "
+            "its shadow. The solved time drives the rendered shadows."))
+        self.trace_shadow_button.setEnabled(False)
+
         instructions = QLabel(self.tr(
             "Drag the white handle to position the reference person. "
             "Silhouettes are drawn at true ground scale for this image's "
@@ -382,6 +403,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.recenter_button = QPushButton(self.tr("Recenter"))
         self.close_button = QPushButton(self.tr("Close"))
         button_row.addWidget(self.recenter_button)
+        button_row.addWidget(self.trace_shadow_button)
         button_row.addWidget(self.adjust_clock_button)
         button_row.addStretch()
         button_row.addWidget(self.close_button)
@@ -409,6 +431,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.color_button.clicked.connect(self._on_color_button_clicked)
         self.recenter_button.clicked.connect(self._recenter)
         self.adjust_clock_button.clicked.connect(self._on_adjust_clock)
+        self.trace_shadow_button.clicked.connect(self._on_trace_shadow_clicked)
         self.close_button.clicked.connect(self.close)
 
     def _is_waldo_image(self) -> bool:
@@ -548,6 +571,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
 
     def update_for_image(self, image_service, image_path, agl_override_m=None):
         """Rebuild the camera/sun for a newly selected image (called by Viewer)."""
+        self._reset_trace_state()
         self._clear_items()
         self._load_image(image_service, image_path, agl_override_m)
 
@@ -557,6 +581,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.sun_az = None
         self.sun_error = None
         self.sun_time_source = None
+        self._capture_utc = None
         if not self.image_path:
             self.sun_error = self.tr("no image loaded")
             return
@@ -581,6 +606,11 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         except SolarTimeUnresolvable:
             self.sun_error = self.tr("capture time / timezone not in metadata")
             return
+        self._capture_utc = utc
+        # A time solved from a traced shadow beats the camera clock.
+        if self._trace_override_utc is not None:
+            utc = self._trace_override_utc
+            source = 'shadow_trace'
         self.sun_time_source = source
         try:
             elev, az = get_solar_position(self.drone_lat, self.drone_lon, utc)
@@ -593,6 +623,9 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
     def _update_sun_label(self):
         """Refresh the sun-info line and enable/disable the shadow toggle."""
         self.adjust_clock_button.setVisible(self._is_waldo_image())
+        self.trace_shadow_button.setEnabled(
+            self.camera is not None and self.drone_lat is not None
+            and self._capture_utc is not None)
         if self.sun_elev is not None and self.sun_elev > 0:
             text = self.tr(
                 "Sun at capture: {elev:.0f}° above horizon, "
@@ -604,6 +637,9 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             elif self.sun_time_source == 'waldo_corrected':
                 text += " " + self.tr(
                     "Using repaired capture time (camera clock fault).")
+            elif self.sun_time_source == 'shadow_trace':
+                text += " " + self.tr(
+                    "Time of day derived from the traced shadow.")
             self.sun_label.setText(text)
             self.shadow_check.setEnabled(True)
         else:
@@ -1042,7 +1078,195 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             self.anchor_item.setPos(self._default_anchor_scene())
             self._render_all()
 
+    # ---------------- shadow trace ----------------
+    def _on_trace_shadow_clicked(self):
+        """Start/cancel a shadow trace, or clear an applied traced time."""
+        if self._trace_active:
+            self._end_trace(cancelled=True)
+            return
+        if self._trace_override_utc is not None:
+            self._reset_trace_state()
+            self._resolve_sun()
+            self._update_sun_label()
+            self._on_params_changed()
+            return
+        self._begin_trace()
+
+    def _begin_trace(self):
+        """Arm the two-click trace on the main image viewer."""
+        self._trace_points = []
+        self._clear_trace_items()
+        try:
+            self.image_viewer.leftMouseButtonPressed.connect(self._on_trace_click)
+        except Exception:
+            return
+        self._trace_active = True
+        self.trace_shadow_button.setText(self.tr("Cancel trace"))
+        self._show_status(self.tr(
+            "Shadow trace: on the image, click the BASE of an object casting "
+            "a shadow (rock, tree, post), then click the TIP of its shadow."))
+
+    def _end_trace(self, cancelled=False):
+        """Disarm the trace clicks; optionally discard what was traced."""
+        self._trace_active = False
+        try:
+            self.image_viewer.leftMouseButtonPressed.disconnect(self._on_trace_click)
+        except Exception:
+            pass
+        if cancelled:
+            self._trace_points = []
+            self._clear_trace_items()
+            self.trace_shadow_button.setText(self.tr("Trace shadow..."))
+            self._show_status(None)
+
+    def _reset_trace_state(self):
+        """Drop the trace override and visuals (image change / clear / close)."""
+        self._end_trace(cancelled=True)
+        self._trace_override_utc = None
+        self.trace_shadow_button.setText(self.tr("Trace shadow..."))
+
+    def _on_trace_click(self, x, y, _viewer=None):
+        """Collect the two trace clicks: shadow base, then shadow tip."""
+        if not self._trace_active:
+            return
+        self._trace_points.append((float(x), float(y)))
+        self._add_trace_marker(float(x), float(y),
+                               first=len(self._trace_points) == 1)
+        if len(self._trace_points) < 2:
+            self._show_status(self.tr(
+                "Shadow trace: now click the TIP of the shadow."))
+            return
+        self._end_trace()
+        self._draw_trace_line()
+        self._solve_traced_shadow()
+
+    def _add_trace_marker(self, x, y, first):
+        """Drop a fixed-screen-size dot where the user clicked."""
+        scene = getattr(self.image_viewer, 'scene', None)
+        if scene is None:
+            return
+        radius = 5.0
+        item = QGraphicsEllipseItem(-radius, -radius, 2 * radius, 2 * radius)
+        item.setPos(QPointF(x, y))
+        color = QColor('#ff9800') if first else QColor('#ffc107')
+        item.setBrush(QBrush(color))
+        item.setPen(QPen(QColor(0, 0, 0), 1))
+        item.setZValue(1101)
+        item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIgnoresTransformations, True)
+        scene.addItem(item)
+        self._trace_items.append(item)
+
+    def _draw_trace_line(self):
+        """Draw the traced base->tip line (kept visible for comparison with
+        the rendered shadow)."""
+        scene = getattr(self.image_viewer, 'scene', None)
+        if scene is None or len(self._trace_points) != 2:
+            return
+        (x1, y1), (x2, y2) = self._trace_points
+        line = QGraphicsLineItem(x1, y1, x2, y2)
+        pen = QPen(QColor('#ff9800'), 2, Qt.DashLine)
+        pen.setCosmetic(True)
+        line.setPen(pen)
+        line.setZValue(1100)
+        scene.addItem(line)
+        self._trace_items.append(line)
+
+    def _clear_trace_items(self):
+        """Remove the trace visuals from the scene."""
+        scene = getattr(self.image_viewer, 'scene', None)
+        for item in self._trace_items:
+            if scene is not None:
+                try:
+                    scene.removeItem(item)
+                except Exception:
+                    pass
+        self._trace_items = []
+
+    def _traced_shadow_azimuth(self):
+        """World azimuth of the traced shadow (base -> tip), or None.
+
+        Both clicks are cast onto the ground through the same CameraModel
+        used to render the person and its shadow, so the traced azimuth and
+        the rendered shadow live in the same frame - after applying the
+        solved time the rendered shadow lines up with the traced line.
+        """
+        if self.camera is None or len(self._trace_points) != 2:
+            return None
+        base = self.camera.pixel_to_ground(*self._trace_points[0])
+        tip = self.camera.pixel_to_ground(*self._trace_points[1])
+        if base is None or tip is None:
+            return None
+        d_north = tip[0] - base[0]
+        d_east = tip[1] - base[1]
+        if abs(d_north) < 1e-9 and abs(d_east) < 1e-9:
+            return None
+        return math.degrees(math.atan2(d_east, d_north)) % 360.0
+
+    def _format_local_time(self, utc_dt):
+        """Format a UTC moment as local wall time at the drone's position."""
+        try:
+            from zoneinfo import ZoneInfo
+            tz_name = timezone_name_for_position(self.drone_lat, self.drone_lon)
+            if tz_name:
+                return utc_dt.astimezone(ZoneInfo(tz_name)).strftime('%H:%M %Z')
+        except Exception:
+            pass
+        return utc_dt.strftime('%H:%M UTC')
+
+    def _solve_traced_shadow(self):
+        """Invert the traced shadow to a time of day and apply it."""
+        shadow_az = self._traced_shadow_azimuth()
+        if shadow_az is None:
+            self._reset_trace_state()
+            self._show_status(self.tr(
+                "Shadow trace: the traced points could not be projected to "
+                "the ground - try two points further apart."))
+            return
+        if self._capture_utc is None or self.drone_lat is None:
+            self._reset_trace_state()
+            self._show_status(self.tr(
+                "Shadow trace: the image is missing the capture date or GPS "
+                "position needed to solve the time."))
+            return
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            solution = solve_time_for_shadow_azimuth(
+                self.drone_lat, self.drone_lon, self._capture_utc, shadow_az)
+        except Exception as e:
+            solution = None
+            self.logger.error(f"Shadow trace: solver failed - {e}")
+        finally:
+            QApplication.restoreOverrideCursor()
+        if solution is None:
+            self._reset_trace_state()
+            self._show_status(self.tr(
+                "Shadow trace: no daylight sun position matches that "
+                "direction on the capture date. Check the traced direction "
+                "(base first, then shadow tip)."))
+            return
+        self._trace_override_utc = solution.utc
+        self.trace_shadow_button.setText(self.tr("Clear traced time"))
+        message = self.tr(
+            "Time solved from the traced shadow: {time} "
+            "(sun azimuth {az:.0f}°, {elev:.0f}° above horizon)."
+        ).format(time=self._format_local_time(solution.utc),
+                 az=solution.sun_azimuth_deg,
+                 elev=solution.sun_elevation_deg)
+        if solution.direction_flipped:
+            message += " " + self.tr(
+                "The traced direction looked reversed and was interpreted "
+                "tip-to-base.")
+        if solution.ambiguous:
+            message += " " + self.tr(
+                "Note: another time of day matches this direction almost "
+                "as well.")
+        self._show_status(message)
+        self._resolve_sun()
+        self._update_sun_label()
+        self._on_params_changed()
+
     # ---------------- close ----------------
     def closeEvent(self, event):
+        self._reset_trace_state()
         self._clear_items()
         super().closeEvent(event)

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -402,6 +402,8 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
 
         button_row = QHBoxLayout()
         self.recenter_button = QPushButton(self.tr("Recenter"))
+        self.recenter_button.setToolTip(self.tr(
+            "Bring the reference person to the center of the current view"))
         self.close_button = QPushButton(self.tr("Close"))
         button_row.addWidget(self.recenter_button)
         button_row.addWidget(self.trace_shadow_button)
@@ -1075,9 +1077,31 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self._render_all()
 
     def _recenter(self):
+        """Bring the reference person into the user's current view.
+
+        The user pans/zooms to the spot they are inspecting and hits
+        Recenter to pull the overlay there - not back to the full-image
+        default. (Initial placement on open still uses the nadir via
+        _default_anchor_scene.)
+        """
         if self.anchor_item is not None:
-            self.anchor_item.setPos(self._default_anchor_scene())
+            self.anchor_item.setPos(self._current_view_anchor_scene())
             self._render_all()
+
+    def _current_view_anchor_scene(self):
+        """Recenter target: the current viewport centre, clamped to the
+        image bounds; falls back to the default (nadir) placement when the
+        view centre cannot be determined."""
+        try:
+            point = self._viewport_center_scene()
+            x = float(point.x())
+            y = float(point.y())
+            if self.camera is not None:
+                x = min(max(x, 0.0), float(self.camera.width))
+                y = min(max(y, 0.0), float(self.camera.height))
+            return QPointF(x, y)
+        except Exception:
+            return self._default_anchor_scene()
 
     # ---------------- shadow trace ----------------
     def _on_trace_shadow_clicked(self):

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -268,6 +268,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self._capture_utc = None          # resolved capture moment (UTC)
         self._trace_override_utc = None   # solved time from a traced shadow
         self._trace_active = False
+        self._trace_connected = False     # click signal currently connected
         self._trace_points = []           # image-pixel clicks, base first
         self._trace_items = []            # scene items visualising the trace
 
@@ -1100,6 +1101,16 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
             self.image_viewer.leftMouseButtonPressed.connect(self._on_trace_click)
         except Exception:
             return
+        self._trace_connected = True
+        # The main image's left button normally starts a region zoom, which
+        # consumes the press before leftMouseButtonPressed is emitted -
+        # point-capture mode routes plain left clicks to the signal instead.
+        begin_capture = getattr(self.image_viewer, 'begin_point_capture', None)
+        if callable(begin_capture):
+            try:
+                begin_capture()
+            except Exception:
+                pass
         self._trace_active = True
         self.trace_shadow_button.setText(self.tr("Cancel trace"))
         self._show_status(self.tr(
@@ -1109,10 +1120,20 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
     def _end_trace(self, cancelled=False):
         """Disarm the trace clicks; optionally discard what was traced."""
         self._trace_active = False
-        try:
-            self.image_viewer.leftMouseButtonPressed.disconnect(self._on_trace_click)
-        except Exception:
-            pass
+        # Only disconnect when actually connected: a blind disconnect makes
+        # Qt print a RuntimeWarning on every image change.
+        if self._trace_connected:
+            self._trace_connected = False
+            try:
+                self.image_viewer.leftMouseButtonPressed.disconnect(self._on_trace_click)
+            except Exception:
+                pass
+        end_capture = getattr(self.image_viewer, 'end_point_capture', None)
+        if callable(end_capture):
+            try:
+                end_capture()
+            except Exception:
+                pass
         if cancelled:
             self._trace_points = []
             self._clear_trace_items()

--- a/app/core/views/images/viewer/widgets/GPSMapView.py
+++ b/app/core/views/images/viewer/widgets/GPSMapView.py
@@ -1517,6 +1517,10 @@ class GPSMapView(TranslationMixin, QGraphicsView):
             roll = image_service.get_gimbal_roll() or 0.0
             if abs(roll) > 90.0:
                 roll = 0.0
+            # WALDO v6+ expresses roll about the FLIGHT axis, not the camera
+            # yaw axis - rolling about the wrong axis mirrors the footprint
+            # to the opposite side of the track (matches AOIService).
+            roll_axis = image_service.get_roll_axis_azimuth() if roll else None
 
             # Match AOIService.estimate_aoi_gps altitude determination exactly
             if custom_alt and custom_alt > 0:
@@ -1591,7 +1595,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                     result = AOIService._calculate_ground_position(
                         image_lat, image_lon, u, v, cx, cy,
                         width, height, focal_mm, sensor_w_mm, sensor_h_mm,
-                        effective_agl, pitch, yaw, roll
+                        effective_agl, pitch, yaw, roll,
+                        roll_axis_azimuth_deg=roll_axis
                     )
                     if result is None:
                         raycast_ok = False
@@ -1614,7 +1619,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                                 refined = AOIService._calculate_ground_position(
                                     image_lat, image_lon, u, v, cx, cy,
                                     width, height, focal_mm, sensor_w_mm, sensor_h_mm,
-                                    pt_agl, pitch, yaw, roll
+                                    pt_agl, pitch, yaw, roll,
+                                    roll_axis_azimuth_deg=roll_axis
                                 )
                                 if refined is None:
                                     break
@@ -1642,6 +1648,7 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                         'pitch': pitch,
                         'yaw': yaw,
                         'roll': roll,
+                        'roll_axis': roll_axis,
                         'effective_agl': effective_agl,
                         'drone_absolute_elev': drone_absolute_elev,
                         'terrain_res_m': terrain_res_m,
@@ -1799,6 +1806,7 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                 edge_gps = []
                 raycast_ok = True
                 roll_cached = cache.get('roll', 0.0)
+                roll_axis_cached = cache.get('roll_axis')
                 for u, v in edge_pixels:
                     result = AOIService._calculate_ground_position(
                         image_lat, image_lon, u, v,
@@ -1806,7 +1814,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                         imgWidth, imgHeight,
                         cache['focal_mm'], cache['sensor_w_mm'], cache['sensor_h_mm'],
                         cache['effective_agl'], cache['pitch'], cache['yaw'],
-                        roll_cached
+                        roll_cached,
+                        roll_axis_azimuth_deg=roll_axis_cached
                     )
                     if result is None:
                         raycast_ok = False
@@ -1841,7 +1850,8 @@ class GPSMapView(TranslationMixin, QGraphicsView):
                                             imgWidth, imgHeight,
                                             cache['focal_mm'], cache['sensor_w_mm'], cache['sensor_h_mm'],
                                             pt_agl, cache['pitch'], cache['yaw'],
-                                            roll_cached
+                                            roll_cached,
+                                            roll_axis_azimuth_deg=roll_axis_cached
                                         )
                                         if refined is None:
                                             break

--- a/app/core/views/images/viewer/widgets/QtImageViewer.py
+++ b/app/core/views/images/viewer/widgets/QtImageViewer.py
@@ -115,6 +115,12 @@ class QtImageViewer(TranslationMixin, QGraphicsView):
         self.canZoom = True
         self.canPan = True
 
+        # Point-capture mode: while active, a plain left click emits
+        # leftMouseButtonPressed instead of starting a region zoom (which
+        # normally consumes the press before the signal is reached). See
+        # begin_point_capture().
+        self._point_capture_active = False
+
         self.setMouseTracking(True)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
@@ -792,8 +798,32 @@ class QtImageViewer(TranslationMixin, QGraphicsView):
     #  original file, only whitespace touched so it fits here.             #
     # -------------------------------------------------------------------- #
     # ------------------------- mousePressEvent -------------------------- #
+    def begin_point_capture(self):
+        """Route plain left clicks to leftMouseButtonPressed.
+
+        Used by tools that need the user to click points on the image (e.g.
+        the Person Reference shadow trace). The left button normally starts
+        a region zoom, which consumes the press before the click signal is
+        reached - while capture is active the press is emitted and consumed
+        instead. Right-button pan, wheel zoom, and modifier clicks keep
+        working so the user can still navigate to the target.
+        """
+        self._point_capture_active = True
+
+    def end_point_capture(self):
+        """Restore normal left-click behaviour (region zoom)."""
+        self._point_capture_active = False
+
     def mousePressEvent(self, ev):
         if self._is_destroyed:
+            return
+
+        # ------------- point capture (takes precedence over every other
+        # left-click behaviour while a tool is collecting clicks)
+        if self._point_capture_active and ev.button() == Qt.LeftButton:
+            scenePos = self.mapToScene(ev.position().toPoint())
+            self.leftMouseButtonPressed.emit(scenePos.x(), scenePos.y(), self)
+            ev.accept()
             return
 
         # Check if we're in AOI creation mode (via parent window)
@@ -883,6 +913,14 @@ class QtImageViewer(TranslationMixin, QGraphicsView):
     # ----------------------- mouseReleaseEvent -------------------------- #
     def mouseReleaseEvent(self, ev):
         if self._is_destroyed:
+            return
+
+        # ---- point capture: the press never started a region zoom, so the
+        # release must not run the zoom-finish logic against stale state.
+        if self._point_capture_active and ev.button() == Qt.LeftButton:
+            scenePos = self.mapToScene(ev.position().toPoint())
+            self.leftMouseButtonReleased.emit(scenePos.x(), scenePos.y())
+            ev.accept()
             return
 
         # Handle AOI creation completion

--- a/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
+++ b/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
@@ -122,3 +122,51 @@ def test_decline_without_remember_is_not_persisted(monkeypatch, tmp_path):
     controller._offer_clock_correction(
         [str(tmp_path / "0_a.jpg")], _proposal(), service=_StubService())
     assert CLOCK_DECISIONS_SETTING not in controller.settings_service.values
+
+
+class _AmendStubService:
+    """No live fault, but a stamped correction that fails the sanity check."""
+
+    def __init__(self, suspect_reason, amend_proposal):
+        self.suspect_reason = suspect_reason
+        self.amend_proposal = amend_proposal
+
+    def stamped_correction_suspect(self, paths):
+        return self.suspect_reason
+
+    def propose_amendment(self, paths):
+        return self.amend_proposal
+
+
+def test_suspect_stamp_triggers_amendment_despite_stored_acceptance(monkeypatch, tmp_path):
+    """A physically impossible applied correction must re-ask, not silently
+    re-apply the remembered (wrong) values."""
+    controller = _make_controller(monkeypatch)
+    paths = [str(tmp_path / "0_a.jpg")]
+    import os
+    folder_key = os.path.normcase(os.path.abspath(str(tmp_path)))
+    controller.settings_service.values[CLOCK_DECISIONS_SETTING] = json.dumps({
+        folder_key: {'decision': 'accepted', 'face_shift_h': -12,
+                     'tz_text': 'America/Los_Angeles'}})
+    _FakeDialog.script = {'applied': True, 'remember': True,
+                          'face_shift': 0, 'tz_text': 'UTC'}
+    service = _AmendStubService("0_a.jpg: sun below horizon on daylight image",
+                                _proposal())
+    controller._offer_clock_correction(paths, None, service=service)
+
+    assert len(_FakeDialog.instances) == 1
+    dlg = _FakeDialog.instances[0]
+    assert dlg.auto_apply is False  # never silently re-apply suspect values
+    assert "sun below horizon" in dlg.proposal.evidence[0]
+    # The new choice replaces the stored decision.
+    stored = json.loads(controller.settings_service.values[CLOCK_DECISIONS_SETTING])
+    assert stored[folder_key] == {'decision': 'accepted', 'face_shift_h': 0,
+                                  'tz_text': 'UTC'}
+
+
+def test_no_proposal_and_healthy_stamp_stays_quiet(monkeypatch, tmp_path):
+    controller = _make_controller(monkeypatch)
+    service = _AmendStubService(None, None)
+    controller._offer_clock_correction(
+        [str(tmp_path / "0_a.jpg")], None, service=service)
+    assert _FakeDialog.instances == []

--- a/app/tests/core/services/coverage/_kernel_helpers.py
+++ b/app/tests/core/services/coverage/_kernel_helpers.py
@@ -19,3 +19,14 @@ def metric_spec(width_m, height_m, cell):
     """A north-up EPSG:3857 GridSpec whose units equal true meters (use
     meters_per_unit=1.0), snapped so the origin sits at (0, 0)."""
     return make_lattice_spec((0.0, 0.0, float(width_m), float(height_m)), float(cell))
+
+
+def make_fg_roll_axis(pitch, yaw, roll, roll_axis, agl=120.0, focal=8.8,
+                      sensor=(13.2, 8.8), size=(4000, 3000)):
+    """FrameGeometry with a WALDO v6+ style flight-axis roll."""
+    return FrameGeometry(
+        lat=38.7, lon=-120.5, agl_m=agl, yaw_deg=yaw, pitch_deg=pitch, roll_deg=roll,
+        focal_mm=focal, sensor_mm=sensor, image_size=size, principal_point_mm=None,
+        yaw_source='gimbal', bearing_confidence=1.0, asl_alt_m=None, cam_elev_m=None,
+        roll_axis_deg=roll_axis,
+    )

--- a/app/tests/core/services/coverage/test_kernel_flat_plane.py
+++ b/app/tests/core/services/coverage/test_kernel_flat_plane.py
@@ -58,3 +58,39 @@ def test_rotated_yaw_preserves_area():
     a0 = int(mask0.sum()) * cell * cell
     a37 = int(mask37.sum()) * cell * cell
     assert a37 == pytest.approx(a0, rel=0.01)
+
+
+def test_footprint_flight_axis_roll_lands_plane_right():
+    """WALDO cam0 v6+ stamp (heading 319.7, image-top backward, roll -22.5
+    about the FLIGHT axis): the footprint centroid must land plane-RIGHT of
+    the track (NE quadrant). Rolling about the camera-yaw axis instead
+    mirrors it to the SW - the map-footprint bug reported from the field."""
+    import math
+    from core.services.coverage.kernel import project_footprint_corners
+    from ._kernel_helpers import make_fg, make_fg_roll_axis
+
+    class _P:
+        max_range_m = 10000.0
+
+    heading = 319.7
+    yaw = (heading + 180.0) % 360.0
+
+    fg_waldo = make_fg_roll_axis(-90.0, yaw, -22.5, heading, agl=776.0,
+                                 focal=50.0, sensor=(36.0, 24.0), size=(8688, 5792))
+    corners = project_footprint_corners(fg_waldo, _P())
+    east = sum(c[0] for c in corners) / 4.0
+    north = sum(c[1] for c in corners) / 4.0
+    # Plane-right of 319.7 = bearing 49.7: east and north both positive,
+    # and the centroid direction matches (the projective corner average
+    # sits farther out than the axis hit, so only direction is asserted).
+    assert east > 100.0 and north > 100.0
+    centroid_bearing = math.degrees(math.atan2(east, north)) % 360.0
+    assert abs(centroid_bearing - 49.7) < 5.0
+
+    # Same numbers WITHOUT the roll axis (legacy stamps): opposite side.
+    fg_legacy = make_fg(-90.0, yaw=yaw, roll=-22.5, agl=776.0,
+                        focal=50.0, sensor=(36.0, 24.0), size=(8688, 5792))
+    corners = project_footprint_corners(fg_legacy, _P())
+    east_l = sum(c[0] for c in corners) / 4.0
+    north_l = sum(c[1] for c in corners) / 4.0
+    assert east_l < -100.0 and north_l < -100.0

--- a/app/tests/core/services/image/test_coverage_extent_service.py
+++ b/app/tests/core/services/image/test_coverage_extent_service.py
@@ -219,3 +219,59 @@ def test_fov_polygon_falls_back_to_flat_when_terrain_unavailable():
     assert len(fake.compute_calls) == 1  # terrain was attempted
     assert len(fake.average_calls) == 1  # then fell back
     assert _span_east_m(corners) == pytest.approx(160.0, rel=0.01)
+
+
+class _WaldoFakeImageService(_FakeImageService):
+    """Fake with WALDO v6+ stamps: roll expressed about the FLIGHT axis."""
+
+    def __init__(self, roll_axis_deg, **kwargs):
+        super().__init__(**kwargs)
+        self.roll_axis_deg = roll_axis_deg
+
+    def get_roll_axis_azimuth(self):
+        return self.roll_axis_deg
+
+
+def test_fov_polygon_waldo_flight_axis_roll_lands_plane_right():
+    """WALDO cam0 v6+ stamp: heading 319.7 (NW), image-top backward
+    (yaw 139.7), roll -22.5 about the FLIGHT axis => footprint plane-RIGHT
+    of the track (NE). Interpreting the roll about the camera axis instead
+    mirrored the blue footprint to the SW - the field-reported bug."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    import math
+    heading = 319.7
+    fake = _WaldoFakeImageService(
+        roll_axis_deg=heading, yaw_deg=(heading + 180.0) % 360.0,
+        roll_deg=-22.5, flat_gsd_cm=4.0, reported_agl_m=776.0)
+    service = CoverageExtentService(use_terrain=False)
+    corners = _fov_corners_with(service, fake)
+
+    assert corners is not None and len(corners) == 4
+    # Offset direction: plane-right of 319.7 = bearing 49.7 (northeast).
+    offset_m = 776.0 * math.tan(math.radians(22.5))
+    expected_east = offset_m * math.sin(math.radians(heading + 90.0))
+    assert expected_east > 0  # sanity: NE means east-positive
+    assert _centroid_east_m(corners) == pytest.approx(expected_east, rel=0.02)
+
+
+def test_fov_polygon_legacy_camera_axis_roll_unchanged():
+    """Without a roll axis (DJI / WALDO v5 stamps) the old camera-axis
+    interpretation must be preserved: same yaw/roll numbers land the
+    footprint on the OPPOSITE side of the WALDO case above."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    import math
+    heading = 319.7
+    fake = _FakeImageService(
+        yaw_deg=(heading + 180.0) % 360.0, roll_deg=-22.5,
+        flat_gsd_cm=4.0, reported_agl_m=776.0)
+    service = CoverageExtentService(use_terrain=False)
+    corners = _fov_corners_with(service, fake)
+
+    assert corners is not None and len(corners) == 4
+    # Legacy: offset -h*tan(roll) along camera-X (yaw+90 = 229.7, SW).
+    offset_m = -776.0 * math.tan(math.radians(-22.5))
+    expected_east = offset_m * math.sin(math.radians(((heading + 180.0) % 360.0) + 90.0))
+    assert expected_east < 0  # sanity: SW means east-negative
+    assert _centroid_east_m(corners) == pytest.approx(expected_east, rel=0.02)

--- a/app/tests/core/services/image/test_frame_geometry.py
+++ b/app/tests/core/services/image/test_frame_geometry.py
@@ -154,8 +154,9 @@ def synthetic_service():
 
 PROJ_CTX_KEYS = {
     'drone_lat', 'drone_lon', 'img_w', 'img_h', 'cx', 'cy', 'focal_mm',
-    'sensor_w_mm', 'sensor_h_mm', 'pitch', 'yaw', 'roll', 'reported_agl',
-    'drone_terrain_elev_m', 'drone_absolute_elev_m', 'terrain_service',
+    'sensor_w_mm', 'sensor_h_mm', 'pitch', 'yaw', 'roll', 'roll_axis',
+    'reported_agl', 'drone_terrain_elev_m', 'drone_absolute_elev_m',
+    'terrain_service',
 }
 
 

--- a/app/tests/core/services/shadow/test_shadow_time_solver.py
+++ b/app/tests/core/services/shadow/test_shadow_time_solver.py
@@ -1,0 +1,88 @@
+"""Tests for ShadowTimeSolver - traced shadow azimuth -> capture time."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.services.shadow.SolarPosition import get_solar_position
+from core.services.shadow.ShadowTimeSolver import (
+    solve_time_for_shadow_azimuth,
+    _circular_diff_deg,
+)
+
+# Mid-latitude test site (Inyo County, CA area).
+_LAT, _LON = 36.8, -118.2
+
+
+def _shadow_azimuth_at(utc):
+    """The azimuth a real shadow points along at the test site at ``utc``."""
+    _elev, sun_az = get_solar_position(_LAT, _LON, utc)
+    return (sun_az + 180.0) % 360.0
+
+
+def test_circular_diff():
+    assert _circular_diff_deg(350.0, 10.0) == pytest.approx(20.0)
+    assert _circular_diff_deg(10.0, 350.0) == pytest.approx(20.0)
+    assert _circular_diff_deg(180.0, 180.0) == pytest.approx(0.0)
+
+
+def test_round_trip_recovers_capture_time():
+    """A shadow computed for a known moment solves back to that moment."""
+    truth = datetime(2026, 6, 15, 17, 0, tzinfo=timezone.utc)  # 10:00 PDT
+    shadow_az = _shadow_azimuth_at(truth)
+    solution = solve_time_for_shadow_azimuth(_LAT, _LON, truth, shadow_az)
+    assert solution is not None
+    assert abs((solution.utc - truth).total_seconds()) < 120
+    assert not solution.direction_flipped
+    assert solution.azimuth_error_deg < 1.0
+    assert solution.sun_elevation_deg > 0
+
+
+def test_solves_even_when_camera_clock_is_hours_wrong():
+    """Only the date matters: a claimed time hours off still resolves."""
+    truth = datetime(2026, 6, 15, 22, 30, tzinfo=timezone.utc)  # 15:30 PDT
+    shadow_az = _shadow_azimuth_at(truth)
+    claimed = truth - timedelta(hours=7)  # broken clock
+    solution = solve_time_for_shadow_azimuth(_LAT, _LON, claimed, shadow_az)
+    assert solution is not None
+    assert abs((solution.utc - truth).total_seconds()) < 120
+
+
+def test_reversed_trace_is_detected_and_flipped():
+    """Clicking tip-then-base yields the anti-azimuth; when that direction
+    is unmatchable by any daylight sun the solver flips it and says so.
+
+    Uses a near-solar-noon truth: its shadow points north, so the reversed
+    trace (south-pointing shadow = northern sun) has no daylight match at
+    mid latitudes and only the flipped interpretation fits.
+    """
+    truth = datetime(2026, 6, 15, 19, 50, tzinfo=timezone.utc)  # ~solar noon
+    reversed_az = (_shadow_azimuth_at(truth) + 180.0) % 360.0
+    solution = solve_time_for_shadow_azimuth(_LAT, _LON, truth, reversed_az)
+    assert solution is not None
+    assert solution.direction_flipped
+    assert abs((solution.utc - truth).total_seconds()) < 300
+
+
+def test_unmatchable_azimuth_returns_none(monkeypatch):
+    """When no daylight sun position matches either orientation -> None."""
+    import core.services.shadow.ShadowTimeSolver as solver_mod
+    # Force "night all day": every sample is below the elevation floor.
+    monkeypatch.setattr(solver_mod, 'MIN_SUN_ELEVATION_DEG', 91.0)
+    truth = datetime(2026, 6, 15, 17, 0, tzinfo=timezone.utc)
+    assert solve_time_for_shadow_azimuth(_LAT, _LON, truth, 45.0) is None
+
+
+def test_winter_date_round_trip():
+    """Solar geometry differs by season; a winter date must also invert."""
+    truth = datetime(2026, 1, 20, 20, 0, tzinfo=timezone.utc)  # 12:00 PST
+    shadow_az = _shadow_azimuth_at(truth)
+    solution = solve_time_for_shadow_azimuth(_LAT, _LON, truth, shadow_az)
+    assert solution is not None
+    assert abs((solution.utc - truth).total_seconds()) < 120
+
+
+def test_naive_capture_time_rejected():
+    with pytest.raises(ValueError):
+        solve_time_for_shadow_azimuth(
+            _LAT, _LON, datetime(2026, 6, 15, 17, 0), 45.0)

--- a/app/tests/core/services/waldo/test_waldo_clock_correction.py
+++ b/app/tests/core/services/waldo/test_waldo_clock_correction.py
@@ -260,3 +260,87 @@ def test_audit_still_warns_without_correction(fault_setup):
     svc = WaldoMetadataService(terrain_service=None)
     warnings = svc.audit_capture_times([fault_setup])
     assert warnings  # timezone mismatch + AM/PM flip both present
+
+
+# --------------------------------------------------------------------------
+# Amendment: propose_amendment / stamped_correction_suspect
+# --------------------------------------------------------------------------
+
+def test_propose_amendment_prefills_from_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(WaldoMetadataService, 'get_correction_stamp_details',
+                        staticmethod(lambda p: (-12.0, 'America/Los_Angeles')))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_amendment([path])
+    assert proposal is not None
+    assert proposal.face_shift_h == -12
+    assert proposal.tz_name == 'America/Los_Angeles'
+    assert "already stamped" in proposal.evidence[0]
+    assert proposal.sample_corrected_utc == "2026-07-23 13:49:37 UTC"
+
+
+def test_propose_amendment_fixed_offset_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(WaldoMetadataService, 'get_correction_stamp_details',
+                        staticmethod(lambda p: (0.0, 'UTC+0.0')))
+    svc = WaldoMetadataService(terrain_service=None)
+    proposal = svc.propose_amendment([path])
+    assert proposal is not None
+    assert proposal.face_shift_h == 0
+    assert proposal.tz_name is None
+    assert proposal.fixed_offset_h == pytest.approx(0.0)
+    # face 18:49:37 interpreted as UTC with no shift
+    assert proposal.sample_corrected_utc == "2026-07-23 18:49:37 UTC"
+
+
+def test_propose_amendment_none_without_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(WaldoMetadataService, 'get_correction_stamp_details',
+                        staticmethod(lambda p: None))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.propose_amendment([path]) is None
+
+
+def test_suspect_flags_below_horizon_daylight(tmp_path, monkeypatch):
+    """A stamped correction placing a bright image before sunrise is wrong."""
+    import numpy as np
+    path = _make_image(tmp_path)
+    # 04:21 PDT = 11:21 UTC on Aug 7 at Inyo: sun well below the horizon.
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-08-07T11:21:28+00:00"))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        staticmethod(lambda exif_data: {'latitude': 37.04, 'longitude': -117.63}))
+    monkeypatch.setattr(waldo_module.cv2, 'imdecode',
+                        lambda buf, flags: np.full((400, 500), 150, dtype=np.uint8))
+    svc = WaldoMetadataService(terrain_service=None)
+    reason = svc.stamped_correction_suspect([path])
+    assert reason is not None
+    assert "below the horizon" in reason
+
+
+def test_suspect_quiet_on_plausible_correction(tmp_path, monkeypatch):
+    """A corrected time with the sun up is not second-guessed."""
+    path = _make_image(tmp_path)
+    # 09:21 PDT = 16:21 UTC: sun up.
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: "2026-08-07T16:21:28+00:00"))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.LocationInfo, 'get_gps',
+                        staticmethod(lambda exif_data: {'latitude': 37.04, 'longitude': -117.63}))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.stamped_correction_suspect([path]) is None
+
+
+def test_suspect_quiet_without_stamp(tmp_path, monkeypatch):
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(WaldoMetadataService, 'get_corrected_utc_stamp',
+                        staticmethod(lambda p: None))
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.stamped_correction_suspect([path]) is None

--- a/app/tests/core/services/waldo/test_waldo_metadata_service.py
+++ b/app/tests/core/services/waldo/test_waldo_metadata_service.py
@@ -53,30 +53,51 @@ def test_optical_axis_cam_0_fallback_yaw_and_flight_axis_roll():
 
 
 def test_optical_axis_cam_1_fallback_yaw_and_flight_axis_roll():
-    # `1_*` = LEFT pod: tilt to plane LEFT = positive roll about the
-    # forward flight axis.
+    # `1_*` = LEFT pod, body mounted opposed to cam 0: its stored image-top
+    # faces plane FORWARD (v9 fix - v5..v8 wrongly stamped it backward).
+    # Tilt to plane LEFT = positive roll about the forward flight axis.
     angles = WaldoMetadataService.compute_optical_axis_angles(0.0, 1)
     assert angles['pitch'] == -90.0
-    assert angles['yaw'] == 180.0
+    assert angles['yaw'] == 0.0  # image-top = heading for cam 1
     assert angles['roll'] == +OUTWARD_ROLL_DEG
 
 
+def test_optical_axis_cam_1_yaw_follows_heading():
+    angles = WaldoMetadataService.compute_optical_axis_angles(270.0, 1)
+    assert angles['yaw'] == 270.0
+    angles = WaldoMetadataService.compute_optical_axis_angles(319.67, 1)
+    assert pytest.approx(angles['yaw'], abs=1e-6) == 319.67
+
+
 def test_optical_axis_measured_orientation_wins_over_model():
-    # A measured image-top bearing overrides the mounting model entirely;
-    # the roll stays anchored to the flight axis so the physical tilt is
+    # A measured orientation overrides the mounting model entirely; the
+    # roll stays anchored to the flight axis so the physical tilt is
     # unchanged by whatever orientation the frames are stored in.
-    angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 0, image_up_deg=1.5)
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        45.0, 0, measured_orientation=('absolute', 1.5))
     assert angles['yaw'] == 1.5
     assert angles['roll'] == -OUTWARD_ROLL_DEG
-    angles = WaldoMetadataService.compute_optical_axis_angles(45.0, 1, image_up_deg=359.0)
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        45.0, 1, measured_orientation=('absolute', 359.0))
     assert angles['yaw'] == 359.0
     assert angles['roll'] == +OUTWARD_ROLL_DEG
 
 
-def test_optical_axis_cam_1_yaw_wraps_past_360():
-    # heading 270°, cam 1 → 270 + 180 = 450 → 90° after mod-360 normalisation.
-    angles = WaldoMetadataService.compute_optical_axis_angles(270.0, 1)
-    assert angles['yaw'] == 90.0
+def test_optical_axis_measured_offset_is_track_relative():
+    # ('offset', d) stamps heading + d per image - serpentine-safe: the
+    # same offset yields opposite absolute yaws on opposite lanes.
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        10.0, 0, measured_orientation=('offset', 175.0))
+    assert pytest.approx(angles['yaw'], abs=1e-6) == 185.0
+    angles = WaldoMetadataService.compute_optical_axis_angles(
+        190.0, 0, measured_orientation=('offset', 175.0))
+    assert pytest.approx(angles['yaw'], abs=1e-6) == 5.0
+
+
+def test_optical_axis_invalid_orientation_mode_raises():
+    with pytest.raises(ValueError):
+        WaldoMetadataService.compute_optical_axis_angles(
+            0.0, 0, measured_orientation=('sideways', 1.0))
 
 
 def test_optical_axis_yaw_normalised_to_360():
@@ -278,7 +299,7 @@ def test_flight_axis_roll_reproduces_v5_tilt_direction():
 
         # v6: measured yaw (north-up here), roll about the flight axis
         angles = WaldoMetadataService.compute_optical_axis_angles(
-            heading, cam_idx, image_up_deg=0.0)
+            heading, cam_idx, measured_orientation=('absolute', 0.0))
         v6 = AOIService._calculate_ground_position(
             lat0, lon0, 2000.0, 1500.0,
             altitude_m=1000.0, pitch_deg=angles['pitch'],
@@ -366,24 +387,26 @@ def _motion_records(tmp_path, heading_deg):
 def test_measurement_overrides_model_only_on_clear_contradiction(tmp_path):
     """North-up frames with a model saying 'south-up' trip the override."""
     service = WaldoMetadataService()
-    # heading 0 -> model image-top = 180; measurement reads ~0 -> gap ~180
+    # heading 0 -> cam0 model offset = 180; measurement reads offset ~0
     records = _motion_records(tmp_path, heading_deg=0.0)
 
-    measured = service.measure_image_up_bearing(records, cam_idx=0)
+    measured = service.measure_image_up_orientation(records, cam_idx=0)
     assert measured is not None
-    assert min(measured, 360.0 - measured) < 8.0
+    mode, value = measured
+    assert mode == 'offset'
+    assert min(value, 360.0 - value) < 8.0
 
 
 def test_measurement_agreeing_with_model_defers_to_it(tmp_path):
     """When measurement and model roughly agree, the model is stamped."""
     service = WaldoMetadataService()
-    # heading 180 -> model image-top = 0; measurement reads ~0 -> gap ~0
+    # heading 180 -> frames read offset (0-180)=180 = cam0 model -> agree
     records = _motion_records(tmp_path, heading_deg=180.0)
 
-    assert service.measure_image_up_bearing(records, cam_idx=0) is None
+    assert service.measure_image_up_orientation(records, cam_idx=0) is None
 
 
-def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
+def test_measurement_rejects_unmatchable(tmp_path):
     """Unrelated noise frames must fail closed (fall back to the model)."""
     service = WaldoMetadataService()
     rng = np.random.default_rng(9)
@@ -393,10 +416,84 @@ def test_measure_image_up_bearing_rejects_unmatchable(tmp_path):
         p = str(tmp_path / f'0_000_00_{i:03d}.jpg')
         cv2.imwrite(p, rng.integers(0, 255, (400, 500), dtype=np.uint8))
         records.append(WaldoImageRecord(path=p, name=f'0_000_00_{i:03d}.jpg',
-                                        cam_idx=0, lat=lat, lon=-122.0))
+                                        cam_idx=0, lat=lat, lon=-122.0,
+                                        heading_deg=0.0))
         lat += 0.0018
 
-    assert service.measure_image_up_bearing(records, cam_idx=0) is None
+    assert service.measure_image_up_orientation(records, cam_idx=0) is None
+
+
+def _serpentine_records(tmp_path, cam, lane_specs, seed0=0):
+    """Records for a multi-lane flight; lane_specs = [(heading, north?, dy)].
+
+    Each lane contributes 3 synthetic frame pairs. dy is the crop shift of
+    the pair's second frame: +dy makes the camera appear to move toward the
+    image BOTTOM between frames, -dy toward the image TOP.
+    """
+    records = []
+    idx = 0
+    lat = 41.0
+    for lane_no, (heading, north, dy) in enumerate(lane_specs):
+        dlat = 0.0018 if north else -0.0018
+        for i in range(3):
+            pa, pb = _write_shifted_frames(
+                tmp_path / f'l{lane_no}p{i}', (0, dy), seed=seed0 + idx)
+            for p in (pa, pb):
+                records.append(WaldoImageRecord(
+                    path=p, name=f'{cam}_000_00_{idx:03d}.jpg', cam_idx=cam,
+                    lat=lat, lon=-122.0, heading_deg=heading))
+                lat += dlat
+                idx += 1
+    return records
+
+
+def test_measurement_serpentine_track_relative_defers_to_model(tmp_path):
+    """Serpentine cam0 storage (image-top follows the track) must NOT trip
+    the override, even though the ABSOLUTE orientations alternate 0/180.
+
+    This is the exact failure mode that hid the cam-1 bug in v5..v8: the
+    absolute circular mean of alternating lanes was garbage, so the
+    measurement returned None instead of validating the model.
+    """
+    service = WaldoMetadataService()
+    # cam0 stores image-top = heading+180. Northbound lane (heading 0):
+    # top faces south -> northward motion reads motion_img 180 -> dy +280.
+    # Southbound lane (heading 180): top faces north -> dy +280 as well.
+    records = _serpentine_records(tmp_path, 0, [
+        (0.0, True, +280),
+        (180.0, False, +280),
+    ])
+    assert service.measure_image_up_orientation(records, cam_idx=0) is None
+
+
+def test_measurement_detects_normalized_absolute_on_serpentine(tmp_path):
+    """North-up-normalized frames on a serpentine flight: the relative space
+    scrambles (offsets 0/180) but the absolute space is tight at ~0, and a
+    constant absolute orientation across mixed headings contradicts ANY
+    mounting model - the override must fire in absolute mode."""
+    service = WaldoMetadataService()
+    records = _serpentine_records(tmp_path, 0, [
+        (0.0, True, -280),    # northbound, north-up: motion toward image top
+        (180.0, False, +280),  # southbound, north-up: motion toward image bottom
+    ])
+    measured = service.measure_image_up_orientation(records, cam_idx=0)
+    assert measured is not None
+    mode, value = measured
+    assert mode == 'absolute'
+    assert min(value, 360.0 - value) < 8.0
+
+
+def test_measurement_cam1_forward_storage_matches_v9_model(tmp_path):
+    """cam1 frames stored image-top = plane FORWARD (the real WALDO output,
+    field-verified on two flights) must agree with the v9 model and stamp
+    it. Under the v5..v8 model (top = backward) this same data was a 180 deg
+    contradiction that the old absolute aggregation failed to report."""
+    service = WaldoMetadataService()
+    records = _serpentine_records(tmp_path, 1, [
+        (0.0, True, -280),     # northbound, top=forward(north): motion toward top
+        (180.0, False, -280),  # southbound, top=forward(south): motion toward top
+    ])
+    assert service.measure_image_up_orientation(records, cam_idx=1) is None
 
 
 # --------------------------------------------------------------------------

--- a/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
@@ -98,8 +98,10 @@ def test_is_near_nadir_gates_on_pitch(app, qtbot, isolated_settings):
     assert dialog._is_near_nadir() is False
 
 
-def test_recenter_returns_to_nadir(app, qtbot, isolated_settings):
-    """Recenter must snap back to the nadir, not the zoomed viewport centre."""
+def test_recenter_falls_back_to_nadir_without_a_view_center(app, qtbot,
+                                                            isolated_settings):
+    """When the viewport centre can't be determined at all, Recenter falls
+    back to the default nadir placement instead of breaking."""
     from core.services.CameraModel import CameraModel
     from core.views.images.viewer.dialogs.PersonReferenceDialog import (
         _AnchorHandle,
@@ -107,6 +109,8 @@ def test_recenter_returns_to_nadir(app, qtbot, isolated_settings):
 
     dialog = _make_dialog(qtbot)
     dialog.camera = CameraModel(50.0, -90.0, 0.0, 8.38, 13.2, 8.8, 5472, 3078)
+    dialog.image_viewer.mapToScene = None  # not callable -> raises
+    dialog.image_viewer.sceneRect = None   # fallback path raises too
     dialog.anchor_item = _AnchorHandle(dialog)
     dialog.anchor_item.setPos(10.0, 10.0)  # simulate an off-nadir position
 
@@ -114,6 +118,51 @@ def test_recenter_returns_to_nadir(app, qtbot, isolated_settings):
 
     assert dialog.anchor_item.pos().x() == pytest.approx(5472 / 2.0, abs=1.0)
     assert dialog.anchor_item.pos().y() == pytest.approx(3078 / 2.0, abs=1.0)
+
+
+def test_recenter_moves_to_current_view_center(app, qtbot, isolated_settings):
+    """Recenter pulls the person to where the user is currently looking
+    (field request: it used to jump back to the full-image default)."""
+    from types import SimpleNamespace as _NS
+    from core.services.CameraModel import CameraModel
+    from core.views.images.viewer.dialogs.PersonReferenceDialog import (
+        _AnchorHandle,
+    )
+
+    dialog = _make_dialog(qtbot)
+    dialog.camera = CameraModel(50.0, -90.0, 0.0, 8.38, 13.2, 8.8, 5472, 3078)
+    # Simulate a zoomed/panned viewer whose viewport centre is (1200, 800).
+    dialog.image_viewer.viewport = lambda: _NS(
+        rect=lambda: QtCore.QRect(0, 0, 400, 300))
+    dialog.image_viewer.mapToScene = lambda p: QtCore.QPointF(1200.0, 800.0)
+    dialog.anchor_item = _AnchorHandle(dialog)
+    dialog.anchor_item.setPos(10.0, 10.0)
+
+    dialog._recenter()
+
+    assert dialog.anchor_item.pos().x() == pytest.approx(1200.0)
+    assert dialog.anchor_item.pos().y() == pytest.approx(800.0)
+
+
+def test_recenter_clamps_to_image_bounds(app, qtbot, isolated_settings):
+    """A viewport centre outside the image cannot fling the person off-frame."""
+    from types import SimpleNamespace as _NS
+    from core.services.CameraModel import CameraModel
+    from core.views.images.viewer.dialogs.PersonReferenceDialog import (
+        _AnchorHandle,
+    )
+
+    dialog = _make_dialog(qtbot)
+    dialog.camera = CameraModel(50.0, -90.0, 0.0, 8.38, 13.2, 8.8, 5472, 3078)
+    dialog.image_viewer.viewport = lambda: _NS(
+        rect=lambda: QtCore.QRect(0, 0, 400, 300))
+    dialog.image_viewer.mapToScene = lambda p: QtCore.QPointF(-500.0, 99999.0)
+    dialog.anchor_item = _AnchorHandle(dialog)
+
+    dialog._recenter()
+
+    assert dialog.anchor_item.pos().x() == pytest.approx(0.0)
+    assert dialog.anchor_item.pos().y() == pytest.approx(3078.0)
 
 
 def test_persists_on_change(app, qtbot, isolated_settings):

--- a/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
@@ -77,12 +77,31 @@ def test_defaults_when_nothing_saved(app, qtbot, isolated_settings):
     assert dialog.terrain_check.isChecked() is True
 
 
-def test_default_anchor_is_nadir(app, qtbot, isolated_settings):
-    """The overlay opens at the straight-down point, not the zoomed view centre."""
+def test_default_anchor_is_current_view_center(app, qtbot, isolated_settings):
+    """The overlay opens where the user is looking, not at the image centre
+    (field report: opening while zoomed to an AOI panned the view away)."""
+    from types import SimpleNamespace as _NS
     from core.services.CameraModel import CameraModel
 
     dialog = _make_dialog(qtbot)
     dialog.camera = CameraModel(50.0, -90.0, 0.0, 8.38, 13.2, 8.8, 5472, 3078)
+    dialog.image_viewer.viewport = lambda: _NS(
+        rect=lambda: QtCore.QRect(0, 0, 400, 300))
+    dialog.image_viewer.mapToScene = lambda p: QtCore.QPointF(1200.0, 800.0)
+    point = dialog._default_anchor_scene()
+    assert point.x() == pytest.approx(1200.0)
+    assert point.y() == pytest.approx(800.0)
+
+
+def test_default_anchor_falls_back_to_nadir(app, qtbot, isolated_settings):
+    """With no usable view centre the overlay opens at the straight-down
+    point (compact, upright silhouette at any camera angle)."""
+    from core.services.CameraModel import CameraModel
+
+    dialog = _make_dialog(qtbot)
+    dialog.camera = CameraModel(50.0, -90.0, 0.0, 8.38, 13.2, 8.8, 5472, 3078)
+    dialog.image_viewer.mapToScene = None  # not callable -> raises
+    dialog.image_viewer.sceneRect = None   # fallback path raises too
     point = dialog._default_anchor_scene()
     assert point.x() == pytest.approx(5472 / 2.0, abs=1.0)
     assert point.y() == pytest.approx(3078 / 2.0, abs=1.0)

--- a/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
@@ -309,6 +309,27 @@ def test_shadow_trace_disabled_without_camera(app, qtbot, isolated_settings,
     assert not dialog.trace_shadow_button.isEnabled()
 
 
+def test_trace_toggles_viewer_point_capture(app, qtbot, isolated_settings,
+                                            monkeypatch):
+    """Arming the trace must put the image viewer in point-capture mode:
+    on the main image the left button region-zooms, so without capture the
+    trace clicks never reach the dialog (field-reported bug)."""
+    claimed = datetime(2026, 6, 15, 22, 0, tzinfo=timezone.utc)
+    _patch_sun_metadata(monkeypatch, claimed)
+    dialog, viewer = _make_projected_dialog(qtbot, agl_m=40.0)
+    calls = []
+    viewer.leftMouseButtonPressed = MagicMock()  # connectable stand-in
+    viewer.begin_point_capture = lambda: calls.append('begin')
+    viewer.end_point_capture = lambda: calls.append('end')
+
+    dialog._begin_trace()
+    assert dialog._trace_active
+    assert calls == ['begin']
+
+    dialog._end_trace(cancelled=True)
+    assert calls == ['begin', 'end']
+
+
 def test_shadow_trace_reset_on_image_change(app, qtbot, isolated_settings,
                                             monkeypatch):
     """Switching images drops the traced time (it belongs to one frame)."""

--- a/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
@@ -415,6 +415,78 @@ def test_shadow_trace_reset_on_image_change(app, qtbot, isolated_settings,
 
 
 # ---------------------------------------------------------------------------
+# Anchor placement avoids the selected AOI (radius + 40 px clearance)
+# ---------------------------------------------------------------------------
+
+def _viewer_with_selected_aoi(center, radius, aoi_index=0):
+    """Minimal parent-viewer stand-in exposing one selected AOI."""
+    return SimpleNamespace(
+        aoi_controller=SimpleNamespace(selected_aoi_index=aoi_index),
+        images=[{'areas_of_interest': [{'center': center, 'radius': radius}]}],
+        current_image=0,
+    )
+
+
+def _dialog_with_view_center(qtbot, view_center):
+    from types import SimpleNamespace as _NS
+    from core.services.CameraModel import CameraModel
+
+    dialog = _make_dialog(qtbot)
+    dialog.camera = CameraModel(50.0, -90.0, 0.0, 8.38, 13.2, 8.8, 5472, 3078)
+    dialog.image_viewer.viewport = lambda: _NS(
+        rect=lambda: QtCore.QRect(0, 0, 400, 300))
+    dialog.image_viewer.mapToScene = lambda p: QtCore.QPointF(*view_center)
+    return dialog
+
+
+def test_anchor_shifts_left_of_a_centered_aoi(app, qtbot, isolated_settings):
+    """View centred on the selected AOI: the person lands left of the AOI's
+    radius + 40 px, level with it, instead of on top of it."""
+    dialog = _dialog_with_view_center(qtbot, (1200.0, 800.0))
+    dialog._parent_viewer = _viewer_with_selected_aoi((1200, 800), 30)
+
+    point = dialog._default_anchor_scene()
+
+    assert point.x() == pytest.approx(1200.0 - (30 + 40))
+    assert point.y() == pytest.approx(800.0)
+
+
+def test_anchor_shifts_right_when_left_is_off_image(app, qtbot,
+                                                    isolated_settings):
+    """An AOI near the left edge pushes the person to its right instead."""
+    dialog = _dialog_with_view_center(qtbot, (50.0, 800.0))
+    dialog._parent_viewer = _viewer_with_selected_aoi((50, 800), 30)
+
+    point = dialog._default_anchor_scene()
+
+    assert point.x() == pytest.approx(50.0 + (30 + 40))
+    assert point.y() == pytest.approx(800.0)
+
+
+def test_anchor_unmoved_when_view_is_not_on_the_aoi(app, qtbot,
+                                                    isolated_settings):
+    """A view centred far from the selected AOI keeps its own centre."""
+    dialog = _dialog_with_view_center(qtbot, (2000.0, 1500.0))
+    dialog._parent_viewer = _viewer_with_selected_aoi((1200, 800), 30)
+
+    point = dialog._default_anchor_scene()
+
+    assert point.x() == pytest.approx(2000.0)
+    assert point.y() == pytest.approx(1500.0)
+
+
+def test_anchor_unmoved_without_a_selected_aoi(app, qtbot, isolated_settings):
+    dialog = _dialog_with_view_center(qtbot, (1200.0, 800.0))
+    dialog._parent_viewer = _viewer_with_selected_aoi((1200, 800), 30,
+                                                      aoi_index=-1)
+
+    point = dialog._default_anchor_scene()
+
+    assert point.x() == pytest.approx(1200.0)
+    assert point.y() == pytest.approx(800.0)
+
+
+# ---------------------------------------------------------------------------
 # Image-change rebuilds defer so navigation (gallery zoom-to-AOI) wins
 # ---------------------------------------------------------------------------
 

--- a/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
@@ -407,7 +407,56 @@ def test_shadow_trace_reset_on_image_change(app, qtbot, isolated_settings,
     assert dialog._trace_override_utc is not None
 
     dialog.update_for_image(_camera_image_service(40.0), 'other-image.jpg')
+    dialog._apply_pending_image()  # flush the deferred rebuild
 
     assert dialog._trace_override_utc is None
     assert dialog.sun_time_source == 'gps'
     assert dialog.trace_shadow_button.text() == 'Trace shadow...'
+
+
+# ---------------------------------------------------------------------------
+# Image-change rebuilds defer so navigation (gallery zoom-to-AOI) wins
+# ---------------------------------------------------------------------------
+
+def test_image_change_rebuild_is_deferred(app, qtbot, isolated_settings):
+    """update_for_image queues the rebuild instead of running it inline."""
+    dialog, _viewer = _make_projected_dialog(qtbot, agl_m=40.0)
+    assert dialog.anchor_item is not None
+
+    dialog.update_for_image(_camera_image_service(40.0), 'other-image.jpg')
+
+    assert dialog._pending_image is not None    # queued, not applied
+    assert dialog.anchor_item is None           # old overlay cleared
+    assert dialog._image_change_timer.isActive()
+
+    dialog._apply_pending_image()
+    assert dialog._pending_image is None
+    assert dialog.anchor_item is not None       # rebuilt after the beat
+    assert dialog.image_path == 'other-image.jpg'
+
+
+def test_image_change_never_auto_zooms(app, qtbot, isolated_settings):
+    """A gallery AOI click zooms the new image to the AOI; the dialog's
+    legibility auto-zoom must not stomp it (field report). The auto-zoom
+    belongs to the FIRST open only - once the dialog is up, an image
+    change is the operator's own navigation and the view stays put."""
+    dialog, viewer = _make_projected_dialog(qtbot, agl_m=1500.0)
+    assert len(viewer.zoom_calls) == 1  # auto-zoomed once on open
+
+    dialog.update_for_image(_camera_image_service(1500.0), 'other-image.jpg')
+    dialog._apply_pending_image()
+
+    assert len(viewer.zoom_calls) == 1  # no second auto-zoom, ever
+
+
+def test_pending_image_change_dropped_on_close(app, qtbot, isolated_settings):
+    """A queued rebuild must not fire into a closed dialog."""
+    dialog, _viewer = _make_projected_dialog(qtbot, agl_m=40.0)
+    dialog.update_for_image(_camera_image_service(40.0), 'other-image.jpg')
+
+    dialog.close()
+
+    assert not dialog._image_change_timer.isActive()
+    assert dialog._pending_image is None
+    dialog._apply_pending_image()  # stray fire is a no-op
+    assert dialog.anchor_item is None

--- a/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
+++ b/app/tests/core/views/images/viewer/dialogs/test_person_reference_dialog.py
@@ -221,3 +221,104 @@ def test_auto_zoom_failure_is_non_fatal(app, qtbot, isolated_settings):
     qtbot.addWidget(dialog)
 
     assert dialog.camera is not None  # dialog still built the overlay
+
+
+# ---------------------------------------------------------------------------
+# Shadow trace -> time of day (the traced shadow drives the sun rendering)
+# ---------------------------------------------------------------------------
+
+import math
+from datetime import datetime, timezone
+
+_TRACE_LAT, _TRACE_LON = 36.8, -118.2
+
+
+def _patch_sun_metadata(monkeypatch, claimed_utc):
+    """Make the dialog resolve GPS + capture time without touching disk."""
+    import core.views.images.viewer.dialogs.PersonReferenceDialog as dlg_mod
+    monkeypatch.setattr(dlg_mod, 'MetaDataHelper', SimpleNamespace(
+        get_exif_data_piexif=lambda path: {},
+        get_xmp_data=lambda path, parse=True: None))
+    monkeypatch.setattr(dlg_mod, 'LocationInfo', SimpleNamespace(
+        get_gps=lambda exif_data: {'latitude': _TRACE_LAT,
+                                   'longitude': _TRACE_LON}))
+    monkeypatch.setattr(
+        dlg_mod, 'resolve_capture_utc',
+        lambda exif, xmp, lat=None, lon=None: (claimed_utc, 'gps'))
+
+
+def _solved_trace_dialog(qtbot, monkeypatch, truth, claimed):
+    """Dialog with a completed shadow trace built from the real sun at ``truth``."""
+    from core.services.shadow.SolarPosition import get_solar_position
+
+    _patch_sun_metadata(monkeypatch, claimed)
+    dialog, _viewer = _make_projected_dialog(qtbot, agl_m=40.0)
+    assert dialog.trace_shadow_button.isEnabled()
+
+    # The camera is nadir with yaw 0, so image +u = east and +v = south.
+    # Trace the shadow a real sun at ``truth`` would cast.
+    _elev, sun_az = get_solar_position(_TRACE_LAT, _TRACE_LON, truth)
+    shadow_rad = math.radians((sun_az + 180.0) % 360.0)
+    base = (434.0, 289.0)  # ~image centre = ground nadir
+    tip = (base[0] + 100.0 * math.sin(shadow_rad),
+           base[1] - 100.0 * math.cos(shadow_rad))
+
+    dialog._trace_active = True
+    dialog._on_trace_click(*base)
+    assert dialog._trace_override_utc is None  # one click is not enough
+    dialog._on_trace_click(*tip)
+    return dialog, sun_az
+
+
+def test_shadow_trace_solves_and_applies_time(app, qtbot, isolated_settings,
+                                              monkeypatch):
+    truth = datetime(2026, 6, 15, 17, 0, tzinfo=timezone.utc)    # 10:00 PDT
+    claimed = datetime(2026, 6, 15, 22, 0, tzinfo=timezone.utc)  # clock wrong
+    dialog, sun_az = _solved_trace_dialog(qtbot, monkeypatch, truth, claimed)
+
+    assert dialog._trace_override_utc is not None
+    assert abs((dialog._trace_override_utc - truth).total_seconds()) < 300
+    assert dialog.sun_time_source == 'shadow_trace'
+    # The rendered sun now matches the traced moment, not the camera clock.
+    assert dialog.sun_az == pytest.approx(sun_az, abs=2.0)
+    assert dialog.trace_shadow_button.text() == 'Clear traced time'
+
+
+def test_shadow_trace_clear_restores_clock_time(app, qtbot, isolated_settings,
+                                                monkeypatch):
+    truth = datetime(2026, 6, 15, 17, 0, tzinfo=timezone.utc)
+    claimed = datetime(2026, 6, 15, 22, 0, tzinfo=timezone.utc)
+    dialog, _sun_az = _solved_trace_dialog(qtbot, monkeypatch, truth, claimed)
+    assert dialog.sun_time_source == 'shadow_trace'
+
+    dialog._on_trace_shadow_clicked()  # "Clear traced time"
+
+    assert dialog._trace_override_utc is None
+    assert dialog.sun_time_source == 'gps'
+    assert dialog.trace_shadow_button.text() == 'Trace shadow...'
+    assert dialog._trace_items == []
+
+
+def test_shadow_trace_disabled_without_camera(app, qtbot, isolated_settings,
+                                              monkeypatch):
+    """No camera model (missing metadata) -> the trace button stays off."""
+    claimed = datetime(2026, 6, 15, 22, 0, tzinfo=timezone.utc)
+    _patch_sun_metadata(monkeypatch, claimed)
+    dialog = _make_dialog(qtbot)  # null-camera mock
+    assert dialog.camera is None
+    assert not dialog.trace_shadow_button.isEnabled()
+
+
+def test_shadow_trace_reset_on_image_change(app, qtbot, isolated_settings,
+                                            monkeypatch):
+    """Switching images drops the traced time (it belongs to one frame)."""
+    truth = datetime(2026, 6, 15, 17, 0, tzinfo=timezone.utc)
+    claimed = datetime(2026, 6, 15, 22, 0, tzinfo=timezone.utc)
+    dialog, _sun_az = _solved_trace_dialog(qtbot, monkeypatch, truth, claimed)
+    assert dialog._trace_override_utc is not None
+
+    dialog.update_for_image(_camera_image_service(40.0), 'other-image.jpg')
+
+    assert dialog._trace_override_utc is None
+    assert dialog.sun_time_source == 'gps'
+    assert dialog.trace_shadow_button.text() == 'Trace shadow...'

--- a/app/tests/core/views/images/viewer/widgets/test_widgets.py
+++ b/app/tests/core/views/images/viewer/widgets/test_widgets.py
@@ -743,3 +743,49 @@ def test_thermal_range_slider_wrap_updates(app):
 
     slider.set_selection_wrap(True)
     assert slider.selection_wrap()
+
+
+# ---------------------------------------------------------------------------
+# Point capture (shadow trace): plain left clicks must reach the click signal
+# on the MAIN image, where the left button normally starts a region zoom
+# ---------------------------------------------------------------------------
+
+def test_left_click_signal_blocked_by_region_zoom_without_capture(app, qtbot):
+    """Documents the default: region zoom consumes the press, no signal."""
+    viewer = _viewer_with_image(qtbot)
+    viewer.window.aoi_creation_mode = False  # MagicMock attrs default truthy
+    clicks = []
+    viewer.leftMouseButtonPressed.connect(lambda x, y, v: clicks.append((x, y)))
+
+    viewer.mousePressEvent(_mouse_event(
+        QEvent.Type.MouseButtonPress, 50, 40, Qt.LeftButton, Qt.LeftButton))
+    viewer.mouseReleaseEvent(_mouse_event(
+        QEvent.Type.MouseButtonRelease, 50, 40, Qt.LeftButton, Qt.NoButton))
+
+    assert clicks == []
+
+
+def test_point_capture_routes_left_clicks_to_signal(app, qtbot):
+    viewer = _viewer_with_image(qtbot)
+    viewer.window.aoi_creation_mode = False
+    clicks = []
+    viewer.leftMouseButtonPressed.connect(lambda x, y, v: clicks.append((x, y)))
+
+    viewer.begin_point_capture()
+    viewer.mousePressEvent(_mouse_event(
+        QEvent.Type.MouseButtonPress, 50, 40, Qt.LeftButton, Qt.LeftButton))
+    viewer.mouseReleaseEvent(_mouse_event(
+        QEvent.Type.MouseButtonRelease, 50, 40, Qt.LeftButton, Qt.NoButton))
+
+    assert len(clicks) == 1
+    assert getattr(viewer, '_isZooming', False) is False
+    assert viewer.zoomStack == []  # the swallowed release must not zoom
+
+    # Ending capture hands the left button back to region zoom.
+    viewer.end_point_capture()
+    viewer.mousePressEvent(_mouse_event(
+        QEvent.Type.MouseButtonPress, 60, 50, Qt.LeftButton, Qt.LeftButton))
+    assert len(clicks) == 1
+    assert getattr(viewer, '_isZooming', False) is True
+    viewer.mouseReleaseEvent(_mouse_event(
+        QEvent.Type.MouseButtonRelease, 60, 50, Qt.LeftButton, Qt.NoButton))

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -5736,8 +5736,8 @@ The map will continue to work with cached tiles where available.</translation>
         <translation>Copy Data</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>Zoom FOV</translation>
     </message>
@@ -10299,97 +10299,107 @@ Expected to find files named:
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Recenter</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>no image loaded</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>image metadata could not be read</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>image has no GPS coordinates</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>capture time / timezone not in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>sun position could not be computed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Capture time zone estimated from GPS location.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>the sun was below the horizon at capture</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>sun position unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Shadow unavailable: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Place the person and shadow on the DEM terrain surface</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terrain (DEM) data is not available for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Choose Overlay Color</translation>
     </message>

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -10234,239 +10234,244 @@ Expected to find files named:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="298"/>
         <source>Person Size Reference</source>
         <translation>Person Size Reference</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="305"/>
         <source>Reference Person</source>
         <translation>Reference Person</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
         <source>Standing</source>
         <translation>Standing</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="326"/>
         <source>Lying down</source>
         <translation>Lying down</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="328"/>
         <source>Sitting</source>
         <translation>Sitting</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="337"/>
         <source>Show shadows (from capture time)</source>
         <translation>Show shadows (from capture time)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="340"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Use terrain elevation (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Rotate the person on the ground to line it up with an object</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
         <source>Click to choose overlay color</source>
         <translation>Click to choose overlay color</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Show:</source>
         <translation>Show:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
         <source>Rotation:</source>
         <translation>Rotation:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1171"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="390"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="396"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Recenter</source>
         <translation>Recenter</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <source>Bring the reference person to the center of the current view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="407"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="472"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="516"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="571"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="589"/>
         <source>no image loaded</source>
         <translation>no image loaded</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="594"/>
         <source>image metadata could not be read</source>
         <translation>image metadata could not be read</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>image has no GPS coordinates</source>
         <translation>image has no GPS coordinates</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="610"/>
         <source>capture time / timezone not in metadata</source>
         <translation>capture time / timezone not in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="621"/>
         <source>sun position could not be computed</source>
         <translation>sun position could not be computed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="634"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Capture time zone estimated from GPS location.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="645"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>the sun was below the horizon at capture</source>
         <translation>the sun was below the horizon at capture</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="652"/>
         <source>sun position unavailable</source>
         <translation>sun position unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Shadow unavailable: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="752"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Place the person and shadow on the DEM terrain surface</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="756"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terrain (DEM) data is not available for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1016"/>
         <source>Choose Overlay Color</source>
         <translation>Choose Overlay Color</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1139"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1141"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1182"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1267"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1273"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1288"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1293"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1295"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1302"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1306"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11060,7 +11065,7 @@ This will require re-downloading tiles when terrain elevation is used.</translat
 <context>
     <name>QtImageViewer</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="384"/>
+        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="390"/>
         <source>Open image</source>
         <translation>Open image</translation>
     </message>

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -5691,7 +5691,7 @@ This downloads Meta/WRI canopy height (1 m) and sets it as the canopy source, re
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
-        <translation>Click point to select • Drag to pan • Scroll to zoom</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="263"/>
@@ -10234,174 +10234,241 @@ Expected to find files named:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="285"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
         <source>Person Size Reference</source>
         <translation>Person Size Reference</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="292"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
         <source>Reference Person</source>
         <translation>Reference Person</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="311"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
         <source>Standing</source>
         <translation>Standing</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="313"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
         <source>Lying down</source>
         <translation>Lying down</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="315"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
         <source>Sitting</source>
         <translation>Sitting</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
         <source>Show shadows (from capture time)</source>
         <translation>Show shadows (from capture time)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Use terrain elevation (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Rotate the person on the ground to line it up with an object</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="341"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
         <source>Click to choose overlay color</source>
         <translation>Click to choose overlay color</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
         <source>Size:</source>
         <translation>Size:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="350"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Show:</source>
         <translation>Show:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotation:</source>
         <translation>Rotation:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <source>Trace shadow...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
         <source>Recenter</source>
         <translation>Recenter</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
         <source>no image loaded</source>
         <translation>no image loaded</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
         <source>image metadata could not be read</source>
         <translation>image metadata could not be read</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
         <source>image has no GPS coordinates</source>
         <translation>image has no GPS coordinates</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
         <source>capture time / timezone not in metadata</source>
         <translation>capture time / timezone not in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
         <source>sun position could not be computed</source>
         <translation>sun position could not be computed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Capture time zone estimated from GPS location.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <source>Time of day derived from the traced shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
         <source>the sun was below the horizon at capture</source>
         <translation>the sun was below the horizon at capture</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
         <source>sun position unavailable</source>
         <translation>sun position unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Shadow unavailable: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Place the person and shadow on the DEM terrain surface</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terrain (DEM) data is not available for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
         <source>Choose Overlay Color</source>
         <translation>Choose Overlay Color</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <source>Cancel trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <source>Shadow trace: now click the TIP of the shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <source>Clear traced time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <source>Note: another time of day matches this direction almost as well.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -5736,8 +5736,8 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
         <translation>Copiar datos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>FOV de zoom</translation>
     </message>
@@ -10299,97 +10299,107 @@ Se esperaba encontrar archivos con estos nombres:
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Arrastre el controlador blanco para colocar a la persona de referencia. Las siluetas se dibujan a escala real del terreno según la altitud y el ángulo de cámara de esta imagen.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Centrar de nuevo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Superposición de perspectiva no disponible: a esta imagen le faltan los metadatos de altitud o lente necesarios para proyectar una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>no hay imagen cargada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>no se pudieron leer los metadatos de la imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>la imagen no tiene coordenadas GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>la hora de captura / zona horaria no está en los metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>no se pudo calcular la posición del sol</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sol durante la captura: {elev:.0f}° sobre el horizonte, acimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Zona horaria de captura estimada a partir de la ubicación GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>el sol estaba por debajo del horizonte durante la captura</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>posición del sol no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Sombra no disponible: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Colocar la persona y la sombra sobre la superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Los datos de terreno (DEM) no están disponibles para esta imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Elegir color de superposición</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -10234,239 +10234,244 @@ Se esperaba encontrar archivos con estos nombres:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="298"/>
         <source>Person Size Reference</source>
         <translation>Referencia de tamaño de persona</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="305"/>
         <source>Reference Person</source>
         <translation>Persona de referencia</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
         <source>Standing</source>
         <translation>De pie</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="326"/>
         <source>Lying down</source>
         <translation>Acostada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="328"/>
         <source>Sitting</source>
         <translation>Sentada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="337"/>
         <source>Show shadows (from capture time)</source>
         <translation>Mostrar sombras (según la hora de captura)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="340"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Usar elevación del terreno (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Gire la persona sobre el terreno para alinearla con un objeto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
         <source>Click to choose overlay color</source>
         <translation>Haga clic para elegir el color de superposición</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Size:</source>
         <translation>Tamaño:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Show:</source>
         <translation>Mostrar:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1171"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="390"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="396"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Arrastre el controlador blanco para colocar a la persona de referencia. Las siluetas se dibujan a escala real del terreno según la altitud y el ángulo de cámara de esta imagen.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Recenter</source>
         <translation>Centrar de nuevo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <source>Bring the reference person to the center of the current view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="407"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="472"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="516"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Superposición de perspectiva no disponible: a esta imagen le faltan los metadatos de altitud o lente necesarios para proyectar una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="571"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="589"/>
         <source>no image loaded</source>
         <translation>no hay imagen cargada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="594"/>
         <source>image metadata could not be read</source>
         <translation>no se pudieron leer los metadatos de la imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>image has no GPS coordinates</source>
         <translation>la imagen no tiene coordenadas GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="610"/>
         <source>capture time / timezone not in metadata</source>
         <translation>la hora de captura / zona horaria no está en los metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="621"/>
         <source>sun position could not be computed</source>
         <translation>no se pudo calcular la posición del sol</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="634"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sol durante la captura: {elev:.0f}° sobre el horizonte, acimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Zona horaria de captura estimada a partir de la ubicación GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="645"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>the sun was below the horizon at capture</source>
         <translation>el sol estaba por debajo del horizonte durante la captura</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="652"/>
         <source>sun position unavailable</source>
         <translation>posición del sol no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Sombra no disponible: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="752"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Colocar la persona y la sombra sobre la superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="756"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Los datos de terreno (DEM) no están disponibles para esta imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1016"/>
         <source>Choose Overlay Color</source>
         <translation>Elegir color de superposición</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1139"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1141"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1182"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1267"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1273"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1288"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1293"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1295"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1302"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1306"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11060,7 +11065,7 @@ Esto requerirá volver a descargar los mosaicos cuando se use la elevación del 
 <context>
     <name>QtImageViewer</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="384"/>
+        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="390"/>
         <source>Open image</source>
         <translation>Abrir imagen</translation>
     </message>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -5691,7 +5691,7 @@ Esto descarga la altura del dosel Meta/WRI (1 m) y la establece como fuente de d
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
-        <translation>Haga clic en un punto para seleccionar • Arrastre para desplazar • Rueda para acercar</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="263"/>
@@ -10234,174 +10234,241 @@ Se esperaba encontrar archivos con estos nombres:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="285"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
         <source>Person Size Reference</source>
         <translation>Referencia de tamaño de persona</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="292"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
         <source>Reference Person</source>
         <translation>Persona de referencia</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="311"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
         <source>Standing</source>
         <translation>De pie</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="313"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
         <source>Lying down</source>
         <translation>Acostada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="315"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
         <source>Sitting</source>
         <translation>Sentada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
         <source>Show shadows (from capture time)</source>
         <translation>Mostrar sombras (según la hora de captura)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Usar elevación del terreno (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Gire la persona sobre el terreno para alinearla con un objeto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="341"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
         <source>Click to choose overlay color</source>
         <translation>Haga clic para elegir el color de superposición</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
         <source>Size:</source>
         <translation>Tamaño:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="350"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Show:</source>
         <translation>Mostrar:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotation:</source>
         <translation>Rotación:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
         <source>Color:</source>
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <source>Trace shadow...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Arrastre el controlador blanco para colocar a la persona de referencia. Las siluetas se dibujan a escala real del terreno según la altitud y el ángulo de cámara de esta imagen.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
         <source>Recenter</source>
         <translation>Centrar de nuevo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Superposición de perspectiva no disponible: a esta imagen le faltan los metadatos de altitud o lente necesarios para proyectar una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
         <source>no image loaded</source>
         <translation>no hay imagen cargada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
         <source>image metadata could not be read</source>
         <translation>no se pudieron leer los metadatos de la imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
         <source>image has no GPS coordinates</source>
         <translation>la imagen no tiene coordenadas GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
         <source>capture time / timezone not in metadata</source>
         <translation>la hora de captura / zona horaria no está en los metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
         <source>sun position could not be computed</source>
         <translation>no se pudo calcular la posición del sol</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sol durante la captura: {elev:.0f}° sobre el horizonte, acimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Zona horaria de captura estimada a partir de la ubicación GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <source>Time of day derived from the traced shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
         <source>the sun was below the horizon at capture</source>
         <translation>el sol estaba por debajo del horizonte durante la captura</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
         <source>sun position unavailable</source>
         <translation>posición del sol no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Sombra no disponible: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Colocar la persona y la sombra sobre la superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Los datos de terreno (DEM) no están disponibles para esta imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
         <source>Choose Overlay Color</source>
         <translation>Elegir color de superposición</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <source>Cancel trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <source>Shadow trace: now click the TIP of the shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <source>Clear traced time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <source>Note: another time of day matches this direction almost as well.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -10234,239 +10234,244 @@ Nomi dei file cercati:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="298"/>
         <source>Person Size Reference</source>
         <translation>Riferimento dimensioni persona</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="305"/>
         <source>Reference Person</source>
         <translation>Persona di riferimento</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
         <source>Standing</source>
         <translation>In piedi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="326"/>
         <source>Lying down</source>
         <translation>Sdraiata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="328"/>
         <source>Sitting</source>
         <translation>Seduta</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="337"/>
         <source>Show shadows (from capture time)</source>
         <translation>Mostra ombre (all&apos;ora dello scatto)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="340"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Usa quota del terreno (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Ruota la persona sul terreno per allinearla a un oggetto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
         <source>Click to choose overlay color</source>
         <translation>Fai clic per scegliere il colore della sovrapposizione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Size:</source>
         <translation>Dimensione:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Show:</source>
         <translation>Mostra:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
         <source>Rotation:</source>
         <translation>Rotazione:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1171"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="390"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="396"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Trascina la maniglia bianca per posizionare la persona di riferimento. Le sagome sono disegnate in scala reale al suolo per l&apos;altitudine e l&apos;angolo della fotocamera di questa immagine.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Recenter</source>
         <translation>Ricentra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <source>Bring the reference person to the center of the current view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="407"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="472"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="516"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Sovrapposizione prospettica non disponibile: a questa immagine mancano i metadati di quota o obiettivo necessari per proiettare una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="571"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="589"/>
         <source>no image loaded</source>
         <translation>nessuna immagine caricata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="594"/>
         <source>image metadata could not be read</source>
         <translation>impossibile leggere i metadati dell&apos;immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>image has no GPS coordinates</source>
         <translation>l&apos;immagine non ha coordinate GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="610"/>
         <source>capture time / timezone not in metadata</source>
         <translation>ora di scatto / fuso orario non presenti nei metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="621"/>
         <source>sun position could not be computed</source>
         <translation>impossibile calcolare la posizione del sole</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="634"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sole allo scatto: {elev:.0f}° sopra l&apos;orizzonte, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Fuso orario dello scatto stimato dalla posizione GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="645"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>the sun was below the horizon at capture</source>
         <translation>il sole era sotto l&apos;orizzonte al momento dello scatto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="652"/>
         <source>sun position unavailable</source>
         <translation>posizione del sole non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Ombra non disponibile: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="752"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Posiziona la persona e l&apos;ombra sulla superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="756"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>I dati del terreno (DEM) non sono disponibili per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1016"/>
         <source>Choose Overlay Color</source>
         <translation>Scegli colore sovrapposizione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1139"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1141"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1182"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1267"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1273"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1288"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1293"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1295"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1302"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1306"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11060,7 +11065,7 @@ Tutte le modifiche vengono salvate automaticamente quando vengono modificate.</t
 <context>
     <name>QtImageViewer</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="384"/>
+        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="390"/>
         <source>Open image</source>
         <translation>Apri immagine</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -5736,8 +5736,8 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
         <translation>Copia Dati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>Zoom FOV</translation>
     </message>
@@ -10299,97 +10299,107 @@ Nomi dei file cercati:
         <translation>Colore:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Trascina la maniglia bianca per posizionare la persona di riferimento. Le sagome sono disegnate in scala reale al suolo per l&apos;altitudine e l&apos;angolo della fotocamera di questa immagine.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Ricentra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Sovrapposizione prospettica non disponibile: a questa immagine mancano i metadati di quota o obiettivo necessari per proiettare una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>nessuna immagine caricata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>impossibile leggere i metadati dell&apos;immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>l&apos;immagine non ha coordinate GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>ora di scatto / fuso orario non presenti nei metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>impossibile calcolare la posizione del sole</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sole allo scatto: {elev:.0f}° sopra l&apos;orizzonte, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Fuso orario dello scatto stimato dalla posizione GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>il sole era sotto l&apos;orizzonte al momento dello scatto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>posizione del sole non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Ombra non disponibile: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Posiziona la persona e l&apos;ombra sulla superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>I dati del terreno (DEM) non sono disponibili per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Scegli colore sovrapposizione</translation>
     </message>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -5691,7 +5691,7 @@ Questo scarica l&apos;altezza chioma Meta/WRI (1 m) e la imposta come origine da
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
-        <translation>Clicca su un punto per selezionare • Trascina per scorrere • Scorri per lo zoom</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="263"/>
@@ -10234,174 +10234,241 @@ Nomi dei file cercati:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="285"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
         <source>Person Size Reference</source>
         <translation>Riferimento dimensioni persona</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="292"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
         <source>Reference Person</source>
         <translation>Persona di riferimento</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="311"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
         <source>Standing</source>
         <translation>In piedi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="313"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
         <source>Lying down</source>
         <translation>Sdraiata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="315"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
         <source>Sitting</source>
         <translation>Seduta</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
         <source>Show shadows (from capture time)</source>
         <translation>Mostra ombre (all&apos;ora dello scatto)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Usa quota del terreno (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Ruota la persona sul terreno per allinearla a un oggetto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="341"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
         <source>Click to choose overlay color</source>
         <translation>Fai clic per scegliere il colore della sovrapposizione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
         <source>Size:</source>
         <translation>Dimensione:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="350"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Show:</source>
         <translation>Mostra:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotation:</source>
         <translation>Rotazione:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
         <source>Color:</source>
         <translation>Colore:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <source>Trace shadow...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Trascina la maniglia bianca per posizionare la persona di riferimento. Le sagome sono disegnate in scala reale al suolo per l&apos;altitudine e l&apos;angolo della fotocamera di questa immagine.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
         <source>Recenter</source>
         <translation>Ricentra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Sovrapposizione prospettica non disponibile: a questa immagine mancano i metadati di quota o obiettivo necessari per proiettare una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
         <source>no image loaded</source>
         <translation>nessuna immagine caricata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
         <source>image metadata could not be read</source>
         <translation>impossibile leggere i metadati dell&apos;immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
         <source>image has no GPS coordinates</source>
         <translation>l&apos;immagine non ha coordinate GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
         <source>capture time / timezone not in metadata</source>
         <translation>ora di scatto / fuso orario non presenti nei metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
         <source>sun position could not be computed</source>
         <translation>impossibile calcolare la posizione del sole</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sole allo scatto: {elev:.0f}° sopra l&apos;orizzonte, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Fuso orario dello scatto stimato dalla posizione GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <source>Time of day derived from the traced shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
         <source>the sun was below the horizon at capture</source>
         <translation>il sole era sotto l&apos;orizzonte al momento dello scatto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
         <source>sun position unavailable</source>
         <translation>posizione del sole non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Ombra non disponibile: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Posiziona la persona e l&apos;ombra sulla superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>I dati del terreno (DEM) non sono disponibili per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
         <source>Choose Overlay Color</source>
         <translation>Scegli colore sovrapposizione</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <source>Cancel trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <source>Shadow trace: now click the TIP of the shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <source>Clear traced time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <source>Note: another time of day matches this direction almost as well.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -5736,8 +5736,8 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
         <translation>Gegevens kopiëren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1770"/>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1878"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1777"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1888"/>
         <source>Zoom FOV</source>
         <translation>Zoom-gezichtsveld</translation>
     </message>
@@ -10299,97 +10299,107 @@ Verwachte bestandsnamen:
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <source>Adjust camera clock...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Sleep de witte greep om de referentiepersoon te plaatsen. Silhouetten worden op ware terreinschaal getekend voor de hoogte en camerahoek van deze afbeelding.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="375"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Recenter</source>
         <translation>Centreren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="431"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <source>No camera clock fault or applied correction was found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspectiefoverlay niet beschikbaar: deze afbeelding mist de hoogte- of lensmetadata die nodig zijn om een persoon te projecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="486"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="502"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
         <source>no image loaded</source>
         <translation>geen afbeelding geladen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="507"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
         <source>image metadata could not be read</source>
         <translation>afbeeldingsmetadata konden niet worden gelezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="511"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
         <source>image has no GPS coordinates</source>
         <translation>afbeelding heeft geen GPS-coördinaten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="523"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
         <source>capture time / timezone not in metadata</source>
         <translation>opnametijd / tijdzone ontbreekt in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="529"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
         <source>sun position could not be computed</source>
         <translation>zonnestand kon niet worden berekend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="538"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Zon bij opname: {elev:.0f}° boven de horizon, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="543"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Tijdzone van opname geschat op basis van GPS-locatie.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="546"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="551"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
         <source>the sun was below the horizon at capture</source>
         <translation>de zon stond tijdens de opname onder de horizon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="553"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
         <source>sun position unavailable</source>
         <translation>zonnestand niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Schaduw niet beschikbaar: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Plaats de persoon en schaduw op het DEM-terreinoppervlak</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="657"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terreingegevens (DEM) zijn niet beschikbaar voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
         <source>Choose Overlay Color</source>
         <translation>Overlaykleur kiezen</translation>
     </message>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -5691,7 +5691,7 @@ Hiermee wordt Meta/WRI-kroonhoogte (1 m) gedownload en ingesteld als bron voor k
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Click point to select • Drag to pan • Scroll to zoom</source>
-        <translation>Klik op punt om te selecteren • Sleep om te verplaatsen • Scrol om te zoomen</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="263"/>
@@ -10234,174 +10234,241 @@ Verwachte bestandsnamen:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="285"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
         <source>Person Size Reference</source>
         <translation>Referentie voor persoonsgrootte</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="292"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
         <source>Reference Person</source>
         <translation>Referentiepersoon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="311"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
         <source>Standing</source>
         <translation>Staand</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="313"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
         <source>Lying down</source>
         <translation>Liggend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="315"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
         <source>Sitting</source>
         <translation>Zittend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
         <source>Show shadows (from capture time)</source>
         <translation>Schaduwen tonen (opnametijd)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Terreinhoogte gebruiken (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Draai de persoon op de grond om deze met een object uit te lijnen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="341"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
         <source>Click to choose overlay color</source>
         <translation>Klik om de overlaykleur te kiezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
         <source>Size:</source>
         <translation>Grootte:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="350"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Show:</source>
         <translation>Tonen:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotation:</source>
         <translation>Rotatie:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="370"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="374"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <source>Trace shadow...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Sleep de witte greep om de referentiepersoon te plaatsen. Silhouetten worden op ware terreinschaal getekend voor de hoogte en camerahoek van deze afbeelding.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
         <source>Recenter</source>
         <translation>Centreren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="446"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspectiefoverlay niet beschikbaar: deze afbeelding mist de hoogte- of lensmetadata die nodig zijn om een persoon te projecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="545"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
         <source>no image loaded</source>
         <translation>geen afbeelding geladen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="566"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
         <source>image metadata could not be read</source>
         <translation>afbeeldingsmetadata konden niet worden gelezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="570"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
         <source>image has no GPS coordinates</source>
         <translation>afbeelding heeft geen GPS-coördinaten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="582"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
         <source>capture time / timezone not in metadata</source>
         <translation>opnametijd / tijdzone ontbreekt in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="588"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
         <source>sun position could not be computed</source>
         <translation>zonnestand kon niet worden berekend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Zon bij opname: {elev:.0f}° boven de horizon, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="603"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Tijdzone van opname geschat op basis van GPS-locatie.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="606"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="611"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <source>Time of day derived from the traced shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
         <source>the sun was below the horizon at capture</source>
         <translation>de zon stond tijdens de opname onder de horizon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="613"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
         <source>sun position unavailable</source>
         <translation>zonnestand niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="614"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Schaduw niet beschikbaar: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="713"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Plaats de persoon en schaduw op het DEM-terreinoppervlak</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="717"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terreingegevens (DEM) zijn niet beschikbaar voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="977"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
         <source>Choose Overlay Color</source>
         <translation>Overlaykleur kiezen</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <source>Cancel trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <source>Shadow trace: now click the TIP of the shadow.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <source>Clear traced time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <source>Note: another time of day matches this direction almost as well.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -10234,239 +10234,244 @@ Verwachte bestandsnamen:
 <context>
     <name>PersonReferenceDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="297"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="298"/>
         <source>Person Size Reference</source>
         <translation>Referentie voor persoonsgrootte</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="304"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="305"/>
         <source>Reference Person</source>
         <translation>Referentiepersoon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="323"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="324"/>
         <source>Standing</source>
         <translation>Staand</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="325"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="326"/>
         <source>Lying down</source>
         <translation>Liggend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="327"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="328"/>
         <source>Sitting</source>
         <translation>Zittend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="336"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="337"/>
         <source>Show shadows (from capture time)</source>
         <translation>Schaduwen tonen (opnametijd)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="339"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="340"/>
         <source>Use terrain elevation (DEM)</source>
         <translation>Terreinhoogte gebruiken (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="348"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="349"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Draai de persoon op de grond om deze met een object uit te lijnen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="353"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="354"/>
         <source>Click to choose overlay color</source>
         <translation>Klik om de overlaykleur te kiezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="361"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
         <source>Size:</source>
         <translation>Grootte:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="362"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Show:</source>
         <translation>Tonen:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
         <source>Rotation:</source>
         <translation>Rotatie:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="366"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="367"/>
         <source>Color:</source>
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="382"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="383"/>
         <source>Adjust camera clock...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="387"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1119"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1126"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1164"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1171"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="390"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="396"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Sleep de witte greep om de referentiepersoon te plaatsen. Silhouetten worden op ware terreinschaal getekend voor de hoogte en camerahoek van deze afbeelding.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="403"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
         <source>Recenter</source>
         <translation>Centreren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <source>Bring the reference person to the center of the current view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="407"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="469"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="472"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="516"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspectiefoverlay niet beschikbaar: deze afbeelding mist de hoogte- of lensmetadata die nodig zijn om een persoon te projecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="568"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="571"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="586"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="589"/>
         <source>no image loaded</source>
         <translation>geen afbeelding geladen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="591"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="594"/>
         <source>image metadata could not be read</source>
         <translation>afbeeldingsmetadata konden niet worden gelezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
         <source>image has no GPS coordinates</source>
         <translation>afbeelding heeft geen GPS-coördinaten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="610"/>
         <source>capture time / timezone not in metadata</source>
         <translation>opnametijd / tijdzone ontbreekt in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="618"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="621"/>
         <source>sun position could not be computed</source>
         <translation>zonnestand kon niet worden berekend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="631"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="634"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Zon bij opname: {elev:.0f}° boven de horizon, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="636"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Tijdzone van opname geschat op basis van GPS-locatie.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="639"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="642"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="645"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
         <source>the sun was below the horizon at capture</source>
         <translation>de zon stond tijdens de opname onder de horizon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="649"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="652"/>
         <source>sun position unavailable</source>
         <translation>zonnestand niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="650"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Schaduw niet beschikbaar: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="749"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="752"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Plaats de persoon en schaduw op het DEM-terreinoppervlak</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="756"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terreingegevens (DEM) zijn niet beschikbaar voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1013"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1016"/>
         <source>Choose Overlay Color</source>
         <translation>Overlaykleur kiezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1104"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1139"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1106"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1141"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1137"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1182"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1267"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1228"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1273"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1243"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1288"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1248"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1293"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1250"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1295"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1257"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1302"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1261"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1306"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11060,7 +11065,7 @@ Hierdoor moeten tegels opnieuw worden gedownload wanneer terreinhoogte wordt geb
 <context>
     <name>QtImageViewer</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="384"/>
+        <location filename="../app/core/views/images/viewer/widgets/QtImageViewer.py" line="390"/>
         <source>Open image</source>
         <translation>Afbeelding openen</translation>
     </message>


### PR DESCRIPTION
## Summary

The Person Size Reference tool's shadow rendering depends on the capture time, and a wrong camera clock silently produces wrong sun angles. This PR adds a **Trace shadow…** flow: click the base of any object casting a shadow (rock, tree, post), then the tip of its shadow, and the tool solves the *actual* time of day from the shadow's direction — then uses that time for the sun-based rendering.

## How it works

1. Both clicks are cast onto the ground through the **same CameraModel** used to project the reference person, so the traced azimuth and the rendered shadow share one frame — after applying the solved time, the rendered shadow lines up with the traced line by construction.
2. A shadow points directly away from the sun, so the target sun azimuth is the traced azimuth + 180°. The new `ShadowTimeSolver` scans the 24 h centred on the claimed capture moment (1-minute coarse, 5-second refine) for the daylight moment matching that azimuth. Scanning the *whole day around the claimed time* means a camera clock that is hours wrong still resolves onto the correct solar day.
3. The solved time overrides the camera clock for sun elevation/azimuth; the sun label reports "Time of day derived from the traced shadow." and the button becomes **Clear traced time**.

Robustness: traces clicked tip-first are detected (the stated direction has no daylight match) and interpreted flipped, with a note; geometrically ambiguous directions (a second daylight time matching almost as well) are flagged; unmatchable directions produce a clear message instead of a guess. The trace override is per-image and drops on image change or dialog close.

## Stacking

Based on #133 (`fix/waldo-orientation-and-renderers`) and includes its commit — both touch `PersonReferenceDialog`'s clock-handling area. Merging #133 first makes this a one-commit diff.

## Testing

- `ShadowTimeSolver`: round-trip recovery (±2 min), wrong-clock recovery, winter date, flipped-trace detection, no-daylight-match → None, naive-datetime rejection (7 tests)
- `PersonReferenceDialog`: full two-click flow solves and applies the time (sun azimuth matches the traced moment), clear restores the clock time, button gated on camera/GPS/date, override drops on image change (5 tests)
- Shadow + dialog suites: 78 passed. `flake8` clean. Translations re-extracted.