### PR TITLE
feat(viewer): open results in gallery mode sorted by largest pixel area

### DIFF
--- a/app/core/controllers/images/viewer/Viewer.py
+++ b/app/core/controllers/images/viewer/Viewer.py
@@ -346,6 +346,30 @@ class Viewer(TranslationMixin, QMainWindow, Ui_Viewer):
         self._loading_dialog = None
         self.showMaximized()
 
+        # First-load view defaults: reviewers work the results as a gallery
+        # with the biggest detections first. Deferred one event-loop turn -
+        # entering gallery mode needs the just-shown window's real geometry.
+        QTimer.singleShot(0, self._apply_first_load_view_defaults)
+
+    def _apply_first_load_view_defaults(self):
+        """Open the results in gallery mode, sorted by pixel area (largest
+        first). Runs once, right after the viewer first becomes visible;
+        the user can switch mode and sort freely afterwards."""
+        try:
+            if hasattr(self, 'aoiSortComboBox'):
+                idx = self.aoiSortComboBox.findData('area_desc')
+                if idx >= 0:
+                    # Fires the combo's change handler, so the sidebar and
+                    # gallery sorts stay in lockstep exactly as on a manual
+                    # selection.
+                    self.aoiSortComboBox.setCurrentIndex(idx)
+            if (self.images and not self.gallery_mode
+                    and hasattr(self, 'galleryModeButton')):
+                # Simulate a real click so all mode-toggle signals fire.
+                self.galleryModeButton.click()
+        except Exception as e:
+            self.logger.error(f"First-load view defaults failed: {e}")
+
     def _initial_fit_image(self):
         if self.main_image is not None and not self.main_image._is_destroyed:
             # Ensure the widget is properly sized before resetting zoom

--- a/app/tests/core/controllers/images/viewer/test_viewer_first_load_defaults.py
+++ b/app/tests/core/controllers/images/viewer/test_viewer_first_load_defaults.py
@@ -1,0 +1,71 @@
+"""First-load view defaults: the results viewer opens in gallery mode with
+AOIs sorted by pixel area, largest first (field request). The hook is
+deferred one event-loop turn after the viewer is shown; these tests drive
+the hook directly against a stub."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication, QComboBox
+
+from core.controllers.images.viewer.Viewer import Viewer
+
+
+@pytest.fixture(scope='session')
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def _sort_combo():
+    combo = QComboBox()
+    combo.addItem("Default", None)
+    combo.addItem("Pixel Area (Smallest First)", 'area_asc')
+    combo.addItem("Pixel Area (Largest First)", 'area_desc')
+    return combo
+
+
+def _stub(images=({'name': 'a.jpg'},), gallery_mode=False):
+    return SimpleNamespace(
+        aoiSortComboBox=_sort_combo(),
+        images=list(images),
+        gallery_mode=gallery_mode,
+        galleryModeButton=MagicMock(),
+        logger=MagicMock(),
+    )
+
+
+def test_first_load_defaults_select_area_desc_and_enter_gallery(app):
+    stub = _stub()
+
+    Viewer._apply_first_load_view_defaults(stub)
+
+    assert stub.aoiSortComboBox.currentData() == 'area_desc'
+    stub.galleryModeButton.click.assert_called_once()
+
+
+def test_first_load_defaults_skip_gallery_when_already_in_it(app):
+    stub = _stub(gallery_mode=True)
+
+    Viewer._apply_first_load_view_defaults(stub)
+
+    assert stub.aoiSortComboBox.currentData() == 'area_desc'
+    stub.galleryModeButton.click.assert_not_called()
+
+
+def test_first_load_defaults_skip_gallery_without_images(app):
+    stub = _stub(images=())
+
+    Viewer._apply_first_load_view_defaults(stub)
+
+    stub.galleryModeButton.click.assert_not_called()
+
+
+def test_first_load_defaults_survive_a_missing_combo_entry(app):
+    """A combo without the area_desc entry must not break startup."""
+    stub = _stub()
+    stub.aoiSortComboBox = QComboBox()  # empty combo, findData -> -1
+
+    Viewer._apply_first_load_view_defaults(stub)
+
+    stub.galleryModeButton.click.assert_called_once()  # gallery still entered


### PR DESCRIPTION
## Summary

Field request: reviewing a completed analysis starts with the biggest detections, so the results viewer now opens in **gallery mode** with the AOI sort preset to **Pixel Area (Largest First)**. The user can switch mode and sort freely afterwards — this only changes the starting state.

## How

A one-shot hook runs one event-loop turn after the viewer is first shown (gallery setup needs the shown window's real geometry). It drives the same paths a manual selection takes — the sort combo's change handler and the gallery-mode button's click — so the sidebar sort, the gallery sort, and the mode button state all stay in lockstep, and every mode-toggle side effect fires exactly as on a user click. No-ops safely when there are no images or the combo/button are absent.

## Testing

- 4 unit tests: defaults applied, gallery skipped when already active, skipped without images, resilient to a missing combo entry.
- Verified offscreen against a full result set: viewer opens with gallery mode on, button checked, sort combo on Pixel Area (Largest First), both sidebar and gallery controllers at `area_desc`, and the gallery's first tiles in strictly descending pixel area.
- Gallery + AOI controller suites: 107 passed. `flake8` clean.