### PR TITLE
feat(launcher): put Review Results first in the selection dialog

### DIFF
--- a/app/core/views/SelectionDialog_ui.py
+++ b/app/core/views/SelectionDialog_ui.py
@@ -43,41 +43,11 @@ class Ui_MediaSelector(object):
         self.selectionWidget.setObjectName(u"selectionWidget")
         self.horizontalLayout_2 = QHBoxLayout(self.selectionWidget)
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
-        self.imageWidget = QWidget(self.selectionWidget)
-        self.imageWidget.setObjectName(u"imageWidget")
+        self.resultsWidget = QWidget(self.selectionWidget)
+        self.resultsWidget.setObjectName(u"resultsWidget")
         sizePolicy1 = QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         sizePolicy1.setHorizontalStretch(0)
         sizePolicy1.setVerticalStretch(0)
-        sizePolicy1.setHeightForWidth(self.imageWidget.sizePolicy().hasHeightForWidth())
-        self.imageWidget.setSizePolicy(sizePolicy1)
-        self.verticalLayout = QVBoxLayout(self.imageWidget)
-        self.verticalLayout.setObjectName(u"verticalLayout")
-        self.verticalSpacer_top = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
-
-        self.verticalLayout.addItem(self.verticalSpacer_top)
-
-        self.imageButton = QToolButton(self.imageWidget)
-        self.imageButton.setObjectName(u"imageButton")
-        self.imageButton.setMinimumSize(QSize(150, 150))
-        self.imageButton.setMaximumSize(QSize(150, 150))
-        font1 = QFont()
-        font1.setPointSize(12)
-        self.imageButton.setFont(font1)
-        self.imageButton.setStyleSheet(u"QToolButton { border: 3px solid palette(mid); border-radius: 8px; }")
-        self.imageButton.setIconSize(QSize(100, 100))
-        self.imageButton.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
-
-        self.verticalLayout.addWidget(self.imageButton, 0, Qt.AlignHCenter)
-
-        self.verticalSpacer_bottom = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
-
-        self.verticalLayout.addItem(self.verticalSpacer_bottom)
-
-
-        self.horizontalLayout_2.addWidget(self.imageWidget)
-
-        self.resultsWidget = QWidget(self.selectionWidget)
-        self.resultsWidget.setObjectName(u"resultsWidget")
         sizePolicy1.setHeightForWidth(self.resultsWidget.sizePolicy().hasHeightForWidth())
         self.resultsWidget.setSizePolicy(sizePolicy1)
         self.verticalLayout_5 = QVBoxLayout(self.resultsWidget)
@@ -90,6 +60,8 @@ class Ui_MediaSelector(object):
         self.resultsButton.setObjectName(u"resultsButton")
         self.resultsButton.setMinimumSize(QSize(150, 150))
         self.resultsButton.setMaximumSize(QSize(150, 150))
+        font1 = QFont()
+        font1.setPointSize(12)
         self.resultsButton.setFont(font1)
         self.resultsButton.setStyleSheet(u"QToolButton { border: 3px solid palette(mid); border-radius: 8px; }")
         self.resultsButton.setIconSize(QSize(100, 100))
@@ -103,6 +75,34 @@ class Ui_MediaSelector(object):
 
 
         self.horizontalLayout_2.addWidget(self.resultsWidget)
+
+        self.imageWidget = QWidget(self.selectionWidget)
+        self.imageWidget.setObjectName(u"imageWidget")
+        sizePolicy1.setHeightForWidth(self.imageWidget.sizePolicy().hasHeightForWidth())
+        self.imageWidget.setSizePolicy(sizePolicy1)
+        self.verticalLayout = QVBoxLayout(self.imageWidget)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalSpacer_top = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout.addItem(self.verticalSpacer_top)
+
+        self.imageButton = QToolButton(self.imageWidget)
+        self.imageButton.setObjectName(u"imageButton")
+        self.imageButton.setMinimumSize(QSize(150, 150))
+        self.imageButton.setMaximumSize(QSize(150, 150))
+        self.imageButton.setFont(font1)
+        self.imageButton.setStyleSheet(u"QToolButton { border: 3px solid palette(mid); border-radius: 8px; }")
+        self.imageButton.setIconSize(QSize(100, 100))
+        self.imageButton.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
+
+        self.verticalLayout.addWidget(self.imageButton, 0, Qt.AlignHCenter)
+
+        self.verticalSpacer_bottom = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
+
+        self.verticalLayout.addItem(self.verticalSpacer_bottom)
+
+
+        self.horizontalLayout_2.addWidget(self.imageWidget)
 
         self.streamWidget = QWidget(self.selectionWidget)
         self.streamWidget.setObjectName(u"streamWidget")
@@ -172,11 +172,11 @@ class Ui_MediaSelector(object):
     def retranslateUi(self, MediaSelector):
         MediaSelector.setWindowTitle(QCoreApplication.translate("MediaSelector", u"Automated Drone Image Analysis Tool (ADIAT)", None))
         self.label.setText(QCoreApplication.translate("MediaSelector", u"What would you like to do?", None))
-        self.imageButton.setText(QCoreApplication.translate("MediaSelector", u"Image Analysis", None))
 #if QT_CONFIG(tooltip)
         self.resultsButton.setToolTip(QCoreApplication.translate("MediaSelector", u"Open a completed analysis for review: scan a folder for results or reopen a recent one.", None))
 #endif // QT_CONFIG(tooltip)
         self.resultsButton.setText(QCoreApplication.translate("MediaSelector", u"Review Results", None))
+        self.imageButton.setText(QCoreApplication.translate("MediaSelector", u"Image Analysis", None))
 #if QT_CONFIG(tooltip)
         self.streamButton.setToolTip(QCoreApplication.translate("MediaSelector", u"RTMP, Video Files, HDMI Capture", None))
 #endif // QT_CONFIG(tooltip)

--- a/app/tests/core/controllers/test_selection_dialog_controller.py
+++ b/app/tests/core/controllers/test_selection_dialog_controller.py
@@ -32,6 +32,23 @@ def test_selection_dialog_runs_startup_update_check(qtbot):
     assert dialog.app_version == "2.1.0 Beta 1"
 
 
+def test_selection_buttons_ordered_review_first(qtbot):
+    """Review Results leads the launcher: reviewing a completed analysis is
+    the most common entry, so its button comes before Image Analysis and
+    Stream Analysis (field request)."""
+    with patch.object(selection_module, "UpdateController"), \
+            patch.object(selection_module, "SettingsService"):
+        dialog = SelectionDialog("Dark")
+        qtbot.addWidget(dialog)
+
+    layout = dialog.horizontalLayout_2
+    # The layout can also hold non-widget items (spacers); order only the
+    # actual selection panels.
+    widgets = [layout.itemAt(i).widget() for i in range(layout.count())]
+    order = [w.objectName() for w in widgets if w is not None]
+    assert order[:3] == ['resultsWidget', 'imageWidget', 'streamWidget']
+
+
 def test_flight_viewer_button_hidden_when_feature_disabled(qtbot):
     """Flight Viewer visibility is gated: when
     FeatureFlags.FLIGHT_VIEWER_ENABLED is False the Selection dialog must

--- a/resources/views/SelectionDialog.ui
+++ b/resources/views/SelectionDialog.ui
@@ -36,86 +36,6 @@
     <widget class="QWidget" name="selectionWidget" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0,0">
       <item>
-       <widget class="QWidget" name="imageWidget" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <spacer name="verticalSpacer_top">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item alignment="Qt::AlignHCenter">
-          <widget class="QToolButton" name="imageButton">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>150</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>150</width>
-             <height>150</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>12</pointsize>
-            </font>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">QToolButton { border: 3px solid palette(mid); border-radius: 8px; }</string>
-           </property>
-           <property name="text">
-            <string>Image Analysis</string>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>100</width>
-             <height>100</height>
-            </size>
-           </property>
-           <property name="toolButtonStyle">
-            <enum>Qt::ToolButtonTextUnderIcon</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer_bottom">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
        <widget class="QWidget" name="resultsWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -181,6 +101,86 @@
          </item>
          <item>
           <spacer name="verticalSpacer_bottom_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="imageWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <spacer name="verticalSpacer_top">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item alignment="Qt::AlignHCenter">
+          <widget class="QToolButton" name="imageButton">
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>150</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>150</width>
+             <height>150</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>12</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QToolButton { border: 3px solid palette(mid); border-radius: 8px; }</string>
+           </property>
+           <property name="text">
+            <string>Image Analysis</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>100</width>
+             <height>100</height>
+            </size>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextUnderIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_bottom">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
            </property>


### PR DESCRIPTION
## Summary

Field request: reviewing a completed analysis is the most common way into the app, so the launcher buttons are reordered to **Review Results → Image Analysis → Stream Analysis** (Flight Viewer unchanged at the end, still feature-flag gated).

## Changes

- Pure panel reorder in `resources/views/SelectionDialog.ui` (no text, sizing, or behaviour changes).
- `SelectionDialog_ui.py` regenerated with `pyside6-uic --from-imports` at 6.10.2 (matches the repo's pinned toolchain — the diff is a clean 33/33-line reorder).
- Focus/tab order follows creation order, so Review Results is also the first keyboard stop.

## Testing

- New regression test asserting the panel order in the built dialog (tolerates non-widget layout items the controller adds).
- Full selection-dialog controller suite: 6 passed. `flake8` clean.