### PR TITLE
feat(waldo): true aircraft attitude and refined capture time from the pilot's flight log

### DIFF
--- a/app/core/controllers/images/viewer/WaldoPrePassController.py
+++ b/app/core/controllers/images/viewer/WaldoPrePassController.py
@@ -20,9 +20,45 @@ from core.services.LoggerService import LoggerService
 from core.services.SettingsService import SettingsService
 from core.services.waldo import WaldoMetadataService
 from core.services.waldo import WaldoClockDecisions
+from core.services.waldo import WaldoFlightLogDecisions
 from core.services.waldo.WaldoClockDecisions import CLOCK_DECISIONS_SETTING
+from core.services.waldo.WaldoFlightLog import WaldoFlightLogService
 from core.views.images.viewer.dialogs.WaldoPrePassDialog import WaldoPrePassDialog
 from core.views.images.viewer.dialogs.WaldoClockCorrectionDialog import WaldoClockCorrectionDialog
+from core.views.images.viewer.dialogs.WaldoFlightLogDialog import WaldoFlightLogDialog
+
+
+def invalidate_attitude_caches(viewer):
+    """Best-effort invalidation of caches built from stamped attitude XMP.
+
+    Needed after a MID-SESSION restamp (manual flight-log attach or clock
+    amendment while the viewer is open): ImageService parses XMP once at
+    construction, the GPS map caches per-image bearings and FOV parameters,
+    and POD coverage products fingerprint only terrain settings - none of
+    them notice the files changing underneath. Folder-open restamps run
+    before any of these exist, so this is a no-op there.
+    """
+    if viewer is None:
+        return
+    if hasattr(viewer, 'current_image_service'):
+        viewer.current_image_service = None
+    pod_cache = getattr(viewer, 'pod_result_cache', None)
+    if pod_cache is not None:
+        try:
+            pod_cache.invalidate()
+        except Exception:
+            pass
+    map_controller = getattr(viewer, 'gps_map_controller', None)
+    map_dialog = getattr(map_controller, 'map_dialog', None)
+    map_view = getattr(map_dialog, 'map_view', None)
+    if map_view is not None:
+        try:
+            map_view._fov_cache = None
+            for entry in getattr(map_view, 'gps_data', None) or []:
+                if isinstance(entry, dict) and 'bearing' in entry:
+                    entry['bearing'] = None
+        except Exception:
+            pass
 
 
 class WaldoPrePassController:
@@ -77,6 +113,9 @@ class WaldoPrePassController:
         if not any_pending:
             self.logger.info("WaldoPrePassController: all WALDO images already processed.")
             self._offer_clock_correction(waldo_paths, proposal, service=detect_service)
+            # Strictly after the clock offer: the flight-log fit reads the
+            # corrected capture times the offer may just have stamped.
+            self._offer_flight_log(waldo_paths, service=detect_service)
             return
 
         # Build a TerrainService that respects the configured provider preference.
@@ -97,6 +136,68 @@ class WaldoPrePassController:
         )
         if not result.cancelled:
             self._offer_clock_correction(waldo_paths, proposal, service=service)
+            self._offer_flight_log(waldo_paths, service=service)
+
+    # ------------------------------------------------------------------
+    # Flight-log attitude
+    # ------------------------------------------------------------------
+
+    def _offer_flight_log(self, waldo_paths: List[str],
+                          service: Optional[WaldoMetadataService] = None):
+        """Discover, calibrate, and offer a ForeFlight track log for the folder.
+
+        Runs strictly AFTER the clock-correction offer in both pre-pass
+        branches: the fit resolves capture times through any correction just
+        stamped, and its signature records the correction it used - a later
+        clock change retriggers the restamp on the next open.
+
+        A remembered acceptance re-applies silently (auto mode); a remembered
+        decline suppresses the offer. With no memory, only a candidate whose
+        clock-offset fit actually matches this folder opens the dialog.
+        """
+        if not waldo_paths:
+            return
+        try:
+            folder_key = WaldoClockDecisions.folder_key_for(waldo_paths[0])
+            decision = WaldoFlightLogDecisions.get_decision(folder_key, self.settings_service)
+            if decision and decision.get('decision') == 'declined':
+                return
+
+            flight_service = WaldoFlightLogService()
+            candidates: List[str] = []
+            remembered_path = (decision or {}).get('log_path')
+            if remembered_path and os.path.isfile(remembered_path):
+                candidates.append(remembered_path)
+            auto = bool(decision and decision.get('decision') == 'accepted' and candidates)
+            if not candidates:
+                candidates = flight_service.candidate_files(os.path.dirname(waldo_paths[0]))
+            if not candidates:
+                return
+
+            if service is None:
+                service = WaldoMetadataService(terrain_service=None)
+            dialog = WaldoFlightLogDialog(
+                self.parent, service, flight_service, waldo_paths, candidates,
+                auto_apply=auto)
+            dialog.exec()
+
+            if dialog.applied and dialog.fit is not None and dialog.remember_choice and not auto:
+                WaldoFlightLogDecisions.store_decision(folder_key, {
+                    'decision': 'accepted',
+                    'log_path': dialog.fit.log_path,
+                }, self.settings_service)
+            elif dialog.declined and dialog.remember_choice:
+                WaldoFlightLogDecisions.store_decision(
+                    folder_key, {'decision': 'declined'}, self.settings_service)
+
+            result = dialog.result_data
+            self.logger.info(
+                "WaldoPrePassController: flight log stamped=%d current=%d "
+                "errors=%d declined=%s"
+                % (result.processed, result.already_current, len(result.errors),
+                   dialog.declined))
+        except Exception as e:
+            self.logger.error(f"WaldoPrePassController: flight-log offer failed - {e}")
 
     # ------------------------------------------------------------------
     # Clock correction

--- a/app/core/controllers/images/viewer/exports/CalTopoExportController.py
+++ b/app/core/controllers/images/viewer/exports/CalTopoExportController.py
@@ -598,9 +598,10 @@ class CalTopoExportController(TranslationMixin):
                         "No coverage area polygons could be calculated.\n\n"
                         "This usually means:\n"
                         "• The images don't have GPS data in their EXIF metadata\n"
-                        "• The images are not nadir (gimbal pitch must be between -85° and -95°)\n"
+                        "• The images are not nadir (gimbal pitch must be between -85° and -95°;\n"
+                        "  WALDO images: boresight within 40° of nadir)\n"
                         "• GSD (ground sample distance) could not be calculated\n\n"
-                        "Please ensure your images have GPS coordinates and are nadir shots."
+                        "Please ensure your images have GPS coordinates and are near-nadir shots."
                     )
                 else:
                     message = self.tr(

--- a/app/core/controllers/images/viewer/exports/CoverageExtentExportController.py
+++ b/app/core/controllers/images/viewer/exports/CoverageExtentExportController.py
@@ -281,7 +281,8 @@ class CoverageExtentExportController(TranslationMixin):
                 "Images may be skipped for the following reasons:\n"
                 "  • Missing GPS data in EXIF\n"
                 "  • No valid GSD (missing altitude/focal length)\n"
-                "  • Gimbal not nadir (must be -85° to -95°)"
+                "  • Gimbal not nadir (must be -85° to -95°;\n"
+                "    WALDO: boresight within 40° of nadir)"
             ).format(
                 processed=coverage_data['image_count'],
                 skipped=coverage_data['skipped_count']

--- a/app/core/services/image/CoverageExtentService.py
+++ b/app/core/services/image/CoverageExtentService.py
@@ -25,6 +25,12 @@ class CoverageExtentService:
     then unions overlapping polygons to create consolidated coverage areas.
     """
 
+    # WALDO composite gate: maximum total boresight off-nadir angle. The
+    # 22.5° mount plus ordinary lane-flight bank/pitch stays well inside;
+    # steep banked turn frames (where the flat-rectangle footprint model
+    # breaks down) fall outside and are skipped.
+    WALDO_MAX_OFF_NADIR_DEG = 40.0
+
     def __init__(self, custom_altitude_ft: Optional[float] = None, logger: Optional[LoggerService] = None,
                  use_terrain: bool = True):
         """
@@ -211,23 +217,40 @@ class CoverageExtentService:
             # Load image service
             image_service = ImageService(image_path, image.get('mask_path', ''), calculated_bearing=image.get('bearing'))
 
-            # Check gimbal angle - must be nadir (allowing for outward roll on
-            # fixed-wing rigs like WALDO, where pitch stays at -90 but roll is
-            # applied about the heading axis to push the footprint sideways).
+            # Outward gimbal roll (e.g. WALDO ±22.5°) shifts the ground footprint
+            # cross-track by h*tan(roll). >90° rolls are the DJI "inverted gimbal"
+            # pattern where get_camera_yaw already flips yaw 180°, so skip those.
             gimbal_pitch = image_service.get_camera_pitch()
-            if gimbal_pitch is not None:
+            gimbal_roll = image_service.get_gimbal_roll() or 0.0
+            if abs(gimbal_roll) > 90.0:
+                gimbal_roll = 0.0
+
+            # Gimbal-angle gate. WALDO images (waldo:ProcessorVersion present)
+            # may carry TRUE per-image attitude from a flight track log: pitch
+            # wanders off -90 with the airframe and roll combines the ±22.5°
+            # mount with aircraft bank - so both axes are gated TOGETHER by
+            # the boresight's total off-nadir angle (the flat-rectangle model
+            # below degrades ~1/cos² off nadir; steep banked turn frames must
+            # drop out). Constant WALDO stamps (-90, ±22.5° -> 22.5° off
+            # nadir) pass exactly as before. Non-WALDO images keep the
+            # historical nadir pitch gate unchanged.
+            is_waldo = image_service.get_waldo_processor_version() is not None
+            if is_waldo:
+                pitch_for_gate = gimbal_pitch if gimbal_pitch is not None else -90.0
+                cos_off_nadir = (math.cos(math.radians(pitch_for_gate + 90.0))
+                                 * math.cos(math.radians(gimbal_roll)))
+                off_nadir = math.degrees(math.acos(max(-1.0, min(1.0, cos_off_nadir))))
+                if off_nadir > self.WALDO_MAX_OFF_NADIR_DEG:
+                    self.logger.warning(
+                        f"Image {image.get('name', 'unknown')} skipped: boresight "
+                        f"{off_nadir:.1f}° off nadir (banked/turning frame)")
+                    return None
+            elif gimbal_pitch is not None:
                 # Nadir is typically -90 degrees (camera pointing straight down)
                 # Allow range from -85 to -95 degrees (5 degree tolerance)
                 if not (-95 <= gimbal_pitch <= -85):
                     self.logger.warning(f"Image {image.get('name', 'unknown')} skipped: gimbal not nadir ({gimbal_pitch:.1f}°)")
                     return None
-
-            # Outward gimbal roll (e.g. WALDO ±22.5°) shifts the ground footprint
-            # cross-track by h*tan(roll). >90° rolls are the DJI "inverted gimbal"
-            # pattern where get_camera_yaw already flips yaw 180°, so skip those.
-            gimbal_roll = image_service.get_gimbal_roll() or 0.0
-            if abs(gimbal_roll) > 90.0:
-                gimbal_roll = 0.0
 
             # Get image dimensions (needed first: terrain GSD samples the center pixel)
             img_array = image_service.img_array
@@ -310,6 +333,17 @@ class CoverageExtentService:
                 offset_m = agl_m * math.tan(math.radians(gimbal_roll))
                 roll_east_m = offset_m * math.sin(left_bearing)
                 roll_north_m = offset_m * math.cos(left_bearing)
+
+            # WALDO flight-log attitude also moves pitch off -90: the
+            # footprint shifts h*tan(pitch+90) ALONG the image-top azimuth
+            # (toward it above nadir, away when tilted beyond nadir).
+            # WALDO-scoped: DJI nadir footprints keep their historical
+            # center, exactly as before.
+            if is_waldo and gimbal_pitch is not None and gimbal_pitch != -90.0:
+                az_rad = math.radians(bearing)
+                pitch_offset_m = agl_m * math.tan(math.radians(gimbal_pitch + 90.0))
+                roll_east_m += pitch_offset_m * math.sin(az_rad)
+                roll_north_m += pitch_offset_m * math.cos(az_rad)
 
             corners_image = [
                 (-width_m / 2, -height_m / 2),  # Top-left

--- a/app/core/services/image/ImageService.py
+++ b/app/core/services/image/ImageService.py
@@ -265,6 +265,13 @@ class ImageService:
     def get_asl_altitude(self, distance_unit):
         """Retrieve the drone's altitude above sea level from EXIF data.
 
+        WALDO imagery (waldo:ProcessorVersion stamped) prefers the
+        pre-pass's drone-dji:AbsoluteAltitude: the synthesis computed a
+        true orthometric ASL there (GPS ellipsoidal minus geoid
+        undulation), while the raw EXIF GPSAltitude on these cameras is
+        WGS84-ellipsoidal - tens of meters off as "sea level". Non-WALDO
+        behaviour is unchanged.
+
         Args:
             distance_unit (str): Unit to return altitude in ("ft" or "m").
 
@@ -272,6 +279,17 @@ class ImageService:
             float or None: Altitude in the requested unit, or None if unavailable.
         """
         METERS_TO_FEET = 3.28084
+
+        if self.get_waldo_processor_version() is not None and self.xmp_data is not None:
+            for key in ('drone-dji:AbsoluteAltitude', 'AbsoluteAltitude',
+                        'XMP-drone-dji:AbsoluteAltitude'):
+                value = self.xmp_data.get(key)
+                if value is not None:
+                    try:
+                        asl_m = float(value)
+                        return round(asl_m * METERS_TO_FEET, 2) if distance_unit == 'ft' else asl_m
+                    except (TypeError, ValueError):
+                        break
 
         if self.exif_data is None:
             return None

--- a/app/core/services/shadow/SolarPosition.py
+++ b/app/core/services/shadow/SolarPosition.py
@@ -56,6 +56,11 @@ def resolve_capture_utc(
     """Resolve image capture time to a tz-aware UTC datetime.
 
     Resolution order (first match wins, most authoritative first):
+        -1. XMP waldo:CaptureUtcRefined — the capture time calibrated to
+           GPS-true time by fitting the image GPS positions against an
+           aircraft track log (WaldoMetadataService.apply_flight_log_attitude).
+           Seconds-accurate, so it outranks the operator-confirmed hour/zone
+           repair below (which it was computed on top of).
         0. XMP waldo:CaptureUtcCorrected — an operator-confirmed repair of a
            known-faulty camera clock (see WaldoMetadataService clock
            correction). When present it outranks everything: the EXIF fields
@@ -87,8 +92,8 @@ def resolve_capture_utc(
 
     Returns:
         (utc_datetime, source_tag) where source_tag is one of
-        'waldo_corrected', 'gps', 'exif_with_offset', 'xmp_create_date',
-        'xmp_modify_date', 'exif_local_tz_from_gps'.
+        'waldo_refined', 'waldo_corrected', 'gps', 'exif_with_offset',
+        'xmp_create_date', 'xmp_modify_date', 'exif_local_tz_from_gps'.
 
     Raises:
         SolarTimeUnresolvable: no resolvable timestamp present.
@@ -96,14 +101,15 @@ def resolve_capture_utc(
     if xmp_data:
         # Key shape depends on the XMP reader: bare when parsed per-namespace,
         # prefixed when merged across namespaces.
-        for key in ('CaptureUtcCorrected', 'waldo:CaptureUtcCorrected',
-                    'XMP-waldo:CaptureUtcCorrected'):
-            value = xmp_data.get(key)
-            if value:
-                try:
-                    return _from_iso8601(value), 'waldo_corrected'
-                except ValueError:
-                    break
+        for tag, source in (('CaptureUtcRefined', 'waldo_refined'),
+                            ('CaptureUtcCorrected', 'waldo_corrected')):
+            for key in (tag, f'waldo:{tag}', f'XMP-waldo:{tag}'):
+                value = xmp_data.get(key)
+                if value:
+                    try:
+                        return _from_iso8601(value), source
+                    except ValueError:
+                        break
 
     gps = exif_data.get('GPS') or {}
     gps_date = gps.get(piexif.GPSIFD.GPSDateStamp)

--- a/app/core/services/waldo/WaldoFlightLog.py
+++ b/app/core/services/waldo/WaldoFlightLog.py
@@ -1,0 +1,524 @@
+"""
+WaldoFlightLog - Per-image aircraft attitude from a ForeFlight track log.
+
+ForeFlight (the pilot's EFB app) exports a per-second track log CSV with the
+aircraft position, ground course, ground speed, and - when an attitude source
+is available (device sensors or an external AHRS such as a Sentry) - bank and
+pitch. WALDO cameras are rigidly mounted to the airframe, so this is the first
+data source that lets the pre-pass stamp TRUE per-image camera attitude
+instead of assuming a level airframe.
+
+File format (verified on field data, 2026-08-07 N183CP sortie):
+    row 1: flight-summary header (starts ``Pilot,Tail Number,...``)
+    row 2: summary values (timestamps in epoch MILLISECONDS)
+    row 3: point header ``Timestamp,Latitude,Longitude,Altitude,Course,
+           Speed,Bank,Pitch,Horizontal Error,Vertical Error``
+    rows 4+: points - epoch SECONDS (float, often scientific notation),
+           Altitude in feet, Speed in KNOTS, Course in degrees true with
+           -1 meaning invalid (stationary), Bank + = right wing down,
+           Pitch + = nose up.
+
+Two calibrations are solved before the log is trusted (both field-verified):
+
+Clock offset - the pod camera clock is not GPS-disciplined (measured 17 s
+fast on field data). The offset is fit by sliding the folder's capture times
+against the log and minimising the distance between each image's EXIF GPS
+and the interpolated track position. A good fit (residual at GPS noise
+level) doubles as proof that this log belongs to this folder; a bad fit
+rejects the pairing.
+
+Attitude lag - ForeFlight's attitude channel is recorded LATE relative to
+its GPS channel (~4-5 s on field data; the AHRS filter and logging path
+delay it). The lag is fit by cross-correlating logged bank against the bank
+a coordinated turn would need for the observed course rate
+(tan(bank) = v*omega/g). Without the fitted lag the bank samples decorrelate
+from the capture instants; with it, correlation reached 0.89-0.97 on field
+data. A low peak correlation means the attitude channel is unusable
+(hand-held phone, no attitude source) and only the clock refinement is kept.
+"""
+
+import csv
+import glob
+import hashlib
+import math
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence, Tuple
+
+from helpers.LocationInfo import LocationInfo
+
+from core.services.LoggerService import LoggerService
+
+# First cells of row 1 that identify a ForeFlight track-log export.
+FLIGHTLOG_SNIFF_PREFIX = "Pilot,Tail Number"
+
+KNOTS_TO_MPS = 0.514444
+FEET_TO_M = 0.3048
+GRAVITY_MPS2 = 9.80665
+
+# Clock-offset fit: coarse scan range/step, then a fine pass around the best
+# coarse offset. The pod clock error observed in the field is tens of
+# seconds; +/-120 s leaves generous margin without risking a false lock onto
+# a different lane pass.
+CLOCK_SCAN_RANGE_S = 120.0
+CLOCK_SCAN_STEP_S = 1.0
+CLOCK_FINE_RANGE_S = 2.0
+CLOCK_FINE_STEP_S = 0.1
+# Accept the fit only when images sit this close to the track on average
+# (GPS + interpolation noise measured 13-20 m; 50 m keeps margin without
+# accepting a neighbouring-lane false lock at typical 150-300 m lane pitch).
+CLOCK_FIT_MAX_MEAN_DIST_M = 50.0
+# The fit subsamples large folders: this many images spread evenly is plenty
+# to lock a single scalar offset.
+CLOCK_FIT_MAX_SAMPLES = 60
+
+# Attitude-lag fit tunables.
+LAG_SCAN_RANGE_S = 10
+LAG_MIN_CORRELATION = 0.7
+# Course-rate bank prediction is only meaningful in flight.
+LAG_MIN_SPEED_MPS = 20.0
+# Box half-width (seconds) for smoothing both series before correlating;
+# kills 1 Hz differencing noise without erasing the turn structure.
+LAG_SMOOTH_HALF_WIDTH_S = 2
+
+# Interpolating across a logging dropout longer than this is guessing.
+MAX_INTERP_GAP_S = 5.0
+
+# Directory levels above the images searched for candidate CSVs (same field
+# layout rationale as WaldoTriggerLog.TRIGGER_SEARCH_LEVELS).
+FLIGHTLOG_SEARCH_LEVELS = 3
+
+
+@dataclass
+class FlightLogTrack:
+    """A parsed ForeFlight track log as parallel per-point arrays.
+
+    ``course`` entries are None where ForeFlight logged -1 (invalid).
+    All arrays share indices and are strictly time-ordered.
+    """
+    path: str
+    t: List[float] = field(default_factory=list)            # epoch seconds
+    lat: List[float] = field(default_factory=list)
+    lon: List[float] = field(default_factory=list)
+    alt_m: List[float] = field(default_factory=list)
+    course: List[Optional[float]] = field(default_factory=list)
+    speed_mps: List[float] = field(default_factory=list)
+    bank: List[float] = field(default_factory=list)
+    pitch: List[float] = field(default_factory=list)
+
+    def __len__(self):
+        return len(self.t)
+
+    @property
+    def t_start(self) -> float:
+        return self.t[0]
+
+    @property
+    def t_end(self) -> float:
+        return self.t[-1]
+
+
+@dataclass
+class AttitudeSample:
+    """Interpolated aircraft state at one capture instant."""
+    in_coverage: bool
+    bank_deg: Optional[float] = None
+    pitch_deg: Optional[float] = None
+    course_deg: Optional[float] = None
+
+
+@dataclass
+class FlightLogFit:
+    """Result of calibrating a track log against one image folder."""
+    log_path: str
+    log_sha256: str
+    accepted: bool
+    reason: str = ""
+    clock_offset_s: float = 0.0
+    mean_track_dist_m: float = float('inf')
+    matched_fraction: float = 0.0
+    attitude_reliable: bool = False
+    attitude_lag_s: float = 0.0
+    lag_correlation: float = 0.0
+    bank_min_deg: float = 0.0
+    bank_max_deg: float = 0.0
+
+
+def _bracket(times: Sequence[float], t: float) -> int:
+    """Index i of the last point with times[i] <= t (binary search).
+
+    Returns -1 before the first point and len-1 at/after the last.
+    Mirrors the search shape of BearingCalculationService._find_bracket_index.
+    """
+    lo, hi = 0, len(times) - 1
+    if t < times[0]:
+        return -1
+    if t >= times[hi]:
+        return hi
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if times[mid] <= t:
+            lo = mid
+        else:
+            hi = mid
+    return lo
+
+
+def _lerp_angle(a: float, b: float, f: float) -> float:
+    """Circular linear interpolation between bearings a and b (degrees)."""
+    delta = (b - a + 180.0) % 360.0 - 180.0
+    return (a + f * delta) % 360.0
+
+
+def _box_smooth(values: List[float], half_width: int) -> List[float]:
+    """Centered box smoothing; plain lists, edges shrink the window."""
+    if half_width <= 0:
+        return list(values)
+    out = []
+    n = len(values)
+    for i in range(n):
+        lo = max(0, i - half_width)
+        hi = min(n, i + half_width + 1)
+        out.append(sum(values[lo:hi]) / (hi - lo))
+    return out
+
+
+def _correlation(a: List[float], b: List[float]) -> float:
+    """Pearson correlation; 0.0 when either series is flat."""
+    n = len(a)
+    if n < 3:
+        return 0.0
+    ma = sum(a) / n
+    mb = sum(b) / n
+    cov = sum((x - ma) * (y - mb) for x, y in zip(a, b)) / n
+    sa = math.sqrt(sum((x - ma) ** 2 for x in a) / n)
+    sb = math.sqrt(sum((y - mb) ** 2 for y in b) / n)
+    if sa < 1e-9 or sb < 1e-9:
+        return 0.0
+    return cov / (sa * sb)
+
+
+class WaldoFlightLogService:
+    """Parse ForeFlight track logs and calibrate them to WALDO image folders."""
+
+    def __init__(self):
+        self.logger = LoggerService()
+
+    # ------------------------------------------------------------------
+    # Discovery + parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def sniff(path: str) -> bool:
+        """True when the file's first line identifies a ForeFlight export."""
+        try:
+            with open(path, 'r', encoding='utf-8-sig', errors='replace') as f:
+                first = f.readline()
+        except OSError:
+            return False
+        return first.strip().startswith(FLIGHTLOG_SNIFF_PREFIX)
+
+    @staticmethod
+    def candidate_files(image_dir: str) -> List[str]:
+        """ForeFlight CSVs in the image folder or up to FLIGHTLOG_SEARCH_LEVELS parents."""
+        candidates: List[str] = []
+        d = os.path.abspath(image_dir)
+        seen = set()
+        for _ in range(FLIGHTLOG_SEARCH_LEVELS + 1):
+            if d in seen:
+                break
+            seen.add(d)
+            for path in sorted(glob.glob(os.path.join(d, '*.csv'))):
+                if WaldoFlightLogService.sniff(path):
+                    candidates.append(path)
+            parent = os.path.dirname(d)
+            if parent == d:
+                break
+            d = parent
+        return candidates
+
+    @staticmethod
+    def content_hash(path: str) -> str:
+        """SHA-256 of the log file content (identity survives copies/moves)."""
+        h = hashlib.sha256()
+        with open(path, 'rb') as f:
+            for chunk in iter(lambda: f.read(1 << 20), b''):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def parse(self, path: str) -> Optional[FlightLogTrack]:
+        """Parse a ForeFlight track log; None when unusable.
+
+        Tolerates truncated tails and malformed rows (skipped). Rejects
+        non-ForeFlight files and logs with fewer than 2 usable points.
+        """
+        if not self.sniff(path):
+            return None
+        track = FlightLogTrack(path=path)
+        try:
+            with open(path, 'r', encoding='utf-8-sig', errors='replace', newline='') as f:
+                reader = csv.reader(f)
+                in_points = False
+                for row in reader:
+                    if not row:
+                        continue
+                    if not in_points:
+                        # The point header marks the start of point rows;
+                        # everything before it is flight summary.
+                        if row[0].strip().lower() == 'timestamp':
+                            in_points = True
+                        continue
+                    if len(row) < 8:
+                        continue
+                    try:
+                        t = float(row[0])
+                        lat = float(row[1])
+                        lon = float(row[2])
+                        alt_ft = float(row[3])
+                        course = float(row[4])
+                        speed_kt = float(row[5])
+                        bank = float(row[6])
+                        pitch = float(row[7])
+                    except ValueError:
+                        continue
+                    # Strictly increasing time keeps interpolation honest.
+                    if track.t and t <= track.t[-1]:
+                        continue
+                    track.t.append(t)
+                    track.lat.append(lat)
+                    track.lon.append(lon)
+                    track.alt_m.append(alt_ft * FEET_TO_M)
+                    track.course.append(course if course >= 0.0 else None)
+                    track.speed_mps.append(speed_kt * KNOTS_TO_MPS)
+                    track.bank.append(bank)
+                    track.pitch.append(pitch)
+        except OSError:
+            return None
+        if len(track) < 2:
+            return None
+        return track
+
+    # ------------------------------------------------------------------
+    # Interpolation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def interpolate_position(track: FlightLogTrack, t: float) -> Optional[Tuple[float, float]]:
+        """(lat, lon) at epoch t, or None outside coverage / across a gap."""
+        i = _bracket(track.t, t)
+        if i < 0 or i >= len(track) - 1:
+            # Exactly at the final point still counts.
+            if i == len(track) - 1 and abs(t - track.t[i]) < 1e-9:
+                return (track.lat[i], track.lon[i])
+            return None
+        dt = track.t[i + 1] - track.t[i]
+        if dt > MAX_INTERP_GAP_S:
+            return None
+        f = (t - track.t[i]) / dt
+        return (
+            track.lat[i] + f * (track.lat[i + 1] - track.lat[i]),
+            track.lon[i] + f * (track.lon[i + 1] - track.lon[i]),
+        )
+
+    @staticmethod
+    def sample_attitude(track: FlightLogTrack, t: float, lag_s: float) -> AttitudeSample:
+        """Aircraft attitude at capture instant t.
+
+        Bank/pitch are read at t + lag_s (the attitude channel is logged
+        late; the fitted lag re-aligns it). Course is GPS-chained and read
+        at t directly, circularly interpolated, None across invalid spans.
+        """
+        ta = t + lag_s
+        i = _bracket(track.t, ta)
+        sample = AttitudeSample(in_coverage=False)
+        if 0 <= i < len(track) - 1:
+            dt = track.t[i + 1] - track.t[i]
+            if dt <= MAX_INTERP_GAP_S:
+                f = (ta - track.t[i]) / dt
+                sample.in_coverage = True
+                sample.bank_deg = track.bank[i] + f * (track.bank[i + 1] - track.bank[i])
+                sample.pitch_deg = track.pitch[i] + f * (track.pitch[i + 1] - track.pitch[i])
+        elif i == len(track) - 1 and abs(ta - track.t[i]) < 1e-9:
+            sample.in_coverage = True
+            sample.bank_deg = track.bank[i]
+            sample.pitch_deg = track.pitch[i]
+
+        j = _bracket(track.t, t)
+        if 0 <= j < len(track) - 1:
+            c0 = track.course[j]
+            c1 = track.course[j + 1]
+            dt = track.t[j + 1] - track.t[j]
+            if c0 is not None and c1 is not None and dt <= MAX_INTERP_GAP_S:
+                f = (t - track.t[j]) / dt
+                sample.course_deg = _lerp_angle(c0, c1, f)
+        return sample
+
+    # ------------------------------------------------------------------
+    # Clock-offset fit
+    # ------------------------------------------------------------------
+
+    def fit_clock_offset(self, track: FlightLogTrack,
+                         images: Sequence[Tuple[float, float, float]]) -> Tuple[float, float, float]:
+        """Fit the capture-clock offset against the track.
+
+        ``images`` is (capture_utc_epoch, lat, lon) per image; the corrected
+        capture time is capture + offset. Returns (offset_s, mean_dist_m,
+        matched_fraction) for the best offset - the caller judges acceptance.
+        """
+        usable = [im for im in images if im[1] is not None and im[2] is not None]
+        if not usable:
+            return (0.0, float('inf'), 0.0)
+        step = max(1, len(usable) // CLOCK_FIT_MAX_SAMPLES)
+        samples = usable[::step]
+
+        def mean_dist(offset: float) -> Tuple[float, int]:
+            total = 0.0
+            hit = 0
+            for t_img, lat, lon in samples:
+                pos = self.interpolate_position(track, t_img + offset)
+                if pos is None:
+                    continue
+                total += LocationInfo.haversine_m(lat, lon, pos[0], pos[1])
+                hit += 1
+            if hit == 0:
+                return (float('inf'), 0)
+            return (total / hit, hit)
+
+        best_offset = 0.0
+        best_dist = float('inf')
+        offset = -CLOCK_SCAN_RANGE_S
+        while offset <= CLOCK_SCAN_RANGE_S:
+            d, hit = mean_dist(offset)
+            # Require the offset to keep most samples inside the log; an
+            # offset that pushes the folder off the log's end can look
+            # artificially good on the few points that remain.
+            if hit >= max(2, len(samples) // 2) and d < best_dist:
+                best_dist = d
+                best_offset = offset
+            offset += CLOCK_SCAN_STEP_S
+
+        fine = best_offset - CLOCK_FINE_RANGE_S
+        while fine <= best_offset + CLOCK_FINE_RANGE_S:
+            d, hit = mean_dist(fine)
+            if hit >= max(2, len(samples) // 2) and d < best_dist:
+                best_dist = d
+                best_offset = fine
+            fine += CLOCK_FINE_STEP_S
+
+        matched = 0
+        for t_img, lat, lon in usable:
+            pos = self.interpolate_position(track, t_img + best_offset)
+            if pos is not None and LocationInfo.haversine_m(lat, lon, pos[0], pos[1]) <= CLOCK_FIT_MAX_MEAN_DIST_M:
+                matched += 1
+        return (best_offset, best_dist, matched / len(usable))
+
+    # ------------------------------------------------------------------
+    # Attitude-lag fit
+    # ------------------------------------------------------------------
+
+    def fit_attitude_lag(self, track: FlightLogTrack,
+                         t0: float, t1: float) -> Tuple[float, float]:
+        """Fit the attitude channel's lag over window [t0, t1].
+
+        Cross-correlates logged bank against coordinated-turn bank predicted
+        from the GPS course rate. Returns (lag_s, peak_correlation); the
+        caller compares the correlation against LAG_MIN_CORRELATION.
+        """
+        # Build a uniform 1 Hz grid over the (padded) window so integer
+        # shifts are exact seconds.
+        pad = float(LAG_SCAN_RANGE_S)
+        g0 = max(track.t_start, t0 - pad)
+        g1 = min(track.t_end, t1 + pad)
+        n = int(g1 - g0)
+        if n < 30:
+            return (0.0, 0.0)
+
+        pred: List[float] = []
+        logged: List[float] = []
+        for k in range(n):
+            t = g0 + k
+            i = _bracket(track.t, t)
+            if i < 1 or i >= len(track) - 1:
+                pred.append(0.0)
+                logged.append(0.0)
+                continue
+            c0 = track.course[i - 1]
+            c1 = track.course[i + 1]
+            dt = track.t[i + 1] - track.t[i - 1]
+            v = track.speed_mps[i]
+            if c0 is None or c1 is None or dt <= 0.0 or dt > 6.0 or v < LAG_MIN_SPEED_MPS:
+                pred.append(0.0)
+            else:
+                dcourse = (c1 - c0 + 180.0) % 360.0 - 180.0
+                omega = math.radians(dcourse / dt)
+                pred.append(math.degrees(math.atan(v * omega / GRAVITY_MPS2)))
+            logged.append(track.bank[i] + (track.bank[i + 1] - track.bank[i])
+                          * ((t - track.t[i]) / (track.t[i + 1] - track.t[i])))
+
+        pred = _box_smooth(pred, LAG_SMOOTH_HALF_WIDTH_S)
+        logged = _box_smooth(logged, LAG_SMOOTH_HALF_WIDTH_S)
+
+        best_lag = 0
+        best_corr = -1.0
+        for lag in range(-LAG_SCAN_RANGE_S, LAG_SCAN_RANGE_S + 1):
+            # logged[k + lag] against pred[k]: positive lag = attitude late.
+            if lag >= 0:
+                a = pred[:n - lag] if lag else pred
+                b = logged[lag:]
+            else:
+                a = pred[-lag:]
+                b = logged[:lag]
+            c = _correlation(a, b)
+            if c > best_corr:
+                best_corr = c
+                best_lag = lag
+        return (float(best_lag), best_corr)
+
+    # ------------------------------------------------------------------
+    # Full calibration
+    # ------------------------------------------------------------------
+
+    def calibrate(self, log_path: str,
+                  images: Sequence[Tuple[float, float, float]]) -> FlightLogFit:
+        """Parse + fit a log against a folder's (capture_utc, lat, lon) images.
+
+        The returned fit carries acceptance and every stat the confirmation
+        dialog shows. Attitude unreliability (low lag correlation) does NOT
+        reject the fit - the clock refinement alone is still valuable; the
+        caller reads ``attitude_reliable``.
+        """
+        sha = self.content_hash(log_path)
+        track = self.parse(log_path)
+        if track is None:
+            return FlightLogFit(log_path=log_path, log_sha256=sha, accepted=False,
+                                reason="not a readable ForeFlight track log")
+
+        offset, mean_dist, matched = self.fit_clock_offset(track, images)
+        if mean_dist > CLOCK_FIT_MAX_MEAN_DIST_M:
+            return FlightLogFit(
+                log_path=log_path, log_sha256=sha, accepted=False,
+                reason=(f"images do not lie on this log's track "
+                        f"(best mean distance {mean_dist:.0f} m)"),
+                clock_offset_s=offset, mean_track_dist_m=mean_dist,
+                matched_fraction=matched)
+
+        times = [im[0] + offset for im in images if im[1] is not None]
+        t0, t1 = min(times), max(times)
+        lag, corr = self.fit_attitude_lag(track, t0, t1)
+        reliable = corr >= LAG_MIN_CORRELATION
+
+        banks = [track.bank[i] for i in range(len(track)) if t0 <= track.t[i] <= t1]
+        fit = FlightLogFit(
+            log_path=log_path, log_sha256=sha, accepted=True,
+            clock_offset_s=offset, mean_track_dist_m=mean_dist,
+            matched_fraction=matched,
+            attitude_reliable=reliable, attitude_lag_s=lag if reliable else 0.0,
+            lag_correlation=corr,
+            bank_min_deg=min(banks) if banks else 0.0,
+            bank_max_deg=max(banks) if banks else 0.0)
+        self.logger.info(
+            f"WALDO flight log {os.path.basename(log_path)}: offset {offset:+.1f} s, "
+            f"mean track dist {mean_dist:.0f} m, matched {matched:.0%}, "
+            f"attitude lag {lag:+.0f} s (corr {corr:.2f}, "
+            f"{'reliable' if reliable else 'UNRELIABLE - constants kept'})")
+        return fit

--- a/app/core/services/waldo/WaldoFlightLogDecisions.py
+++ b/app/core/services/waldo/WaldoFlightLogDecisions.py
@@ -1,0 +1,56 @@
+"""
+WaldoFlightLogDecisions - Per-folder persistence of flight-log choices.
+
+Remembers, per image folder, whether the operator attached (or declined) a
+ForeFlight track log, and which file it was - so re-opens silently re-apply
+to any new files instead of re-asking, mirroring WaldoClockDecisions.
+
+Decision payload shape:
+    {'decision': 'accepted', 'log_path': str}   or   {'decision': 'declined'}
+"""
+
+import json
+from typing import Optional
+
+from core.services.SettingsService import SettingsService
+from core.services.waldo.WaldoClockDecisions import folder_key_for  # noqa: F401  (re-exported)
+
+FLIGHTLOG_DECISIONS_SETTING = 'WaldoFlightLogs'
+
+
+def get_decisions(settings_service: Optional[SettingsService] = None) -> dict:
+    """All stored per-folder decisions ({folder_key: decision_dict})."""
+    settings_service = settings_service or SettingsService()
+    raw = settings_service.get_setting(FLIGHTLOG_DECISIONS_SETTING)
+    if not raw:
+        return {}
+    try:
+        decisions = json.loads(raw)
+        return decisions if isinstance(decisions, dict) else {}
+    except (TypeError, ValueError):
+        return {}
+
+
+def get_decision(folder_key: str,
+                 settings_service: Optional[SettingsService] = None) -> Optional[dict]:
+    """The stored decision for one folder, or None."""
+    return get_decisions(settings_service).get(folder_key)
+
+
+def store_decision(folder_key: str, decision: dict,
+                   settings_service: Optional[SettingsService] = None):
+    """Persist (or overwrite) the decision for one folder."""
+    settings_service = settings_service or SettingsService()
+    decisions = get_decisions(settings_service)
+    decisions[folder_key] = decision
+    settings_service.set_setting(FLIGHTLOG_DECISIONS_SETTING, json.dumps(decisions))
+
+
+def clear_decision(folder_key: str,
+                   settings_service: Optional[SettingsService] = None):
+    """Remove the stored decision for one folder (detach flow)."""
+    settings_service = settings_service or SettingsService()
+    decisions = get_decisions(settings_service)
+    if folder_key in decisions:
+        del decisions[folder_key]
+        settings_service.set_setting(FLIGHTLOG_DECISIONS_SETTING, json.dumps(decisions))

--- a/app/core/services/waldo/WaldoMetadataService.py
+++ b/app/core/services/waldo/WaldoMetadataService.py
@@ -6,7 +6,9 @@ WALDO airframe assumptions (per user spec):
     - Two Canon EOS 5DS R DSLRs in left/right pods.
     - Filename prefix `0_*` = left camera, `1_*` = right camera.
     - 22.5° outward roll about the heading axis. Camera otherwise nadir.
-    - Plane assumed roughly level (bank ignored).
+    - Plane assumed roughly level UNLESS a ForeFlight track log is attached:
+      apply_flight_log_attitude then composes true per-image bank/pitch into
+      the stamps (see WaldoFlightLog).
     - GPS altitude is ellipsoidal (WGS84-native).
 
 The synthesised XMP fields use the standard `drone-dji:` namespace so the
@@ -45,6 +47,11 @@ from core.services.waldo.WaldoTriggerLog import (
     TRIGGER_MIN_CHRONOLOGY_FRACTION,
     WaldoTriggerLogService,
 )
+from core.services.waldo.WaldoFlightLog import (
+    FlightLogFit,
+    FlightLogTrack,
+    WaldoFlightLogService,
+)
 
 
 WALDO_NAMESPACE_URI = "http://adiat.io/ns/waldo/1.0/"
@@ -81,6 +88,38 @@ DRONE_DJI_NS = "http://www.dji.com/drone-dji/1.0/"
 CLOCK_CORRECTED_UTC_XMP = "CaptureUtcCorrected"
 CLOCK_FACE_SHIFT_XMP = "ClockFaceShiftHours"
 CLOCK_TIMEZONE_XMP = "ClockTimeZone"
+
+# Flight-log attitude XMP fields (waldo namespace), stamped by
+# apply_flight_log_attitude from a calibrated ForeFlight track log.
+# CaptureUtcRefined is deliberately a SEPARATE field from
+# CaptureUtcCorrected: apply_clock_correction's idempotence compares the
+# exact CaptureUtcCorrected string, so refining that stamp in place would
+# make every remembered clock auto-apply rewrite the whole folder on every
+# open (clobbering the refinement) and the flight-log stage restamp it
+# right back - a permanent two-rewrite loop.
+CLOCK_REFINED_UTC_XMP = "CaptureUtcRefined"
+CLOCK_OFFSET_SECONDS_XMP = "ClockOffsetSeconds"
+ATTITUDE_SOURCE_XMP = "AttitudeSource"
+FLIGHTLOG_SIGNATURE_XMP = "FlightLogSignature"
+# The level-airframe image-top bearing the composition starts from. Stamped
+# so a re-run (new log, new clock decision) can rebuild from the true
+# baseline instead of double-composing on already-composed gimbal values.
+LEVEL_YAW_XMP = "LevelYawDegree"
+LEVEL_YAW_VERSION_XMP = "LevelYawVersion"
+
+# Bump to re-apply flight-log attitude on stamped datasets when this stage's
+# algorithm changes (independent of WALDO_PROCESSOR_VERSION, which would
+# force a full re-synthesis of every log-less dataset too).
+FLIGHTLOG_STAGE_VERSION = "1"
+
+# Composed roll beyond this bound falls back to the constant mount attitude:
+# every consumer treats |roll| > 90 as DJI's inverted-gimbal encoding
+# (yaw flipped 180, roll zeroed), so steep-bank turn frames must never be
+# stamped anywhere near that regime.
+FLIGHTLOG_MAX_ROLL_DEG = 60.0
+
+ATTITUDE_SOURCE_TRACKLOG = "foreflight-tracklog"
+ATTITUDE_SOURCE_CONSTANTS = "constants"
 
 # Heading-derivation tunables
 STATIONARY_THRESHOLD_M = 5.0
@@ -152,6 +191,33 @@ class WaldoProcessResult:
     warnings: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)  # informational, non-warning
     cancelled: bool = False
+
+
+@dataclass
+class FlightLogImageRecord:
+    """Per-image inputs for the flight-log attitude stage.
+
+    Built by collect_flight_log_records in its OWN read pass: the stage runs
+    on already-stamped folders where process_folder built no records at all.
+    ``capture_epoch`` is resolved through the clock-correction chain but
+    NEVER through a previous CaptureUtcRefined stamp - the fit must always
+    reference the same un-refined clock, or re-runs would chase their own
+    output.
+    """
+    path: str
+    name: str
+    cam_idx: int
+    capture_epoch: Optional[float] = None
+    lat: Optional[float] = None
+    lon: Optional[float] = None
+    flight_yaw_deg: Optional[float] = None
+    gimbal_yaw_deg: Optional[float] = None
+    level_yaw_deg: Optional[float] = None       # trusted stamped baseline, if any
+    processor_version: Optional[str] = None
+    clock_face_shift: Optional[str] = None
+    clock_tz: Optional[str] = None
+    existing_signature: Optional[str] = None
+    error: Optional[str] = None
 
 
 @dataclass
@@ -267,6 +333,334 @@ class WaldoMetadataService:
             'yaw': yaw,
             'roll': roll,
         }
+
+    # ------------------------------------------------------------------
+    # Flight-log attitude: aircraft bank/pitch composed into the stamps
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _horizontal_axis(azimuth_deg: float) -> np.ndarray:
+        """Horizontal NED unit vector at the given compass azimuth."""
+        az = math.radians(azimuth_deg)
+        return np.array([math.cos(az), math.sin(az), 0.0])
+
+    @staticmethod
+    def _rodrigues_horizontal(azimuth_deg: float, angle_deg: float) -> np.ndarray:
+        """Rodrigues rotation about the horizontal axis at ``azimuth_deg``.
+
+        Same construction as AOIService._calculate_ground_position's roll
+        step; the two must stay identical or stamps and consumers diverge.
+        """
+        k = WaldoMetadataService._horizontal_axis(azimuth_deg)
+        kx, ky, kz = k
+        big_k = np.array([
+            [0.0, -kz, ky],
+            [kz, 0.0, -kx],
+            [-ky, kx, 0.0],
+        ])
+        ang = math.radians(angle_deg)
+        return np.eye(3) + math.sin(ang) * big_k + (1.0 - math.cos(ang)) * (big_k @ big_k)
+
+    @staticmethod
+    def _base_rotation(pitch_deg: float, yaw_deg: float) -> np.ndarray:
+        """Camera-to-NED rotation of the consumer model at zero roll.
+
+        Mirrors AOIService._calculate_ground_position exactly: optical axis
+        at (pitch, yaw), camera image-right horizontal, image-up toward the
+        horizon at the yaw azimuth.
+        """
+        el = math.radians(pitch_deg)
+        az = math.radians(yaw_deg)
+        opt = np.array([
+            math.cos(el) * math.cos(az),
+            math.cos(el) * math.sin(az),
+            -math.sin(el),
+        ])
+        up = np.array([
+            -math.sin(el) * math.cos(az),
+            -math.sin(el) * math.sin(az),
+            -math.cos(el),
+        ])
+        cam_y = -up
+        cam_x = np.cross(opt, up)
+        cam_x = cam_x / np.linalg.norm(cam_x)
+        return np.column_stack([cam_x, cam_y, opt])
+
+    @staticmethod
+    def compose_attitude_rotation(level_yaw_deg: float, level_roll_deg: float,
+                                  flight_yaw_deg: float,
+                                  aircraft_pitch_deg: float,
+                                  aircraft_bank_deg: float) -> np.ndarray:
+        """True camera-to-NED rotation of a banked/pitched airframe.
+
+        Starts from the level-airframe camera rotation the v9 stamps encode
+        (nadir pitch, stored image-top ``level_yaw_deg``, mount roll about
+        the flight axis) and applies the aircraft attitude in world axes:
+        bank about the forward flight axis, then pitch about the lateral
+        (wing) axis. Signs follow the ForeFlight log: bank + = right wing
+        down (which IS a positive Rodrigues angle about the forward axis -
+        it tilts a belly camera's boresight to plane LEFT), pitch + = nose
+        up (tilts the boresight ahead of the aircraft).
+        """
+        r_level = (WaldoMetadataService._rodrigues_horizontal(flight_yaw_deg, level_roll_deg)
+                   @ WaldoMetadataService._base_rotation(-90.0, level_yaw_deg))
+        r_bank = WaldoMetadataService._rodrigues_horizontal(flight_yaw_deg, aircraft_bank_deg)
+        r_pitch = WaldoMetadataService._rodrigues_horizontal(flight_yaw_deg + 90.0, aircraft_pitch_deg)
+        return r_pitch @ r_bank @ r_level
+
+    @staticmethod
+    def invert_to_gimbal_angles(r_true: np.ndarray,
+                                flight_yaw_deg: float) -> Tuple[float, float, float]:
+        """Exact (pitch, yaw, roll) stamp triple reproducing ``r_true``.
+
+        The consumer model is R = Rodrigues(flight axis, roll) @ Base(pitch,
+        yaw), where Base keeps camera image-right horizontal. Un-rolling by
+        the right angle must therefore make the camera-X row horizontal
+        again: with x = R_true[:,0], solving x_D*cos(r) - (k x x)_D*sin(r)
+        = 0 gives r = atan2(x_D, (k x x)_D) up to 180 deg. BOTH roots are
+        exact decompositions (the other one views the scene from an
+        above-horizon Base rolled ~180 deg further), so the physical branch
+        is chosen: the one whose Base looks below the horizon (pitch < 0).
+        """
+        x = r_true[:, 0]
+        k = WaldoMetadataService._horizontal_axis(flight_yaw_deg)
+        kx_d = float(np.cross(k, x)[2])
+        r0 = math.degrees(math.atan2(float(x[2]), kx_d))
+
+        best_exact: Optional[Tuple[float, float, float]] = None
+        best_any: Optional[Tuple[float, Tuple[float, float, float]]] = None
+        for cand in (r0, r0 + 180.0):
+            roll = ((cand + 180.0) % 360.0) - 180.0
+            unrolled = (WaldoMetadataService._rodrigues_horizontal(flight_yaw_deg, -roll)
+                        @ r_true)
+            cam_x = unrolled[:, 0]
+            opt = unrolled[:, 2]
+            yaw = math.degrees(math.atan2(-float(cam_x[0]), float(cam_x[1]))) % 360.0
+            # Elevation from the SIGNED horizontal component along the yaw
+            # azimuth: negative means the axis tilts beyond nadir, away from
+            # the image-top azimuth (pitch < -90) - routine for cam 0, whose
+            # image-top faces backward while nose-up pitch tilts the axis
+            # forward. atan2 keeps the quadrant and stays well-conditioned
+            # at nadir (asin(~1) would lose ~1e-6 deg to float noise).
+            az = math.radians(yaw)
+            along = float(opt[0]) * math.cos(az) + float(opt[1]) * math.sin(az)
+            pitch = math.degrees(math.atan2(-float(opt[2]), along))
+            recomposed = (WaldoMetadataService._rodrigues_horizontal(flight_yaw_deg, roll)
+                          @ WaldoMetadataService._base_rotation(pitch, yaw))
+            err = float(np.linalg.norm(recomposed - r_true))
+            if best_any is None or err < best_any[0]:
+                best_any = (err, (pitch, yaw, roll))
+            if err < 1e-9 and pitch < 0.0 and best_exact is None:
+                best_exact = (pitch, yaw, roll)
+        return best_exact if best_exact is not None else best_any[1]
+
+    def collect_flight_log_records(
+        self,
+        image_paths: List[str],
+        progress_cb: Optional[Callable[[int, int, str], None]] = None,
+        cancel_cb: Optional[Callable[[], bool]] = None,
+    ) -> Tuple[List[FlightLogImageRecord], bool]:
+        """Read the per-image inputs for the flight-log stage.
+
+        Returns (records, cancelled). Runs over ALL WALDO paths - unlike
+        process_folder's records, already-current images are included, since
+        the stage restamps them too.
+        """
+        cancel_cb = cancel_cb or (lambda: False)
+        records: List[FlightLogImageRecord] = []
+        total = len(image_paths)
+        for i, path in enumerate(image_paths):
+            if cancel_cb():
+                return records, True
+            cam_idx = self.is_waldo_image(path)
+            if cam_idx is None:
+                continue
+            if progress_cb is not None and (i % 10 == 0 or i == total - 1):
+                try:
+                    progress_cb(i + 1, total, f"Reading metadata {i + 1}/{total}")
+                except Exception:
+                    pass
+            rec = FlightLogImageRecord(path=path, name=os.path.basename(path), cam_idx=cam_idx)
+            records.append(rec)
+            try:
+                exif = MetaDataHelper.get_exif_data_piexif(path)
+                xmp = MetaDataHelper.get_xmp_data_merged(path) or {}
+            except Exception as e:
+                rec.error = f"Metadata read failed: {e}"
+                continue
+
+            gps = LocationInfo.get_gps(exif_data=exif)
+            if gps:
+                rec.lat = gps['latitude']
+                rec.lon = gps['longitude']
+
+            def xmp_value(tag, prefixes=('waldo:', '', 'XMP-waldo:')):
+                for prefix in prefixes:
+                    value = xmp.get(f"{prefix}{tag}")
+                    if value is not None and str(value) != '':
+                        return str(value)
+                return None
+
+            dji = ('drone-dji:', '', 'XMP-drone-dji:')
+            rec.flight_yaw_deg = self._parse_float(xmp_value('FlightYawDegree', dji))
+            rec.gimbal_yaw_deg = self._parse_float(xmp_value('GimbalYawDegree', dji))
+            rec.processor_version = xmp_value('ProcessorVersion')
+            rec.clock_face_shift = xmp_value(CLOCK_FACE_SHIFT_XMP)
+            rec.clock_tz = xmp_value(CLOCK_TIMEZONE_XMP)
+            rec.existing_signature = xmp_value(FLIGHTLOG_SIGNATURE_XMP)
+            level_yaw = self._parse_float(xmp_value(LEVEL_YAW_XMP))
+            level_version = xmp_value(LEVEL_YAW_VERSION_XMP)
+            # A stamped baseline is only trusted while the synthesis that
+            # produced it is still current; after a version bump the fresh
+            # GimbalYawDegree is the new baseline.
+            if level_yaw is not None and level_version == rec.processor_version:
+                rec.level_yaw_deg = level_yaw
+
+            # Resolve capture UTC through the clock-correction chain but
+            # never through our own refinement (see class docstring).
+            xmp_for_time = {key: value for key, value in xmp.items()
+                            if CLOCK_REFINED_UTC_XMP not in key}
+            try:
+                utc, _source = resolve_capture_utc(exif, xmp_for_time, rec.lat, rec.lon)
+                rec.capture_epoch = utc.timestamp()
+            except SolarTimeUnresolvable:
+                rec.error = "Capture time unresolvable"
+        return records, False
+
+    def _flight_log_signature(self, rec: FlightLogImageRecord, fit: FlightLogFit) -> str:
+        """Per-image idempotence signature for the flight-log stage.
+
+        Encodes every input whose change must retrigger a restamp: stage
+        algorithm version, the synthesis version the stamps sit on, the log
+        file's content, and the clock decision the fit referenced.
+        """
+        clock = f"{rec.clock_face_shift or 'none'}/{rec.clock_tz or 'none'}"
+        return (f"v{FLIGHTLOG_STAGE_VERSION}|p{rec.processor_version or '?'}|"
+                f"{fit.log_sha256[:16]}|clk:{clock}")
+
+    def apply_flight_log_attitude(
+        self,
+        records: List[FlightLogImageRecord],
+        fit: FlightLogFit,
+        track: FlightLogTrack,
+        progress_cb: Optional[Callable[[int, int, str], None]] = None,
+        cancel_cb: Optional[Callable[[], bool]] = None,
+    ) -> WaldoProcessResult:
+        """Stamp per-image attitude (and refined capture UTC) from a calibrated log.
+
+        Per image the composed camera rotation is exactly re-expressed in the
+        consumer model's (pitch, yaw, roll-about-flight-axis) parameters, so
+        AOIService / FOV / coverage read true attitude with no code changes.
+        Images the log cannot cover (outside its window, steep-bank guard,
+        unreliable attitude channel) are restamped with the constant mount
+        attitude instead - never left holding a stale composition.
+        """
+        result = WaldoProcessResult()
+        cancel_cb = cancel_cb or (lambda: False)
+        if not fit.accepted:
+            result.warnings.append(f"Flight log rejected: {fit.reason}")
+            return result
+
+        stats = {'composed': 0, 'constants': 0}
+        total = len(records)
+        for i, rec in enumerate(records):
+            if cancel_cb():
+                result.cancelled = True
+                break
+            if progress_cb is not None:
+                try:
+                    progress_cb(i + 1, total, f"Applying flight-log attitude {i + 1}/{total}: {rec.name}")
+                except Exception:
+                    pass
+            if rec.error:
+                result.errors.append((rec.name, rec.error))
+                continue
+            signature = self._flight_log_signature(rec, fit)
+            if rec.existing_signature == signature:
+                result.already_current += 1
+                continue
+            level_yaw = rec.level_yaw_deg if rec.level_yaw_deg is not None else rec.gimbal_yaw_deg
+            if level_yaw is None or rec.flight_yaw_deg is None:
+                result.errors.append((rec.name, "No stamped yaw baseline (pre-pass has not run?)"))
+                continue
+
+            level_roll = (-OUTWARD_ROLL_DEG) if rec.cam_idx == 0 else (+OUTWARD_ROLL_DEG)
+            fields = [
+                (WALDO_NAMESPACE_URI, FLIGHTLOG_SIGNATURE_XMP, signature),
+                (WALDO_NAMESPACE_URI, CLOCK_OFFSET_SECONDS_XMP, f"{fit.clock_offset_s:+.2f}"),
+                (WALDO_NAMESPACE_URI, LEVEL_YAW_XMP, f"{level_yaw:+.4f}"),
+                (WALDO_NAMESPACE_URI, LEVEL_YAW_VERSION_XMP, rec.processor_version or "?"),
+            ]
+            if rec.capture_epoch is not None:
+                refined = datetime.fromtimestamp(
+                    round(rec.capture_epoch + fit.clock_offset_s), tz=timezone.utc)
+                fields.append((WALDO_NAMESPACE_URI, CLOCK_REFINED_UTC_XMP,
+                               refined.strftime("%Y-%m-%dT%H:%M:%S+00:00")))
+
+            sample = None
+            if fit.attitude_reliable and rec.capture_epoch is not None:
+                sample = WaldoFlightLogService.sample_attitude(
+                    track, rec.capture_epoch + fit.clock_offset_s, fit.attitude_lag_s)
+
+            composed = None
+            if sample is not None and sample.in_coverage and sample.bank_deg is not None:
+                r_true = self.compose_attitude_rotation(
+                    level_yaw, level_roll, rec.flight_yaw_deg,
+                    sample.pitch_deg or 0.0, sample.bank_deg)
+                pitch, yaw, roll = self.invert_to_gimbal_angles(r_true, rec.flight_yaw_deg)
+                if abs(roll) <= FLIGHTLOG_MAX_ROLL_DEG:
+                    composed = (pitch, yaw, roll, sample.pitch_deg or 0.0, sample.bank_deg)
+
+            if composed is not None:
+                pitch, yaw, roll, raw_pitch, raw_bank = composed
+                fields.extend([
+                    (DRONE_DJI_NS, "GimbalPitchDegree", f"{pitch:+.4f}"),
+                    (DRONE_DJI_NS, "GimbalYawDegree", f"{yaw:+.4f}"),
+                    (DRONE_DJI_NS, "GimbalRollDegree", f"{roll:+.4f}"),
+                    (DRONE_DJI_NS, "FlightPitchDegree", f"{raw_pitch:+.4f}"),
+                    (DRONE_DJI_NS, "FlightRollDegree", f"{raw_bank:+.4f}"),
+                    (WALDO_NAMESPACE_URI, ATTITUDE_SOURCE_XMP, ATTITUDE_SOURCE_TRACKLOG),
+                ])
+                stats['composed'] += 1
+            else:
+                # Constants restamp: also RESETS any stale composition from a
+                # previous log/decision (never leave composed values behind a
+                # signature that no longer matches how they were made).
+                fields.extend([
+                    (DRONE_DJI_NS, "GimbalPitchDegree", f"{-90.0:+.4f}"),
+                    (DRONE_DJI_NS, "GimbalYawDegree", f"{level_yaw:+.4f}"),
+                    (DRONE_DJI_NS, "GimbalRollDegree", f"{level_roll:+.4f}"),
+                    (WALDO_NAMESPACE_URI, ATTITUDE_SOURCE_XMP, ATTITUDE_SOURCE_CONSTANTS),
+                ])
+                stats['constants'] += 1
+
+            try:
+                MetaDataHelper.add_xmp_fields(rec.path, fields)
+            except Exception as e:
+                result.errors.append((rec.name, f"Flight-log XMP write failed: {e}"))
+                continue
+            result.processed += 1
+
+        if result.processed:
+            note = (f"Flight log applied: clock {fit.clock_offset_s:+.1f} s, "
+                    f"attitude lag {fit.attitude_lag_s:+.0f} s, "
+                    f"{stats['composed']} images with measured attitude, "
+                    f"{stats['constants']} kept mount constants")
+            if not fit.attitude_reliable:
+                note += " (attitude channel unreliable - clock refinement only)"
+            result.notes.append(note)
+            self.logger.info(f"WALDO {note}")
+        return result
+
+    @staticmethod
+    def _parse_float(value: Optional[str]) -> Optional[float]:
+        """Float from a stamped '+123.4567'-style string; None when absent/garbage."""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
 
     # ------------------------------------------------------------------
     # Image-orientation measurement

--- a/app/core/services/waldo/__init__.py
+++ b/app/core/services/waldo/__init__.py
@@ -22,6 +22,12 @@ from .WaldoTriggerLog import (
     WaldoTriggerLogService,
     TriggerPoint,
 )
+from .WaldoFlightLog import (
+    WaldoFlightLogService,
+    FlightLogFit,
+    FlightLogTrack,
+)
+from . import WaldoFlightLogDecisions
 
 __all__ = [
     'WaldoMetadataService',
@@ -35,4 +41,8 @@ __all__ = [
     'WALDO_PROCESSOR_VERSION',
     'WaldoTriggerLogService',
     'TriggerPoint',
+    'WaldoFlightLogService',
+    'FlightLogFit',
+    'FlightLogTrack',
+    'WaldoFlightLogDecisions',
 ]

--- a/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
+++ b/app/core/views/images/viewer/dialogs/PersonReferenceDialog.py
@@ -397,6 +397,15 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.adjust_clock_button = QPushButton(self.tr("Adjust camera clock..."))
         self.adjust_clock_button.setVisible(False)
 
+        # WALDO imagery: attach the pilot's ForeFlight track log to stamp
+        # true per-image bank/pitch and GPS-accurate capture times.
+        self.flight_log_button = QPushButton(self.tr("Flight track log..."))
+        self.flight_log_button.setToolTip(self.tr(
+            "Attach a ForeFlight track log CSV to stamp true aircraft "
+            "attitude (bank/pitch) and GPS-accurate capture times onto "
+            "these images."))
+        self.flight_log_button.setVisible(False)
+
         # Trace a real shadow in the image to recover the true time of day
         # (works even when the camera clock is wrong).
         self.trace_shadow_button = QPushButton(self.tr("Trace shadow..."))
@@ -422,6 +431,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         button_row.addWidget(self.recenter_button)
         button_row.addWidget(self.trace_shadow_button)
         button_row.addWidget(self.adjust_clock_button)
+        button_row.addWidget(self.flight_log_button)
         button_row.addStretch()
         button_row.addWidget(self.close_button)
 
@@ -448,6 +458,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
         self.color_button.clicked.connect(self._on_color_button_clicked)
         self.recenter_button.clicked.connect(self._recenter)
         self.adjust_clock_button.clicked.connect(self._on_adjust_clock)
+        self.flight_log_button.clicked.connect(self._on_flight_log)
         self.trace_shadow_button.clicked.connect(self._on_trace_shadow_clicked)
         self.close_button.clicked.connect(self.close)
 
@@ -495,11 +506,116 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
                         {'decision': 'accepted',
                          'face_shift_h': dialog.accepted_face_shift_h,
                          'tz_text': dialog.accepted_tz_text})
+                # A changed clock invalidates any applied flight-log stamps
+                # (their signature records the correction the fit used) -
+                # silently re-apply a remembered log against the new clock.
+                self._reapply_flight_log_if_remembered(paths)
+                self._invalidate_viewer_caches()
                 self._resolve_sun()
                 self._update_sun_label()
                 self._on_params_changed()
         except Exception as e:
             LoggerService().error(f"PersonReferenceDialog: clock adjustment failed - {e}")
+
+    def _waldo_folder_paths(self):
+        """All WALDO image paths in this image's folder (sorted)."""
+        import glob as _glob
+        import os as _os
+        from core.services.waldo import WaldoMetadataService
+        folder = _os.path.dirname(self.image_path)
+        return [p for p in sorted(_glob.glob(_os.path.join(folder, '*.jpg')))
+                if WaldoMetadataService.is_waldo_image(p) is not None]
+
+    def _invalidate_viewer_caches(self):
+        """Drop viewer caches built from the (just restamped) attitude XMP."""
+        try:
+            from core.controllers.images.viewer.WaldoPrePassController import (
+                invalidate_attitude_caches,
+            )
+            invalidate_attitude_caches(self.parent())
+        except Exception as e:
+            LoggerService().error(f"PersonReferenceDialog: cache invalidation failed - {e}")
+
+    def _reapply_flight_log_if_remembered(self, paths):
+        """Silently re-run the flight-log stage when this folder has one attached."""
+        import os as _os
+        from core.services.waldo import (
+            WaldoMetadataService, WaldoClockDecisions, WaldoFlightLogDecisions,
+        )
+        from core.services.waldo.WaldoFlightLog import WaldoFlightLogService
+        from core.views.images.viewer.dialogs.WaldoFlightLogDialog import (
+            WaldoFlightLogDialog,
+        )
+        try:
+            decision = WaldoFlightLogDecisions.get_decision(
+                WaldoClockDecisions.folder_key_for(paths[0]))
+            log_path = (decision or {}).get('log_path')
+            if (decision or {}).get('decision') != 'accepted' or not log_path:
+                return
+            if not _os.path.isfile(log_path):
+                return
+            service = WaldoMetadataService(terrain_service=None)
+            dialog = WaldoFlightLogDialog(
+                self, service, WaldoFlightLogService(), paths, [log_path],
+                auto_apply=True)
+            dialog.exec()
+        except Exception as e:
+            LoggerService().error(f"PersonReferenceDialog: flight-log re-apply failed - {e}")
+
+    def _on_flight_log(self):
+        """Attach (or re-run) a ForeFlight track log for this image's folder.
+
+        Discovers candidate CSVs near the folder; falls back to a file picker
+        when none are found. After an apply, viewer caches rebuild so the
+        FOV boxes / AOI positions reflect the new attitude immediately.
+        """
+        from PySide6.QtWidgets import QFileDialog
+        from core.services.waldo import WaldoClockDecisions, WaldoFlightLogDecisions
+        from core.services.waldo import WaldoMetadataService
+        from core.services.waldo.WaldoFlightLog import WaldoFlightLogService
+        from core.views.images.viewer.dialogs.WaldoFlightLogDialog import (
+            WaldoFlightLogDialog,
+        )
+        import os as _os
+        try:
+            paths = self._waldo_folder_paths()
+            if not paths:
+                return
+            folder_key = WaldoClockDecisions.folder_key_for(paths[0])
+            flight_service = WaldoFlightLogService()
+
+            candidates = []
+            remembered = WaldoFlightLogDecisions.get_decision(folder_key)
+            remembered_path = (remembered or {}).get('log_path')
+            if remembered_path and _os.path.isfile(remembered_path):
+                candidates.append(remembered_path)
+            candidates.extend(p for p in flight_service.candidate_files(
+                _os.path.dirname(paths[0])) if p not in candidates)
+            if not candidates:
+                picked, _filter = QFileDialog.getOpenFileName(
+                    self, self.tr("Select ForeFlight track log"),
+                    _os.path.dirname(paths[0]),
+                    self.tr("Track logs (*.csv);;All files (*.*)"))
+                if not picked:
+                    return
+                candidates = [picked]
+
+            service = WaldoMetadataService(terrain_service=None)
+            dialog = WaldoFlightLogDialog(
+                self, service, flight_service, paths, candidates, auto_apply=False)
+            dialog.exec()
+            if dialog.applied and dialog.fit is not None:
+                if dialog.remember_choice:
+                    WaldoFlightLogDecisions.store_decision(folder_key, {
+                        'decision': 'accepted',
+                        'log_path': dialog.fit.log_path,
+                    })
+                self._invalidate_viewer_caches()
+                self._resolve_sun()
+                self._update_sun_label()
+                self._on_params_changed()
+        except Exception as e:
+            LoggerService().error(f"PersonReferenceDialog: flight-log attach failed - {e}")
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -674,6 +790,7 @@ class PersonReferenceDialog(TranslationMixin, QDialog):
     def _update_sun_label(self):
         """Refresh the sun-info line and enable/disable the shadow toggle."""
         self.adjust_clock_button.setVisible(self._is_waldo_image())
+        self.flight_log_button.setVisible(self._is_waldo_image())
         self.trace_shadow_button.setEnabled(
             self.camera is not None and self.drone_lat is not None
             and self._capture_utc is not None)

--- a/app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py
+++ b/app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py
@@ -1,0 +1,363 @@
+"""
+WaldoFlightLogDialog - Calibrate and apply a ForeFlight track log's attitude.
+
+Two-phase modal mirroring WaldoClockCorrectionDialog:
+
+1. Calibration (worker thread): reads per-image metadata, then fits each
+   candidate CSV's clock offset against the image GPS positions and the
+   attitude channel's lag against coordinated-turn physics. The first
+   candidate whose fit is accepted wins; a bad fit means "wrong log for
+   this folder" and is skipped.
+2. Confirmation + apply (worker thread): shows the fit statistics for the
+   operator to sanity-check, then stamps per-image camera attitude and the
+   refined capture time. In auto mode (remembered acceptance) the
+   confirmation page is skipped and a silent re-apply runs with progress.
+"""
+
+from typing import List, Optional, Tuple
+
+from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QProgressBar, QPlainTextEdit, QCheckBox
+)
+
+from helpers.TranslationMixin import TranslationMixin
+
+from core.services.waldo import WaldoMetadataService, WaldoProcessResult
+from core.services.waldo.WaldoFlightLog import (
+    FlightLogFit,
+    FlightLogTrack,
+    WaldoFlightLogService,
+)
+
+
+class _CalibrateWorker(QThread):
+    progress = Signal(int, int, str)
+    finished_with_result = Signal(object)  # (fit|None, track|None, records, fail_reason)
+
+    def __init__(self, metadata_service: WaldoMetadataService,
+                 flight_service: WaldoFlightLogService,
+                 image_paths: List[str], candidate_logs: List[str]):
+        super().__init__()
+        self._metadata_service = metadata_service
+        self._flight_service = flight_service
+        self._image_paths = image_paths
+        self._candidate_logs = candidate_logs
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def run(self):
+        try:
+            records, cancelled = self._metadata_service.collect_flight_log_records(
+                self._image_paths,
+                progress_cb=lambda i, n, name: self.progress.emit(i, n, name),
+                cancel_cb=lambda: self._cancelled,
+            )
+            if cancelled:
+                self.finished_with_result.emit((None, None, [], "cancelled"))
+                return
+            images = [(r.capture_epoch, r.lat, r.lon) for r in records
+                      if r.error is None and r.capture_epoch is not None and r.lat is not None]
+            if not images:
+                self.finished_with_result.emit(
+                    (None, None, records, self.tr("No images with resolvable GPS + capture time.")))
+                return
+            reason = self.tr("No ForeFlight track log found for this folder.")
+            for log_path in self._candidate_logs:
+                if self._cancelled:
+                    self.finished_with_result.emit((None, None, records, "cancelled"))
+                    return
+                self.progress.emit(0, 0, self.tr("Calibrating {name}...").format(
+                    name=log_path.rsplit('\\', 1)[-1].rsplit('/', 1)[-1]))
+                fit = self._flight_service.calibrate(log_path, images)
+                if fit.accepted:
+                    track = self._flight_service.parse(log_path)
+                    self.finished_with_result.emit((fit, track, records, None))
+                    return
+                reason = fit.reason
+            self.finished_with_result.emit((None, None, records, reason))
+        except Exception as e:
+            self.finished_with_result.emit((None, None, [], f"{e!r}"))
+
+
+class _ApplyWorker(QThread):
+    progress = Signal(int, int, str)
+    finished_with_result = Signal(object)
+
+    def __init__(self, metadata_service: WaldoMetadataService, records,
+                 fit: FlightLogFit, track: FlightLogTrack):
+        super().__init__()
+        self._metadata_service = metadata_service
+        self._records = records
+        self._fit = fit
+        self._track = track
+        self._cancelled = False
+
+    def cancel(self):
+        self._cancelled = True
+
+    def run(self):
+        try:
+            result = self._metadata_service.apply_flight_log_attitude(
+                self._records, self._fit, self._track,
+                progress_cb=lambda i, n, name: self.progress.emit(i, n, name),
+                cancel_cb=lambda: self._cancelled,
+            )
+        except Exception as e:
+            result = WaldoProcessResult()
+            result.errors.append(("<service>", f"{e!r}"))
+        self.finished_with_result.emit(result)
+
+
+class WaldoFlightLogDialog(TranslationMixin, QDialog):
+    """Calibration + confirmation + progress dialog for the flight-log stage."""
+
+    def __init__(self, parent, metadata_service: WaldoMetadataService,
+                 flight_service: WaldoFlightLogService,
+                 image_paths: List[str], candidate_logs: List[str],
+                 auto_apply: bool = False):
+        from PySide6.QtWidgets import QWidget
+        if parent is not None and not isinstance(parent, QWidget):
+            parent = None
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("WALDO Flight Track Log"))
+        self.setModal(True)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
+        self.resize(600, 400)
+
+        self._metadata_service = metadata_service
+        self._flight_service = flight_service
+        self._image_paths = image_paths
+        self._candidate_logs = candidate_logs
+        self._auto_apply = auto_apply
+        self._worker: Optional[QThread] = None
+        self._records = []
+        self._track: Optional[FlightLogTrack] = None
+        self._result: WaldoProcessResult = WaldoProcessResult()
+
+        # Outcome flags the caller reads after exec():
+        self.applied = False
+        self.declined = False
+        self.remember_choice = False
+        self.fit: Optional[FlightLogFit] = None
+
+        layout = QVBoxLayout(self)
+
+        self._intro_label = QLabel(self.tr(
+            "An aircraft track log can supply the true per-image camera "
+            "attitude (bank and pitch) and a GPS-accurate capture time, "
+            "making image footprints and AOI positions substantially more "
+            "accurate."))
+        self._intro_label.setWordWrap(True)
+        layout.addWidget(self._intro_label)
+
+        self._stats_label = QLabel()
+        self._stats_label.setWordWrap(True)
+        self._stats_label.setVisible(False)
+        layout.addWidget(self._stats_label)
+
+        self._remember_check = QCheckBox(self.tr("Remember my choice for this folder"))
+        self._remember_check.setChecked(True)
+        self._remember_check.setVisible(False)
+        layout.addWidget(self._remember_check)
+
+        self._progress = QProgressBar()
+        self._progress.setRange(0, 0)
+        layout.addWidget(self._progress)
+
+        self._status_label = QLabel(self.tr("Reading image metadata..."))
+        self._status_label.setWordWrap(True)
+        layout.addWidget(self._status_label)
+
+        self._summary = QPlainTextEdit()
+        self._summary.setReadOnly(True)
+        self._summary.setVisible(False)
+        layout.addWidget(self._summary, 1)
+
+        button_row = QHBoxLayout()
+        button_row.addStretch()
+        self._apply_button = QPushButton(self.tr("Apply Flight Log"))
+        self._apply_button.clicked.connect(self._on_apply)
+        self._apply_button.setVisible(False)
+        button_row.addWidget(self._apply_button)
+        self._decline_button = QPushButton(self.tr("Not Now"))
+        self._decline_button.clicked.connect(self._on_decline)
+        self._decline_button.setVisible(False)
+        button_row.addWidget(self._decline_button)
+        self._cancel_button = QPushButton(self.tr("Cancel"))
+        self._cancel_button.clicked.connect(self._on_cancel)
+        button_row.addWidget(self._cancel_button)
+        self._ok_button = QPushButton(self.tr("OK"))
+        self._ok_button.clicked.connect(self.accept)
+        self._ok_button.setVisible(False)
+        button_row.addWidget(self._ok_button)
+        layout.addLayout(button_row)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self.activateWindow()
+        self.raise_()
+        if self._worker is None:
+            self._start_calibration()
+
+    def closeEvent(self, event):
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.cancel()
+            self._worker.wait(2000)
+        super().closeEvent(event)
+
+    @property
+    def result_data(self) -> WaldoProcessResult:
+        return self._result
+
+    # ------------------------------------------------------------------
+    # Calibration phase
+    # ------------------------------------------------------------------
+
+    def _start_calibration(self):
+        self._worker = _CalibrateWorker(
+            self._metadata_service, self._flight_service,
+            self._image_paths, self._candidate_logs)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished_with_result.connect(self._on_calibrated)
+        self._worker.start()
+
+    def _on_calibrated(self, payload: Tuple):
+        fit, track, records, fail_reason = payload
+        self._records = records
+        self._track = track
+        self.fit = fit
+
+        if fit is None:
+            if fail_reason == "cancelled" or self._auto_apply:
+                # Silent for auto mode: a remembered log that stops fitting
+                # (file moved, folder re-tasked) must not nag on every open.
+                self.reject()
+                return
+            self._progress.setVisible(False)
+            self._status_label.setText(self.tr(
+                "The track log does not match these images: {reason}").format(
+                    reason=fail_reason))
+            self._cancel_button.setVisible(False)
+            self._ok_button.setVisible(True)
+            return
+
+        if self._auto_apply:
+            self._start_apply()
+            return
+
+        offset = fit.clock_offset_s
+        clock_line = self.tr(
+            "Camera clock is {n:.1f} s {direction} of GPS time").format(
+                n=abs(offset), direction=self.tr("ahead") if offset < 0 else self.tr("behind"))
+        lines = [
+            self.tr("Track log: {name}").format(name=fit.log_path),
+            clock_line,
+            self.tr("Images sit {d:.0f} m from the flight track on average "
+                    "({p:.0%} matched)").format(d=fit.mean_track_dist_m,
+                                                p=fit.matched_fraction),
+        ]
+        if fit.attitude_reliable:
+            lines.append(self.tr(
+                "Attitude channel verified against turn physics "
+                "(correlation {c:.2f}, recorded {lag:+.0f} s late)").format(
+                    c=fit.lag_correlation, lag=fit.attitude_lag_s))
+            lines.append(self.tr(
+                "Bank during capture: {lo:+.1f}° to {hi:+.1f}°").format(
+                    lo=fit.bank_min_deg, hi=fit.bank_max_deg))
+        else:
+            lines.append(self.tr(
+                "Attitude channel is NOT reliable (correlation {c:.2f}) - "
+                "only the capture-time refinement will be stamped").format(
+                    c=fit.lag_correlation))
+        self._stats_label.setText("\n".join(f"• {line}" for line in lines))
+        self._stats_label.setVisible(True)
+        self._remember_check.setVisible(True)
+        self._progress.setVisible(False)
+        self._status_label.setVisible(False)
+        self._apply_button.setVisible(True)
+        self._apply_button.setDefault(True)
+        self._decline_button.setVisible(True)
+        self._cancel_button.setVisible(False)
+
+    # ------------------------------------------------------------------
+    # Apply phase
+    # ------------------------------------------------------------------
+
+    def _on_apply(self):
+        self.remember_choice = self._remember_check.isChecked()
+        self._start_apply()
+
+    def _start_apply(self):
+        for w in (self._intro_label, self._stats_label, self._remember_check,
+                  self._apply_button, self._decline_button):
+            w.setVisible(False)
+        self._progress.setRange(0, max(1, len(self._records)))
+        self._progress.setValue(0)
+        self._progress.setVisible(True)
+        self._status_label.setText(self.tr("Stamping flight-log attitude..."))
+        self._status_label.setVisible(True)
+        self._cancel_button.setVisible(True)
+
+        self._worker = _ApplyWorker(
+            self._metadata_service, self._records, self.fit, self._track)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.finished_with_result.connect(self._on_finished)
+        self._worker.start()
+
+    def _on_decline(self):
+        self.declined = True
+        self.remember_choice = self._remember_check.isChecked()
+        self.reject()
+
+    def _on_cancel(self):
+        if self._worker is not None:
+            self._worker.cancel()
+        self._cancel_button.setEnabled(False)
+        self._cancel_button.setText(self.tr("Cancelling..."))
+
+    def _on_progress(self, current: int, total: int, status_text: str):
+        if total > 0:
+            if self._progress.maximum() != total:
+                self._progress.setRange(0, total)
+            self._progress.setValue(current)
+        elif self._progress.maximum() != 0:
+            self._progress.setRange(0, 0)
+        self._status_label.setText(status_text)
+
+    def _on_finished(self, result: WaldoProcessResult):
+        self._result = result
+        self.applied = not result.cancelled
+        if self._auto_apply:
+            # Silent re-apply: no summary page, just finish.
+            self.accept()
+            return
+        self._status_label.setVisible(False)
+        self._progress.setRange(0, max(1, self._progress.value() or 1))
+        self._progress.setValue(self._progress.maximum())
+
+        lines = []
+        lines.append(self.tr("Stamped:          {n}").format(n=result.processed))
+        lines.append(self.tr("Already current:  {n}").format(n=result.already_current))
+        lines.append(self.tr("Errors:           {n}").format(n=len(result.errors)))
+        for note in result.notes:
+            lines.append("")
+            lines.append(note)
+        if result.cancelled:
+            lines.append("")
+            lines.append(self.tr("Cancelled - remaining images are unstamped."))
+        for name, msg in result.errors[:20]:
+            lines.append(f"  {name}: {msg}")
+        self._summary.setPlainText("\n".join(lines))
+        self._summary.setVisible(True)
+        self._cancel_button.setVisible(False)
+        self._ok_button.setVisible(True)
+        self._ok_button.setDefault(True)
+        self._ok_button.setFocus()

--- a/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
+++ b/app/tests/core/controllers/images/viewer/test_waldo_pre_pass_controller.py
@@ -170,3 +170,116 @@ def test_no_proposal_and_healthy_stamp_stays_quiet(monkeypatch, tmp_path):
     controller._offer_clock_correction(
         [str(tmp_path / "0_a.jpg")], None, service=service)
     assert _FakeDialog.instances == []
+
+
+# --------------------------------------------------------------------------
+# Flight-log offer
+# --------------------------------------------------------------------------
+
+from core.services.waldo.WaldoFlightLog import FlightLogFit  # noqa: E402
+from core.services.waldo.WaldoFlightLogDecisions import (  # noqa: E402
+    FLIGHTLOG_DECISIONS_SETTING,
+)
+
+
+class _FakeFlightDialog:
+    """Stands in for WaldoFlightLogDialog; scripted outcome."""
+
+    instances = []
+    script = {}
+
+    def __init__(self, parent, service, flight_service, image_paths,
+                 candidate_logs, auto_apply=False):
+        self.image_paths = image_paths
+        self.candidate_logs = candidate_logs
+        self.auto_apply = auto_apply
+        self.applied = self.script.get('applied', False)
+        self.declined = self.script.get('declined', False)
+        self.remember_choice = self.script.get('remember', False)
+        self.fit = self.script.get('fit', None)
+        self.result_data = WaldoProcessResult()
+        _FakeFlightDialog.instances.append(self)
+
+    def exec(self):
+        return None
+
+
+def _accepted_fit(log_path="E:/logs/tracklog.csv"):
+    return FlightLogFit(log_path=log_path, log_sha256="ab" * 32, accepted=True,
+                        clock_offset_s=-17.0, mean_track_dist_m=15.0,
+                        matched_fraction=1.0, attitude_reliable=True,
+                        attitude_lag_s=4.0, lag_correlation=0.95)
+
+
+def _make_flight_controller(monkeypatch, candidates):
+    controller = _make_controller(monkeypatch)
+    monkeypatch.setattr(controller_module, 'WaldoFlightLogDialog', _FakeFlightDialog)
+    monkeypatch.setattr(controller_module.WaldoFlightLogService, 'candidate_files',
+                        staticmethod(lambda image_dir: list(candidates)))
+    _FakeFlightDialog.instances = []
+    _FakeFlightDialog.script = {}
+    return controller
+
+
+def test_flight_log_no_candidates_stays_quiet(monkeypatch, tmp_path):
+    controller = _make_flight_controller(monkeypatch, candidates=[])
+    controller._offer_flight_log([str(tmp_path / "0_a.jpg")], service=_StubService())
+    assert _FakeFlightDialog.instances == []
+
+
+def test_flight_log_accept_with_remember_persists_log_path(monkeypatch, tmp_path):
+    log = tmp_path / "tracklog.csv"
+    controller = _make_flight_controller(monkeypatch, candidates=[str(log)])
+    _FakeFlightDialog.script = {'applied': True, 'remember': True,
+                                'fit': _accepted_fit(str(log))}
+    controller._offer_flight_log([str(tmp_path / "0_a.jpg")], service=_StubService())
+    assert len(_FakeFlightDialog.instances) == 1
+    assert _FakeFlightDialog.instances[0].auto_apply is False
+    stored = json.loads(controller.settings_service.values[FLIGHTLOG_DECISIONS_SETTING])
+    decision = next(iter(stored.values()))
+    assert decision == {'decision': 'accepted', 'log_path': str(log)}
+
+
+def test_flight_log_declined_with_remember_suppresses_future_offers(monkeypatch, tmp_path):
+    log = tmp_path / "tracklog.csv"
+    controller = _make_flight_controller(monkeypatch, candidates=[str(log)])
+    _FakeFlightDialog.script = {'declined': True, 'remember': True}
+    paths = [str(tmp_path / "0_a.jpg")]
+    controller._offer_flight_log(paths, service=_StubService())
+    assert len(_FakeFlightDialog.instances) == 1
+
+    controller._offer_flight_log(paths, service=_StubService())
+    assert len(_FakeFlightDialog.instances) == 1
+
+
+def test_flight_log_remembered_acceptance_runs_auto_with_stored_path(monkeypatch, tmp_path):
+    log = tmp_path / "tracklog.csv"
+    log.write_text("Pilot,Tail Number\n", encoding="utf-8")
+    controller = _make_flight_controller(monkeypatch, candidates=[])
+    import os
+    folder_key = os.path.normcase(os.path.abspath(str(tmp_path)))
+    controller.settings_service.values[FLIGHTLOG_DECISIONS_SETTING] = json.dumps({
+        folder_key: {'decision': 'accepted', 'log_path': str(log)}})
+    _FakeFlightDialog.script = {'applied': True, 'remember': False,
+                                'fit': _accepted_fit(str(log))}
+    controller._offer_flight_log([str(tmp_path / "0_a.jpg")], service=_StubService())
+    assert len(_FakeFlightDialog.instances) == 1
+    dlg = _FakeFlightDialog.instances[0]
+    assert dlg.auto_apply is True
+    assert dlg.candidate_logs == [str(log)]
+
+
+def test_flight_log_missing_remembered_file_falls_back_to_discovery(monkeypatch, tmp_path):
+    fresh = tmp_path / "tracklog-2.csv"
+    controller = _make_flight_controller(monkeypatch, candidates=[str(fresh)])
+    import os
+    folder_key = os.path.normcase(os.path.abspath(str(tmp_path)))
+    controller.settings_service.values[FLIGHTLOG_DECISIONS_SETTING] = json.dumps({
+        folder_key: {'decision': 'accepted', 'log_path': str(tmp_path / 'gone.csv')}})
+    _FakeFlightDialog.script = {'applied': False}
+    controller._offer_flight_log([str(tmp_path / "0_a.jpg")], service=_StubService())
+    assert len(_FakeFlightDialog.instances) == 1
+    dlg = _FakeFlightDialog.instances[0]
+    # The remembered file is gone: not auto mode, discovery candidates offered.
+    assert dlg.auto_apply is False
+    assert dlg.candidate_logs == [str(fresh)]

--- a/app/tests/core/services/image/test_coverage_extent_service.py
+++ b/app/tests/core/services/image/test_coverage_extent_service.py
@@ -86,7 +86,8 @@ class _FakeImageService:
     """Configurable stand-in for ImageService in the FOV polygon path."""
 
     def __init__(self, terrain_gsd_cm=None, terrain_agl_m=None, flat_gsd_cm=4.0,
-                 roll_deg=0.0, reported_agl_m=100.0, yaw_deg=0.0):
+                 roll_deg=0.0, reported_agl_m=100.0, yaw_deg=0.0,
+                 pitch_deg=-90.0, waldo_version=None, roll_axis_deg=None):
         import math as _math
         self._math = _math
         self.terrain_gsd_cm = terrain_gsd_cm
@@ -95,18 +96,27 @@ class _FakeImageService:
         self.roll_deg = roll_deg
         self.reported_agl_m = reported_agl_m
         self.yaw_deg = yaw_deg
+        self.pitch_deg = pitch_deg
+        self.waldo_version = waldo_version
+        self.roll_axis_deg = roll_axis_deg
         self.img_array = MagicMock(shape=(3000, 4000))
         self.compute_calls = []
         self.average_calls = []
 
     def get_camera_pitch(self):
-        return -90.0
+        return self.pitch_deg
 
     def get_gimbal_roll(self):
         return self.roll_deg
 
     def get_camera_yaw(self):
         return self.yaw_deg
+
+    def get_waldo_processor_version(self):
+        return self.waldo_version
+
+    def get_roll_axis_azimuth(self):
+        return self.roll_axis_deg
 
     def get_relative_altitude(self, unit):
         assert unit == 'm'
@@ -149,6 +159,14 @@ def _span_east_m(corners):
     import math
     lons = [lon for _lat, lon in corners]
     return (max(lons) - min(lons)) * _EARTH_RADIUS * math.cos(math.radians(_LAT)) * math.pi / 180.0
+
+
+def _centroid_north_m(corners):
+    """Mean north-offset of the corners from the drone position, in meters."""
+    import math
+    lats = [lat for lat, _lon in corners]
+    mean_dlat = sum(lats) / len(lats) - _LAT
+    return mean_dlat * _EARTH_RADIUS * math.pi / 180.0
 
 
 def test_fov_polygon_uses_terrain_gsd_and_agl():
@@ -275,3 +293,73 @@ def test_fov_polygon_legacy_camera_axis_roll_unchanged():
     expected_east = offset_m * math.sin(math.radians(((heading + 180.0) % 360.0) + 90.0))
     assert expected_east < 0  # sanity: SW means east-negative
     assert _centroid_east_m(corners) == pytest.approx(expected_east, rel=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Composite off-nadir gate (WALDO flight-log attitude)
+# ---------------------------------------------------------------------------
+
+def test_gate_dji_oblique_still_skipped_and_nadir_still_passes():
+    """Non-WALDO images keep the historical pitch gate, unchanged."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    service = CoverageExtentService(use_terrain=False)
+    oblique = _FakeImageService(pitch_deg=-60.0)
+    assert _fov_corners_with(service, oblique) is None
+    nadir = _FakeImageService(pitch_deg=-89.0)
+    assert _fov_corners_with(service, nadir) is not None
+
+
+def test_gate_waldo_constants_pass_as_before():
+    """WALDO without a flight log: (-90, ±22.5) is 22.5° off nadir - inside."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    service = CoverageExtentService(use_terrain=False)
+    fake = _FakeImageService(waldo_version="9", roll_deg=22.5, roll_axis_deg=0.0)
+    assert _fov_corners_with(service, fake) is not None
+
+
+def test_gate_waldo_composed_attitude_inside_threshold_passes():
+    """Flight-log attitude: pitch -92 with roll -35 is ~35° off nadir - inside."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    service = CoverageExtentService(use_terrain=False)
+    fake = _FakeImageService(waldo_version="9", pitch_deg=-92.0, roll_deg=-35.0,
+                             roll_axis_deg=0.0)
+    assert _fov_corners_with(service, fake) is not None
+
+
+def test_gate_waldo_steep_bank_skipped():
+    """A banked turn frame past the composite threshold drops out of coverage."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    service = CoverageExtentService(use_terrain=False)
+    fake = _FakeImageService(waldo_version="9", roll_deg=45.0, roll_axis_deg=0.0)
+    assert _fov_corners_with(service, fake) is None
+
+
+def test_waldo_pitch_shifts_footprint_along_image_top_azimuth():
+    """WALDO pitch off -90 adds an along-azimuth h*tan(pitch+90) offset."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    import math
+    fake = _FakeImageService(waldo_version="9", pitch_deg=-95.0, roll_deg=0.0,
+                             yaw_deg=0.0, flat_gsd_cm=4.0, reported_agl_m=100.0)
+    service = CoverageExtentService(use_terrain=False)
+    corners = _fov_corners_with(service, fake)
+    assert corners is not None
+    # pitch+90 = -5°: shifted AWAY from the yaw azimuth (south of the drone).
+    expected_north = 100.0 * math.tan(math.radians(-5.0))
+    assert _centroid_north_m(corners) == pytest.approx(expected_north, rel=0.02)
+
+
+def test_dji_pitch_gets_no_footprint_shift():
+    """Non-WALDO: a -89 pitch keeps the historical footprint center."""
+    if not _SHAPELY_AVAILABLE:
+        pytest.skip(f"Shapely not available: {_SHAPELY_IMPORT_ERROR}")
+    fake = _FakeImageService(pitch_deg=-89.0, roll_deg=0.0, yaw_deg=0.0,
+                             flat_gsd_cm=4.0, reported_agl_m=100.0)
+    service = CoverageExtentService(use_terrain=False)
+    corners = _fov_corners_with(service, fake)
+    assert corners is not None
+    assert _centroid_north_m(corners) == pytest.approx(0.0, abs=0.01)

--- a/app/tests/core/services/image/test_image_service.py
+++ b/app/tests/core/services/image/test_image_service.py
@@ -112,6 +112,38 @@ def test_get_asl_altitude(image_service):
     assert altitude_ft is None or isinstance(altitude_ft, (int, float))
 
 
+def _asl_service(xmp_data, gps_alt_m=1500.0, make=b'Canon'):
+    """ImageService with injected metadata for the ASL preference tests."""
+    exif = {'0th': {piexif.ImageIFD.Make: make},
+            'GPS': {piexif.GPSIFD.GPSAltitude: (int(gps_alt_m * 100), 100),
+                    piexif.GPSIFD.GPSAltitudeRef: 0}}
+    return ImageService(
+        "dummy.jpg",
+        img_array=np.zeros((10, 10, 3), dtype=np.uint8),
+        exif_data=exif, xmp_data=xmp_data)
+
+
+def test_get_asl_altitude_waldo_prefers_stamped_orthometric():
+    """WALDO images use the pre-pass's orthometric AbsoluteAltitude, not the
+    (ellipsoidal) EXIF GPSAltitude - a geoid-magnitude difference."""
+    svc = _asl_service({'waldo:ProcessorVersion': '9',
+                        'drone-dji:AbsoluteAltitude': '+1470.2500'})
+    assert svc.get_asl_altitude('m') == pytest.approx(1470.25)
+    assert svc.get_asl_altitude('ft') == pytest.approx(1470.25 * 3.28084, abs=0.01)
+
+
+def test_get_asl_altitude_waldo_without_stamp_falls_back_to_exif():
+    svc = _asl_service({'waldo:ProcessorVersion': '9'})
+    assert svc.get_asl_altitude('m') == pytest.approx(1500.0)
+
+
+def test_get_asl_altitude_non_waldo_unchanged():
+    """DJI images keep reading EXIF GPSAltitude even when AbsoluteAltitude
+    exists in XMP (DJI's own field; historical behaviour preserved)."""
+    svc = _asl_service({'drone-dji:AbsoluteAltitude': '+1470.2500'}, make=b'DJI')
+    assert svc.get_asl_altitude('m') == pytest.approx(1500.0)
+
+
 def test_get_camera_pitch(image_service):
     """Test getting camera pitch angle."""
     pitch = image_service.get_camera_pitch()

--- a/app/tests/core/services/shadow/test_solar_position.py
+++ b/app/tests/core/services/shadow/test_solar_position.py
@@ -69,6 +69,35 @@ def test_resolve_utc_bad_corrected_value_falls_through():
     assert utc == datetime(2025, 6, 15, 19, 30, 0, tzinfo=timezone.utc)
 
 
+@pytest.mark.parametrize("key", [
+    'CaptureUtcRefined',
+    'waldo:CaptureUtcRefined',
+    'XMP-waldo:CaptureUtcRefined',
+])
+def test_resolve_utc_prefers_refined_over_corrected(key):
+    # The track-log refinement is seconds-accurate GPS-true time computed ON
+    # TOP of the operator's hour/zone repair - it must outrank it.
+    exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (0, 1)))
+    xmp = {
+        'CaptureUtcCorrected': '2026-07-23T13:49:37+00:00',
+        key: '2026-07-23T13:49:20+00:00',
+    }
+    utc, source = resolve_capture_utc(exif, xmp)
+    assert source == 'waldo_refined'
+    assert utc == datetime(2026, 7, 23, 13, 49, 20, tzinfo=timezone.utc)
+
+
+def test_resolve_utc_bad_refined_value_falls_to_corrected():
+    exif = _make_gps_exif(b'2025:06:15', ((19, 1), (30, 1), (0, 1)))
+    xmp = {
+        'CaptureUtcRefined': 'not-a-timestamp',
+        'CaptureUtcCorrected': '2026-07-23T13:49:37+00:00',
+    }
+    utc, source = resolve_capture_utc(exif, xmp)
+    assert source == 'waldo_corrected'
+    assert utc == datetime(2026, 7, 23, 13, 49, 37, tzinfo=timezone.utc)
+
+
 def test_timezone_name_for_position_returns_zone_or_none():
     name = solar_mod.timezone_name_for_position(_TX_LAT, _TX_LON)
     assert name in ('America/Chicago', None)  # None only if tzfinder missing

--- a/app/tests/core/services/waldo/test_waldo_clock_correction.py
+++ b/app/tests/core/services/waldo/test_waldo_clock_correction.py
@@ -206,6 +206,30 @@ def test_apply_is_idempotent(tmp_path, monkeypatch):
     assert calls == []
 
 
+def test_apply_stays_idempotent_with_refined_stamp_present(tmp_path, monkeypatch):
+    # The flight-log stage writes waldo:CaptureUtcRefined ALONGSIDE the
+    # corrected stamp. The remembered clock auto-apply must keep seeing its
+    # own stamp as current, or every folder open would rewrite every image
+    # and clobber the refinement (the two-rewrite loop).
+    path = _make_image(tmp_path)
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_exif_data_piexif',
+                        staticmethod(lambda p: _fault_exif()))
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'get_xmp_data_merged',
+                        staticmethod(lambda p: {
+                            'waldo:CaptureUtcCorrected': '2026-07-23T13:49:37+00:00',
+                            'waldo:CaptureUtcRefined': '2026-07-23T13:49:20+00:00',
+                        }))
+    calls = []
+    monkeypatch.setattr(waldo_module.MetaDataHelper, 'add_xmp_fields',
+                        staticmethod(lambda p, fields: calls.append(p)))
+
+    svc = WaldoMetadataService(terrain_service=None)
+    assert svc.get_corrected_utc_stamp(path) == '2026-07-23T13:49:37+00:00'
+    result = svc.apply_clock_correction([path], -12, tz_name="America/Los_Angeles")
+    assert result.already_current == 1 and result.processed == 0
+    assert calls == []
+
+
 def test_apply_skips_non_waldo_and_reports_missing_exif(tmp_path, monkeypatch):
     waldo = _make_image(tmp_path, name="0_000_02_035.jpg")
     other = _make_image(tmp_path, name="DJI_0001.jpg")

--- a/app/tests/core/services/waldo/test_waldo_flight_log.py
+++ b/app/tests/core/services/waldo/test_waldo_flight_log.py
@@ -1,0 +1,281 @@
+"""Unit tests for WaldoFlightLogService (ForeFlight track-log calibration)."""
+
+import math
+
+from core.services.waldo.WaldoFlightLog import (
+    CLOCK_FIT_MAX_MEAN_DIST_M,
+    FEET_TO_M,
+    KNOTS_TO_MPS,
+    LAG_MIN_CORRELATION,
+    FlightLogTrack,
+    WaldoFlightLogService,
+    _lerp_angle,
+)
+
+
+# --------------------------------------------------------------------------
+# CSV synthesis helpers
+# --------------------------------------------------------------------------
+
+SUMMARY_ROWS = (
+    "Pilot,Tail Number,Derived Origin,Start Latitude,Start Longitude,"
+    "Derived Destination,End Latitude,End Longitude,Start Time,End Time\n"
+    '"","N183CP","KBIH",37.0,-118.0,"KOAK",37.7,-122.2,1700000000000,1700000300000\n'
+)
+
+POINT_HEADER = (
+    "Timestamp,Latitude,Longitude,Altitude,Course,Speed,Bank,Pitch,"
+    "Horizontal Error,Vertical Error\n"
+)
+
+
+def _point_row(t, lat, lon, alt_ft=5000.0, course=0.0, speed_kt=97.2,
+               bank=0.0, pitch=1.5, fmt="{:.6f}"):
+    ts = fmt.format(t) if isinstance(fmt, str) else fmt(t)
+    return f"{ts},{lat:.8f},{lon:.8f},{alt_ft:.1f},{course:.4f},{speed_kt:.4f},{bank:.4f},{pitch:.4f},1.0,1.5\n"
+
+
+def _write_log(path, point_rows, summary=SUMMARY_ROWS, header=POINT_HEADER):
+    path.write_text(summary + header + "".join(point_rows), encoding="utf-8")
+    return str(path)
+
+
+# Northbound line at ~50 m/s starting (37.0, -118.0) at epoch T0.
+T0 = 1_700_000_000.0
+LAT_PER_S = 50.0 / 111_320.0
+
+
+def _line_lat(t):
+    return 37.0 + (t - T0) * LAT_PER_S
+
+
+def _line_rows(duration_s, **kwargs):
+    return [_point_row(T0 + k, _line_lat(T0 + k), -118.0, **kwargs)
+            for k in range(int(duration_s) + 1)]
+
+
+# --------------------------------------------------------------------------
+# sniff + candidate discovery
+# --------------------------------------------------------------------------
+
+def test_sniff_accepts_foreflight_and_rejects_others(tmp_path):
+    good = tmp_path / "tracklog.csv"
+    good.write_text(SUMMARY_ROWS, encoding="utf-8")
+    bad = tmp_path / "other.csv"
+    bad.write_text("Timestamp,Latitude\n1,2\n", encoding="utf-8")
+    assert WaldoFlightLogService.sniff(str(good)) is True
+    assert WaldoFlightLogService.sniff(str(bad)) is False
+    assert WaldoFlightLogService.sniff(str(tmp_path / "missing.csv")) is False
+
+
+def test_candidate_files_searches_parents_and_filters(tmp_path):
+    images = tmp_path / "one" / "two" / "images"
+    images.mkdir(parents=True)
+    root_log = tmp_path / "tracklog-1.csv"
+    root_log.write_text(SUMMARY_ROWS, encoding="utf-8")
+    local_log = images / "tracklog-2.csv"
+    local_log.write_text(SUMMARY_ROWS, encoding="utf-8")
+    decoy = images / "notes.csv"
+    decoy.write_text("just,a,csv\n", encoding="utf-8")
+
+    found = WaldoFlightLogService.candidate_files(str(images))
+    assert str(local_log) in found
+    assert str(root_log) in found
+    assert str(decoy) not in found
+
+
+# --------------------------------------------------------------------------
+# parse
+# --------------------------------------------------------------------------
+
+def test_parse_units_conversions_and_tolerance(tmp_path):
+    rows = [
+        # scientific-notation timestamp like real exports
+        _point_row(T0, 37.0, -118.0, alt_ft=1000.0, course=90.0, speed_kt=100.0,
+                   bank=5.0, pitch=2.0, fmt=lambda t: f"{t:.10E}"),
+        _point_row(T0 + 1, 37.0001, -118.0, course=-1.0),      # invalid course
+        "garbage,row\n",                                        # malformed: skipped
+        _point_row(T0 + 0.5, 37.0, -118.0),                     # non-monotonic: skipped
+        _point_row(T0 + 2, 37.0002, -118.0),
+        "1.700000003E9,37.0003,-118.0,5000.0,0.0",              # truncated tail: skipped
+    ]
+    svc = WaldoFlightLogService()
+    track = svc.parse(_write_log(tmp_path / "log.csv", rows))
+    assert track is not None
+    assert len(track) == 3
+    assert track.t == [T0, T0 + 1, T0 + 2]
+    assert math.isclose(track.alt_m[0], 1000.0 * FEET_TO_M)
+    assert math.isclose(track.speed_mps[0], 100.0 * KNOTS_TO_MPS)
+    assert track.course[0] == 90.0
+    assert track.course[1] is None
+    assert track.bank[0] == 5.0
+    assert track.pitch[0] == 2.0
+
+
+def test_parse_rejects_non_foreflight_and_tiny_logs(tmp_path):
+    svc = WaldoFlightLogService()
+    not_ff = tmp_path / "plain.csv"
+    not_ff.write_text(POINT_HEADER + _point_row(T0, 37.0, -118.0), encoding="utf-8")
+    assert svc.parse(str(not_ff)) is None
+    tiny = _write_log(tmp_path / "tiny.csv", [_point_row(T0, 37.0, -118.0)])
+    assert svc.parse(tiny) is None
+
+
+# --------------------------------------------------------------------------
+# interpolation
+# --------------------------------------------------------------------------
+
+def test_interpolate_position_midpoint_bounds_and_gaps(tmp_path):
+    track = FlightLogTrack(path="x", t=[0.0, 1.0, 10.0], lat=[37.0, 37.001, 37.002],
+                           lon=[-118.0, -118.0, -118.0], alt_m=[0, 0, 0],
+                           course=[0.0, 0.0, 0.0], speed_mps=[50, 50, 50],
+                           bank=[0, 0, 0], pitch=[0, 0, 0])
+    lat, lon = WaldoFlightLogService.interpolate_position(track, 0.5)
+    assert math.isclose(lat, 37.0005)
+    assert WaldoFlightLogService.interpolate_position(track, -0.1) is None
+    assert WaldoFlightLogService.interpolate_position(track, 10.5) is None
+    # 9-second spacing exceeds MAX_INTERP_GAP_S
+    assert WaldoFlightLogService.interpolate_position(track, 5.0) is None
+
+
+def test_sample_attitude_lag_shift_and_circular_course():
+    track = FlightLogTrack(path="x", t=[float(k) for k in range(11)],
+                           lat=[37.0] * 11, lon=[-118.0] * 11, alt_m=[0] * 11,
+                           course=[350.0, 10.0] + [10.0] * 9,
+                           speed_mps=[50] * 11,
+                           bank=[float(k) for k in range(11)],
+                           pitch=[float(k) / 2 for k in range(11)])
+    s = WaldoFlightLogService.sample_attitude(track, 5.0, lag_s=2.0)
+    assert s.in_coverage
+    assert math.isclose(s.bank_deg, 7.0)
+    assert math.isclose(s.pitch_deg, 3.5)
+    # course read at t (not lagged), circularly across north
+    s0 = WaldoFlightLogService.sample_attitude(track, 0.5, lag_s=0.0)
+    assert math.isclose(s0.course_deg, 0.0, abs_tol=1e-9)
+    # outside coverage after lag shift
+    far = WaldoFlightLogService.sample_attitude(track, 10.5, lag_s=2.0)
+    assert far.in_coverage is False
+    assert far.bank_deg is None
+
+
+def test_lerp_angle_wraps():
+    assert math.isclose(_lerp_angle(350.0, 10.0, 0.5), 0.0, abs_tol=1e-9)
+    assert math.isclose(_lerp_angle(10.0, 350.0, 0.25), 5.0, abs_tol=1e-9)
+
+
+# --------------------------------------------------------------------------
+# clock-offset fit
+# --------------------------------------------------------------------------
+
+def test_fit_clock_offset_recovers_known_offset(tmp_path):
+    svc = WaldoFlightLogService()
+    track = svc.parse(_write_log(tmp_path / "log.csv", _line_rows(240)))
+    # Pod clock 17 s FAST: face time = true + 17, so the image taken at true
+    # time (t_face - 17) carries GPS from there; the fit must find -17.
+    images = []
+    for t_face in range(int(T0) + 40, int(T0) + 200, 10):
+        t_true = t_face - 17.0
+        images.append((float(t_face), _line_lat(t_true), -118.0))
+    offset, mean_dist, matched = svc.fit_clock_offset(track, images)
+    assert math.isclose(offset, -17.0, abs_tol=0.2)
+    assert mean_dist < 2.0
+    assert matched == 1.0
+
+
+def test_calibrate_rejects_wrong_area_log(tmp_path):
+    svc = WaldoFlightLogService()
+    log = _write_log(tmp_path / "log.csv", _line_rows(240))
+    images = [(T0 + 60.0 + k, 36.5, -117.5) for k in range(0, 100, 10)]  # ~70 km away
+    fit = svc.calibrate(log, images)
+    assert fit.accepted is False
+    assert "track" in fit.reason
+    assert fit.mean_track_dist_m > CLOCK_FIT_MAX_MEAN_DIST_M
+
+
+# --------------------------------------------------------------------------
+# attitude-lag fit
+# --------------------------------------------------------------------------
+
+def _turning_rows(lag_s):
+    """Straight flight, a coordinated right turn, straight again.
+
+    The bank profile is SMOOTH (the aircraft rolls in/out over 6 s) so the
+    correlation peak is unambiguous; a step profile would leave the discrete
+    peak straddling a half-sample. Course is the integral of the turn rate a
+    coordinated turn at that bank produces; the logged bank column reproduces
+    the true bank of (t - lag_s), i.e. the attitude channel is recorded late.
+    """
+    v = 97.2 * KNOTS_TO_MPS
+    max_bank = math.degrees(math.atan(v * math.radians(3.0) / 9.80665))  # ~15 deg
+
+    def bank_true(t):
+        s = t - T0
+        if s < 120.0 or s >= 180.0:
+            return 0.0
+        if s < 126.0:
+            return max_bank * (s - 120.0) / 6.0
+        if s >= 174.0:
+            return max_bank * (180.0 - s) / 6.0
+        return max_bank
+
+    rows = []
+    lat, lon = 37.0, -118.0
+    course = 0.0
+    substeps = 10  # fine integration so the logged course is not Euler-biased
+    for k in range(301):
+        t = T0 + k
+        c = math.radians(course)
+        lat += (v / 111_320.0) * math.cos(c)
+        lon += (v / (111_320.0 * math.cos(math.radians(lat)))) * math.sin(c)
+        rows.append(_point_row(t, lat, lon, course=course % 360.0,
+                               bank=bank_true(t - lag_s)))
+        for j in range(substeps):
+            omega = math.tan(math.radians(bank_true(t + (j + 0.5) / substeps))) * 9.80665 / v
+            course += math.degrees(omega) / substeps
+    return rows
+
+
+def test_fit_attitude_lag_recovers_known_lag(tmp_path):
+    svc = WaldoFlightLogService()
+    track = svc.parse(_write_log(tmp_path / "log.csv", _turning_rows(lag_s=4.0)))
+    lag, corr = svc.fit_attitude_lag(track, T0 + 20, T0 + 280)
+    assert lag == 4.0
+    assert corr > 0.9
+
+
+def test_calibrate_flags_flat_attitude_as_unreliable(tmp_path):
+    svc = WaldoFlightLogService()
+    # Real turns in the course channel but a dead-flat bank column: the
+    # correlation cannot reach the threshold, so attitude must be untrusted
+    # while the clock fit stays accepted.
+    rows = _turning_rows(lag_s=0.0)
+    rows = [r.rsplit(",", 4)[0] + ",0.0000,1.5000,1.0,1.5\n" for r in rows]
+    track_path = _write_log(tmp_path / "log.csv", rows)
+    svc_track = svc.parse(track_path)
+    images = []
+    for k in range(20, 280, 10):
+        pos = WaldoFlightLogService.interpolate_position(svc_track, T0 + k)
+        images.append((T0 + k, pos[0], pos[1]))
+    fit = svc.calibrate(track_path, images)
+    assert fit.accepted is True
+    assert math.isclose(fit.clock_offset_s, 0.0, abs_tol=0.2)
+    assert fit.attitude_reliable is False
+    assert fit.lag_correlation < LAG_MIN_CORRELATION
+
+
+def test_calibrate_full_pipeline_accepts_and_reports(tmp_path):
+    svc = WaldoFlightLogService()
+    log = _write_log(tmp_path / "log.csv", _turning_rows(lag_s=4.0))
+    track = svc.parse(log)
+    images = []
+    for k in range(20, 280, 10):
+        t_true = T0 + k
+        pos = WaldoFlightLogService.interpolate_position(track, t_true)
+        images.append((t_true + 17.0, pos[0], pos[1]))  # clock 17 s fast
+    fit = svc.calibrate(log, images)
+    assert fit.accepted is True
+    assert math.isclose(fit.clock_offset_s, -17.0, abs_tol=0.2)
+    assert fit.attitude_reliable is True
+    assert fit.attitude_lag_s == 4.0
+    assert fit.bank_max_deg > 10.0
+    assert fit.log_sha256 == WaldoFlightLogService.content_hash(log)

--- a/app/tests/core/services/waldo/test_waldo_flight_log_attitude.py
+++ b/app/tests/core/services/waldo/test_waldo_flight_log_attitude.py
@@ -1,0 +1,243 @@
+"""Tests for the flight-log attitude stage: composition, exact inversion, stamping."""
+
+import importlib
+import math
+
+import numpy as np
+import pytest
+
+from core.services.image.AOIService import AOIService
+from core.services.waldo.WaldoFlightLog import FlightLogFit, FlightLogTrack
+from core.services.waldo.WaldoMetadataService import (
+    ATTITUDE_SOURCE_CONSTANTS,
+    ATTITUDE_SOURCE_TRACKLOG,
+    FLIGHTLOG_MAX_ROLL_DEG,
+    FlightLogImageRecord,
+    OUTWARD_ROLL_DEG,
+    WaldoMetadataService,
+)
+
+waldo_module = importlib.import_module("core.services.waldo.WaldoMetadataService")
+
+
+# --------------------------------------------------------------------------
+# Composition + inversion round trips
+# --------------------------------------------------------------------------
+
+def test_invert_zero_attitude_reproduces_v9_constants():
+    svc = WaldoMetadataService
+    for cam_idx, level_roll in ((0, -OUTWARD_ROLL_DEG), (1, +OUTWARD_ROLL_DEG)):
+        level_yaw = (123.0 + 180.0 * (cam_idx == 0)) % 360.0
+        r_true = svc.compose_attitude_rotation(level_yaw, level_roll, 123.0, 0.0, 0.0)
+        pitch, yaw, roll = svc.invert_to_gimbal_angles(r_true, 123.0)
+        assert math.isclose(pitch, -90.0, abs_tol=1e-9)
+        assert math.isclose(yaw, level_yaw, abs_tol=1e-9)
+        assert math.isclose(roll, level_roll, abs_tol=1e-9)
+
+
+def test_compose_invert_round_trip_grid():
+    svc = WaldoMetadataService
+    for flight_yaw in (0.0, 87.3, 214.6):
+        for cam_idx, level_roll in ((0, -OUTWARD_ROLL_DEG), (1, +OUTWARD_ROLL_DEG)):
+            level_yaw = (flight_yaw + (180.0 if cam_idx == 0 else 0.0)) % 360.0
+            for bank in (-35.0, -6.2, 0.0, 4.9, 30.0):
+                for ac_pitch in (-9.5, 0.0, 7.8):
+                    r_true = svc.compose_attitude_rotation(
+                        level_yaw, level_roll, flight_yaw, ac_pitch, bank)
+                    pitch, yaw, roll = svc.invert_to_gimbal_angles(r_true, flight_yaw)
+                    recomposed = (svc._rodrigues_horizontal(flight_yaw, roll)
+                                  @ svc._base_rotation(pitch, yaw))
+                    assert np.allclose(recomposed, r_true, atol=1e-9), (
+                        f"yaw={flight_yaw} cam={cam_idx} bank={bank} pitch={ac_pitch}")
+
+
+def test_bank_right_tilts_cam0_boresight_toward_nadir():
+    # Right bank (+) rotates the right-tilted cam 0 boresight TOWARD nadir:
+    # at bank = +22.5 it looks straight down. The docstring's "positive
+    # Rodrigues roll tilts the optical axis plane LEFT" implies exactly this.
+    svc = WaldoMetadataService
+    r_true = svc.compose_attitude_rotation(180.0, -OUTWARD_ROLL_DEG, 0.0, 0.0, +6.0)
+    pitch, yaw, roll = svc.invert_to_gimbal_angles(r_true, 0.0)
+    assert math.isclose(roll, -16.5, abs_tol=1e-9)
+    assert math.isclose(pitch, -90.0, abs_tol=1e-9)
+    r_nadir = svc.compose_attitude_rotation(180.0, -OUTWARD_ROLL_DEG, 0.0, 0.0, +OUTWARD_ROLL_DEG)
+    assert math.isclose(abs(float(r_nadir[2, 2])), 1.0, abs_tol=1e-9)
+
+
+def test_inverted_angles_reproduce_ground_position_through_consumer():
+    """The stamped triple must land the consumer raycast on the true ground point."""
+    svc = WaldoMetadataService
+    flight_yaw = 42.0
+    level_yaw = (flight_yaw + 180.0) % 360.0
+    r_true = svc.compose_attitude_rotation(level_yaw, -OUTWARD_ROLL_DEG,
+                                           flight_yaw, 3.5, -8.0)
+    pitch, yaw, roll = svc.invert_to_gimbal_angles(r_true, flight_yaw)
+
+    alt = 500.0
+    drone_lat, drone_lon = 37.0, -118.0
+    result = AOIService._calculate_ground_position(
+        drone_lat, drone_lon, 2000.0, 1500.0, 2000.0, 1500.0, 4000, 3000,
+        50.0, 36.0, 24.0, alt, pitch, yaw, roll,
+        roll_axis_azimuth_deg=flight_yaw)
+    assert result is not None
+    got_north = (result[0] - drone_lat) * 111_320.0
+    got_east = (result[1] - drone_lon) * 111_320.0 * math.cos(math.radians(drone_lat))
+
+    ray = r_true[:, 2]
+    t = alt / float(ray[2])
+    want_north = float(ray[0]) * t
+    want_east = float(ray[1]) * t
+    assert math.isclose(got_north, want_north, abs_tol=1.0)
+    assert math.isclose(got_east, want_east, abs_tol=1.0)
+
+
+# --------------------------------------------------------------------------
+# apply_flight_log_attitude
+# --------------------------------------------------------------------------
+
+T0 = 1_700_000_000.0
+
+
+def _track(n=101, bank=6.0, pitch=2.0):
+    return FlightLogTrack(
+        path="log.csv", t=[T0 + k for k in range(n)],
+        lat=[37.0] * n, lon=[-118.0] * n, alt_m=[1500.0] * n,
+        course=[0.0] * n, speed_mps=[50.0] * n,
+        bank=[bank] * n, pitch=[pitch] * n)
+
+
+def _fit(**kwargs):
+    defaults = dict(log_path="log.csv", log_sha256="ab" * 32, accepted=True,
+                    clock_offset_s=-17.0, mean_track_dist_m=15.0,
+                    matched_fraction=1.0, attitude_reliable=True,
+                    attitude_lag_s=4.0, lag_correlation=0.95)
+    defaults.update(kwargs)
+    return FlightLogFit(**defaults)
+
+
+def _record(**kwargs):
+    defaults = dict(path="E:/img/0_000_00_010.jpg", name="0_000_00_010.jpg",
+                    cam_idx=0, capture_epoch=T0 + 50.0 + 17.0, lat=37.0, lon=-118.0,
+                    flight_yaw_deg=0.0, gimbal_yaw_deg=180.0,
+                    processor_version="9")
+    defaults.update(kwargs)
+    return FlightLogImageRecord(**defaults)
+
+
+@pytest.fixture
+def captured_writes(monkeypatch):
+    writes = []
+    monkeypatch.setattr(
+        waldo_module.MetaDataHelper, 'add_xmp_fields',
+        staticmethod(lambda path, fields: writes.append((path, list(fields)))))
+    return writes
+
+
+def _field(writes, tag):
+    for _path, fields in writes:
+        for _ns, name, value in fields:
+            if name == tag:
+                return value
+    return None
+
+
+def test_apply_composes_and_stamps(captured_writes):
+    svc = WaldoMetadataService()
+    result = svc.apply_flight_log_attitude([_record()], _fit(), _track())
+    assert result.processed == 1
+    assert not result.errors
+    assert _field(captured_writes, "AttitudeSource") == ATTITUDE_SOURCE_TRACKLOG
+    # bank +6 on cam0 (-22.5) with zero pitch: exact composed roll -16.5
+    assert math.isclose(float(_field(captured_writes, "GimbalRollDegree")), -16.5, abs_tol=0.01)
+    assert math.isclose(float(_field(captured_writes, "FlightRollDegree")), 6.0, abs_tol=1e-6)
+    assert math.isclose(float(_field(captured_writes, "FlightPitchDegree")), 2.0, abs_tol=1e-6)
+    # capture (face-resolved) T0+67, offset -17 -> refined T0+50
+    assert _field(captured_writes, "CaptureUtcRefined") == "2023-11-14T22:14:10+00:00"
+    assert _field(captured_writes, "ClockOffsetSeconds") == "-17.00"
+    assert _field(captured_writes, "LevelYawDegree") is not None
+    assert result.notes and "clock -17.0 s" in result.notes[0]
+
+
+def test_apply_pitch_only_changes_composed_pitch(captured_writes):
+    svc = WaldoMetadataService()
+    svc.apply_flight_log_attitude([_record()], _fit(), _track(bank=0.0, pitch=5.0))
+    pitch = float(_field(captured_writes, "GimbalPitchDegree"))
+    roll = float(_field(captured_writes, "GimbalRollDegree"))
+    # Nose-up 5 deg tilts the boresight AHEAD of the aircraft - away from
+    # cam 0's backward image-top azimuth, so the composed pitch goes BEYOND
+    # nadir (< -90) while roll keeps roughly the mount value.
+    assert -96.0 < pitch < -90.0
+    assert math.isclose(roll, -OUTWARD_ROLL_DEG, abs_tol=0.5)
+
+
+def test_apply_signature_idempotence(captured_writes):
+    svc = WaldoMetadataService()
+    fit = _fit()
+    rec = _record()
+    sig = svc._flight_log_signature(rec, fit)
+    rec.existing_signature = sig
+    result = svc.apply_flight_log_attitude([rec], fit, _track())
+    assert result.already_current == 1
+    assert result.processed == 0
+    assert captured_writes == []
+
+    # A changed clock decision must break the signature and restamp.
+    rec2 = _record(clock_face_shift="-12", clock_tz="America/Los_Angeles",
+                   existing_signature=sig)
+    result2 = svc.apply_flight_log_attitude([rec2], fit, _track())
+    assert result2.processed == 1
+
+
+def test_apply_steep_bank_falls_back_to_constants(captured_writes):
+    svc = WaldoMetadataService()
+    # cam1 mount +22.5 plus 50 deg left-wing-down bank -> composed roll ~72.5
+    rec = _record(cam_idx=1, gimbal_yaw_deg=0.0)
+    svc.apply_flight_log_attitude([rec], _fit(), _track(bank=50.0))
+    assert _field(captured_writes, "AttitudeSource") == ATTITUDE_SOURCE_CONSTANTS
+    assert math.isclose(float(_field(captured_writes, "GimbalRollDegree")),
+                        +OUTWARD_ROLL_DEG, abs_tol=1e-6)
+    assert math.isclose(float(_field(captured_writes, "GimbalPitchDegree")), -90.0, abs_tol=1e-6)
+    assert _field(captured_writes, "FlightRollDegree") is None
+    # sanity: the guard bound itself
+    assert 50.0 + OUTWARD_ROLL_DEG > FLIGHTLOG_MAX_ROLL_DEG
+
+
+def test_apply_out_of_coverage_falls_back_to_constants(captured_writes):
+    svc = WaldoMetadataService()
+    rec = _record(capture_epoch=T0 + 500.0)  # past the 100 s track
+    svc.apply_flight_log_attitude([rec], _fit(), _track())
+    assert _field(captured_writes, "AttitudeSource") == ATTITUDE_SOURCE_CONSTANTS
+    # the clock refinement still applies
+    assert _field(captured_writes, "CaptureUtcRefined") is not None
+
+
+def test_apply_unreliable_attitude_keeps_constants_but_refines_clock(captured_writes):
+    svc = WaldoMetadataService()
+    result = svc.apply_flight_log_attitude(
+        [_record()], _fit(attitude_reliable=False, attitude_lag_s=0.0, lag_correlation=0.2),
+        _track())
+    assert result.processed == 1
+    assert _field(captured_writes, "AttitudeSource") == ATTITUDE_SOURCE_CONSTANTS
+    assert _field(captured_writes, "CaptureUtcRefined") == "2023-11-14T22:14:10+00:00"
+    assert result.notes and "unreliable" in result.notes[0]
+
+
+def test_apply_rejected_fit_stamps_nothing(captured_writes):
+    svc = WaldoMetadataService()
+    result = svc.apply_flight_log_attitude(
+        [_record()], _fit(accepted=False, reason="images do not lie on this log's track"),
+        _track())
+    assert result.processed == 0
+    assert captured_writes == []
+    assert result.warnings and "rejected" in result.warnings[0]
+
+
+def test_apply_restores_constants_over_stale_composition(captured_writes):
+    # Image previously composed with another log (LevelYaw stamped, gimbal
+    # values composed): with the new fit unable to cover it, the constants
+    # restamp must rebuild from the LEVEL baseline, not the composed yaw.
+    svc = WaldoMetadataService()
+    rec = _record(capture_epoch=T0 + 500.0, gimbal_yaw_deg=171.2,
+                  level_yaw_deg=180.0, existing_signature="v1|stale")
+    svc.apply_flight_log_attitude([rec], _fit(), _track())
+    assert math.isclose(float(_field(captured_writes, "GimbalYawDegree")), 180.0, abs_tol=1e-6)

--- a/translations/app_en.ts
+++ b/translations/app_en.ts
@@ -125,12 +125,12 @@ GPU acceleration significantly improves processing speed for AI models.</transla
 <context>
     <name>AIPersonDetectorController</name>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="82"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="81"/>
         <source>GPU Not Available</source>
         <translation>GPU Not Available</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="88"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="87"/>
         <source>GPU Available</source>
         <translation>GPU Available</translation>
     </message>
@@ -203,7 +203,7 @@ Permissive</translation>
         <translation>AOI Comment</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="38"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="37"/>
         <source>Add a comment for this flagged AOI (max 256 characters):</source>
         <translation>Add a comment for this flagged AOI (max 256 characters):</translation>
     </message>
@@ -287,7 +287,7 @@ Permissive</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1092"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1091"/>
         <source>Terrain-corrected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -297,12 +297,12 @@ Permissive</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1105"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1102"/>
         <source>Flat terrain assumed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1538"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Temperature sorting unavailable (no thermal data)</translation>
     </message>
@@ -312,7 +312,7 @@ Permissive</translation>
         <translation>Cannot Delete AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1895"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1892"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</translation>
     </message>
@@ -322,7 +322,7 @@ Permissive</translation>
         <translation>Delete AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1904"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1903"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>Are you sure you want to delete this AOI? This action cannot be undone.</translation>
     </message>
@@ -596,7 +596,7 @@ Permissive</translation>
         <translation>Select Mask Image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="610"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="609"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)</source>
         <translation>Images (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)</translation>
     </message>
@@ -606,7 +606,7 @@ Permissive</translation>
         <translation>Invalid Image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="620"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="619"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>Could not load the selected image. Please choose a valid image file.</translation>
     </message>
@@ -659,12 +659,12 @@ Permissive</translation>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="380"/>
         <source>Showing the {count} nearest images containing this AOI; there are more. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="385"/>
         <source>Found AOI in {count} image(s). Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,7 +677,7 @@ Permissive</translation>
         <translation>No AOI Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="194"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="193"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Please select an AOI first by clicking on it in the thumbnail panel.</translation>
     </message>
@@ -687,7 +687,7 @@ Permissive</translation>
         <translation>Cannot Calculate GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="406"/>
         <source>Unable to calculate GPS coordinates for this AOI.
 
 This may be due to missing image metadata (GPS, altitude, or camera info).</source>
@@ -728,7 +728,7 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
         <translation>No Neighbors Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="437"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>The AOI was not found in any neighboring images.</translation>
     </message>
@@ -745,7 +745,7 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="587"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="584"/>
         <source> (no detections)</source>
         <translation> (no detections)</translation>
     </message>
@@ -770,7 +770,7 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
         <translation>No AOI Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="142"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Please select an AOI first by clicking on it in the thumbnail panel.</translation>
     </message>
@@ -813,7 +813,7 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
         <translation>No Similar AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="280"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="279"/>
         <source>No other AOIs could be analyzed for similarity.</source>
         <translation>No other AOIs could be analyzed for similarity.</translation>
     </message>
@@ -865,7 +865,7 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
         <translation>Similar AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="479"/>
         <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
         <translation>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</translation>
     </message>
@@ -936,7 +936,7 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
         <translation>AOI #{number}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="584"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="582"/>
         <source>the selected AOI</source>
         <translation>the selected AOI</translation>
     </message>
@@ -944,15 +944,15 @@ This may be due to missing image metadata (GPS, altitude, or camera info).</tran
 <context>
     <name>AOIUIComponent</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="251"/>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="347"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="250"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="346"/>
         <source>AOI Information
 Right-click to copy data to clipboard</source>
         <translation>AOI Information
 Right-click to copy data to clipboard</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="257"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="256"/>
         <source>
 
 Score Type: {type}
@@ -973,7 +973,7 @@ Raw Score: {score} ({method})</translation>
         <translation>Unflag AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="387"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="386"/>
         <source>Flag AOI</source>
         <translation>Flag AOI</translation>
     </message>
@@ -989,7 +989,7 @@ Click to edit comment</source>
 Click to edit comment</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="415"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="411"/>
         <source>No comment yet.
 Click to add a comment for this AOI.
 
@@ -1002,7 +1002,7 @@ Use comments to note important details, observations,
 or actions needed for this detection.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="429"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="428"/>
         <source>Calculate and show GPS location for this AOI</source>
         <translation>Calculate and show GPS location for this AOI</translation>
     </message>
@@ -1017,7 +1017,7 @@ or actions needed for this detection.</translation>
         <translation>Area</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="485"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="484"/>
         <source>Areas</source>
         <translation>Areas</translation>
     </message>
@@ -1027,12 +1027,12 @@ or actions needed for this detection.</translation>
         <translation>{filtered} of {total} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="496"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="495"/>
         <source>Area of Interest</source>
         <translation>Area of Interest</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="498"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="497"/>
         <source>Areas of Interest</source>
         <translation>Areas of Interest</translation>
     </message>
@@ -1055,7 +1055,7 @@ or actions needed for this detection.</translation>
 <context>
     <name>AlertManager</name>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="295"/>
+        <location filename="../app/core/services/AlertService.py" line="294"/>
         <source>ADIAT - Color Detection Alerts</source>
         <translation>ADIAT - Color Detection Alerts</translation>
     </message>
@@ -1065,7 +1065,7 @@ or actions needed for this detection.</translation>
         <translation>ADIAT - Color Detection Alert</translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="613"/>
+        <location filename="../app/core/services/AlertService.py" line="610"/>
         <source>Detected {count} object(s)
 Average confidence: {avg_confidence:.2f}
 Total area: {area:.0f} pixels
@@ -1076,7 +1076,7 @@ Total area: {area:.0f} pixels
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="621"/>
+        <location filename="../app/core/services/AlertService.py" line="620"/>
         <source>
 Details:
 </source>
@@ -1085,7 +1085,7 @@ Details:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="625"/>
+        <location filename="../app/core/services/AlertService.py" line="624"/>
         <source>  #{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
 </source>
         <translation>  #{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
@@ -1113,7 +1113,7 @@ Details:
         <translation>Are you using thermal images?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="157"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="156"/>
         <source>Are you looking for anomalies within a specific temperature range?</source>
         <translation>Are you looking for anomalies within a specific temperature range?</translation>
     </message>
@@ -1123,7 +1123,7 @@ Details:
         <translation>Do you specifically want to detect people?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="169"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="168"/>
         <source>Do you want to detect anomalies relative to local surroundings?</source>
         <translation>Do you want to detect anomalies relative to local surroundings?</translation>
     </message>
@@ -1138,12 +1138,12 @@ Details:
         <translation>Do you want to manually adjust the color range?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="194"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="193"/>
         <source>Do your images contain complex backgrounds or structures?</source>
         <translation>Do your images contain complex backgrounds or structures?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="201"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="200"/>
         <source>Do your images include shadows or areas with uneven lighting?</source>
         <translation>Do your images include shadows or areas with uneven lighting?</translation>
     </message>
@@ -1179,7 +1179,7 @@ Details:
 <context>
     <name>AlignImageDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="53"/>
         <source>This saved alignment looks mirrored - re-place each corner handle on its matching photo corner (coloured squares).</source>
         <translation>This saved alignment looks mirrored - re-place each corner handle on its matching photo corner (coloured squares).</translation>
     </message>
@@ -1189,7 +1189,7 @@ Details:
         <translation>Align Image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="136"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="130"/>
         <source>Rotate the drone image to line it up with the map. The small coloured squares mark the photo&apos;s corners - drag each corner handle onto the map where its matching-coloured photo corner belongs. For extra accuracy, add tie points: put the IMAGE end on a feature in the drone photo and the MAP end on the same feature on the map.</source>
         <translation>Rotate the drone image to line it up with the map. The small coloured squares mark the photo&apos;s corners - drag each corner handle onto the map where its matching-coloured photo corner belongs. For extra accuracy, add tie points: put the IMAGE end on a feature in the drone photo and the MAP end on the same feature on the map.</translation>
     </message>
@@ -1235,7 +1235,7 @@ Details:
         <translation>Corners look mirrored</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="220"/>
         <source>The four corners appear mirrored - the drone image would map to the ground flipped.
 
 Each corner handle is colour-matched to a corner of the drone photo (the small coloured squares). Make sure every handle sits where its matching photo corner belongs.</source>
@@ -1275,7 +1275,7 @@ Each corner handle is colour-matched to a corner of the drone photo (the small c
         <translation>meters</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="100"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="98"/>
         <source>feet</source>
         <translation>feet</translation>
     </message>
@@ -1285,7 +1285,7 @@ Each corner handle is colour-matched to a corner of the drone photo (the small c
         <translation>Negative Altitude Detected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="113"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="111"/>
         <source>WARNING! Relative Altitude is negative. Enter an AGL altitude to be used for GSD calculations (in {unit}):</source>
         <translation>WARNING! Relative Altitude is negative. Enter an AGL altitude to be used for GSD calculations (in {unit}):</translation>
     </message>
@@ -1295,7 +1295,7 @@ Each corner handle is colour-matched to a corner of the drone photo (the small c
         <translation>Override Altitude</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="132"/>
         <source>Enter a custom AGL altitude to be used for GSD calculations for all images (in {unit}):</source>
         <translation>Enter a custom AGL altitude to be used for GSD calculations for all images (in {unit}):</translation>
     </message>
@@ -1367,7 +1367,7 @@ Each corner handle is colour-matched to a corner of the drone photo (the small c
         <translation>Missing Bearings Detected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="135"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="132"/>
         <source>Some images are missing bearing/heading information. We can estimate bearings from a flight track file (KML/GPX/CSV) or calculate them automatically from image GPS coordinates.</source>
         <translation>Some images are missing bearing/heading information. We can estimate bearings from a flight track file (KML/GPX/CSV) or calculate them automatically from image GPS coordinates.</translation>
     </message>
@@ -1402,7 +1402,7 @@ Each corner handle is colour-matched to a corner of the drone photo (the small c
         <translation>Select Track File</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="262"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="261"/>
         <source>Track Files (*.kml *.gpx *.csv);;KML Files (*.kml);;GPX Files (*.gpx);;CSV Files (*.csv);;All Files (*.*)</source>
         <translation>Track Files (*.kml *.gpx *.csv);;KML Files (*.kml);;GPX Files (*.gpx);;CSV Files (*.csv);;All Files (*.*)</translation>
     </message>
@@ -1442,7 +1442,7 @@ Each corner handle is colour-matched to a corner of the drone photo (the small c
         <translation>Bearing Calculation Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="393"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="391"/>
         <source>An error occurred during bearing calculation:
 
 {error}
@@ -1470,7 +1470,7 @@ Please check your input files and try again.</translation>
         <translation>Bearing Recovery Not Needed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="440"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="437"/>
         <source>Bearing recovery requires multiple images to calculate direction of travel.
 
 With only one image, bearing recovery cannot be performed.</source>
@@ -1479,7 +1479,7 @@ With only one image, bearing recovery cannot be performed.</source>
 With only one image, bearing recovery cannot be performed.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="452"/>
         <source>
 &lt;h3&gt;What is Bearing Recovery?&lt;/h3&gt;
 
@@ -1558,14 +1558,14 @@ Proceed without bearing recovery. Some features may not work correctly.&lt;/p&gt
         <translation>Cached Data Not Found</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="57"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="56"/>
         <source>The following cached items were not found:
 </source>
         <translation>The following cached items were not found:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="71"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="66"/>
         <source>Without cached data, thumbnails and colors will be generated on-demand, which may cause delays when viewing results.
 
 If you have previously processed this dataset and have an ADIAT_Results folder with cached data, you can locate it now to improve performance.</source>
@@ -1594,7 +1594,7 @@ If you have previously processed this dataset and have an ADIAT_Results folder w
         <translation>Invalid Cache Folder</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="143"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="138"/>
         <source>The selected folder does not contain thumbnail cache directory.
 
 Expected to find:
@@ -1658,7 +1658,7 @@ Please select a valid ADIAT_Results folder.</translation>
         <translation>Credentials Updated</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="517"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="516"/>
         <source>Credentials have been updated and the map list has been refreshed.</source>
         <translation>Credentials have been updated and the map list has been refreshed.</translation>
     </message>
@@ -1668,7 +1668,7 @@ Please select a valid ADIAT_Results folder.</translation>
         <translation>Update Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="526"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="523"/>
         <source>Failed to refresh account data with new credentials.
 
 Please check your credentials and try again.</source>
@@ -1691,7 +1691,7 @@ Please check your credentials and try again.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="544"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="542"/>
         <source>Credentials have been updated. Please close and reopen this dialog to refresh the map list.</source>
         <translation>Credentials have been updated. Please close and reopen this dialog to refresh the map list.</translation>
     </message>
@@ -1701,7 +1701,7 @@ Please check your credentials and try again.</translation>
         <translation>No Map Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="560"/>
         <source>Please select a map from the list.</source>
         <translation>Please select a map from the list.</translation>
     </message>
@@ -1757,7 +1757,7 @@ Please check your credentials and try again.</translation>
         <translation>Failed to Load</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Failed to load CalTopo. Please check your internet connection and try again.</translation>
     </message>
@@ -1772,7 +1772,7 @@ Please check your credentials and try again.</translation>
         <translation>No Map Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="480"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1786,7 +1786,7 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</translatio
         <translation>Browser Not Ready</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="488"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>The CalTopo browser is still loading. Please wait a moment and try again.</translation>
     </message>
@@ -1802,12 +1802,12 @@ The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</translatio
         <translation>Authentication Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser not initialized. Please try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="768"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1834,7 +1834,7 @@ Make sure you are signed in to CalTopo in this window and have opened your map, 
         <translation>CalTopo Team API Credentials</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="87"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="85"/>
         <source>Enter your CalTopo Team API credentials.
 These can be found in the Team Admin page under Service Accounts.</source>
         <translation>Enter your CalTopo Team API credentials.
@@ -1945,7 +1945,7 @@ These can be found in the Team Admin page under Service Accounts.</translation>
         <translation>Invalid Credential Secret</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="268"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="263"/>
         <source>The Credential Secret cannot be used to sign a CalTopo request.
 
 Copy it exactly as shown on the CalTopo Team Admin page under Service Accounts - it is a long base64 string, not the Credential ID or the Team ID.
@@ -1968,7 +1968,7 @@ Details: {error}</translation>
         <translation>Credentials Valid</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="319"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="318"/>
         <source>The credentials are valid and successfully authenticated with CalTopo API.</source>
         <translation>The credentials are valid and successfully authenticated with CalTopo API.</translation>
     </message>
@@ -1978,7 +1978,7 @@ Details: {error}</translation>
         <translation>Credentials Invalid</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="332"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="325"/>
         <source>The credentials failed to authenticate with CalTopo API.
 
 Please check:
@@ -2013,13 +2013,13 @@ Please check:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="488"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1297"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1298"/>
         <source>Offline Mode Enabled</source>
         <translation>Offline Mode Enabled</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="495"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1304"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1300"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2035,13 +2035,13 @@ Turn off Offline Only to export to CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="501"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1310"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1311"/>
         <source>Nothing Selected</source>
         <translation>Nothing Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="505"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="503"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1313"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</translation>
     </message>
@@ -2066,7 +2066,7 @@ Turn off Offline Only to export to CalTopo.</translation>
         <translation>Preparation Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="563"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="562"/>
         <source>An error occurred while preparing export data:
 
 {error}</source>
@@ -2090,14 +2090,14 @@ Turn off Offline Only to export to CalTopo.</translation>
         <translation>coverage area</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="582"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="579"/>
         <source>No flagged AOIs, geotagged image locations, or coverage areas are available.
 Flag some AOIs with the &apos;F&apos; key or ensure your images have GPS metadata.</source>
         <translation>No flagged AOIs, geotagged image locations, or coverage areas are available.
 Flag some AOIs with the &apos;F&apos; key or ensure your images have GPS metadata.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="590"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="585"/>
         <source>Found {count} flagged AOI(s), but could not extract GPS coordinates.
 
 This usually means:
@@ -2114,30 +2114,11 @@ This usually means:
 Please ensure your images have GPS coordinates embedded.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="593"/>
         <source>No geotagged drone/image locations were found.
 Ensure your images contain GPS metadata and try again.</source>
         <translation>No geotagged drone/image locations were found.
 Ensure your images contain GPS metadata and try again.</translation>
-    </message>
-    <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="605"/>
-        <source>No coverage area polygons could be calculated.
-
-This usually means:
-• The images don&apos;t have GPS data in their EXIF metadata
-• The images are not nadir (gimbal pitch must be between -85° and -95°)
-• GSD (ground sample distance) could not be calculated
-
-Please ensure your images have GPS coordinates and are nadir shots.</source>
-        <translation>No coverage area polygons could be calculated.
-
-This usually means:
-• The images don&apos;t have GPS data in their EXIF metadata
-• The images are not nadir (gimbal pitch must be between -85° and -95°)
-• GSD (ground sample distance) could not be calculated
-
-Please ensure your images have GPS coordinates and are nadir shots.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="608"/>
@@ -2145,18 +2126,18 @@ Please ensure your images have GPS coordinates and are nadir shots.</translation
         <translation>No {types} are available to export.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="613"/>
         <source>Nothing to Export</source>
         <translation>Nothing to Export</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="637"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="680"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="638"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No Map Selected</source>
         <translation>No Map Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="643"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="640"/>
         <source>Please navigate to a CalTopo map before clicking &apos;I&apos;m Logged In&apos;.
 
 The map URL should look like:
@@ -2167,7 +2148,7 @@ The map URL should look like:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="686"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2176,7 +2157,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1615"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1613"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2190,7 +2171,7 @@ The reason was written to the log (adiat_logs.txt) and the console.</translation
         <translation>Photos uploaded: {uploaded} of {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1630"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2199,7 +2180,7 @@ The items should now be visible on your map.</source>
 The items should now be visible on your map.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1641"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1639"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2208,24 +2189,24 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1628"/>
         <source>Export Successful</source>
         <translation>Export Successful</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1636"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1637"/>
         <source>Partial Success</source>
         <translation>Partial Success</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1610"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1611"/>
         <source>Export Failed</source>
         <translation>Export Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="718"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1377"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1572"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1378"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1573"/>
         <source>Export Error</source>
         <translation>Export Error</translation>
     </message>
@@ -2240,7 +2221,7 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1057"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1055"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2249,14 +2230,27 @@ Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1534"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1535"/>
         <source>Exporting to CalTopo</source>
         <translation>Exporting to CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1265"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1266"/>
         <source>Logged Out</source>
         <translation>Logged Out</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="598"/>
+        <source>No coverage area polygons could be calculated.
+
+This usually means:
+• The images don&apos;t have GPS data in their EXIF metadata
+• The images are not nadir (gimbal pitch must be between -85° and -95°;
+  WALDO images: boresight within 40° of nadir)
+• GSD (ground sample distance) could not be calculated
+
+Please ensure your images have GPS coordinates and are near-nadir shots.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1267"/>
@@ -2264,17 +2258,17 @@ Number of corners: {count}</translation>
         <translation>Successfully logged out from CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1425"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1426"/>
         <source>Loading CalTopo Maps</source>
         <translation>Loading CalTopo Maps</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
         <source>Connecting to CalTopo...</source>
         <translation>Connecting to CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1430"/>
         <source>Fetching account data and maps...</source>
         <translation>Fetching account data and maps...</translation>
     </message>
@@ -2293,7 +2287,7 @@ Number of corners: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="696"/>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
         <source>Authentication Failed</source>
         <translation>Authentication Failed</translation>
@@ -2313,7 +2307,7 @@ Number of corners: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1497"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1492"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2326,12 +2320,12 @@ The reason was written to the log (adiat_logs.txt) and the console.
 Would you like to re-enter your Team ID, Credential ID and Credential Secret?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1537"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exporting to CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1539"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparing data and exporting...</translation>
     </message>
@@ -2349,7 +2343,7 @@ Would you like to re-enter your Team ID, Credential ID and Credential Secret?</t
         <translation>Select CalTopo Export Method</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="62"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="61"/>
         <source>Choose how you want to authenticate with CalTopo:</source>
         <translation>Choose how you want to authenticate with CalTopo:</translation>
     </message>
@@ -2364,7 +2358,7 @@ Would you like to re-enter your Team ID, Credential ID and Credential Secret?</t
         <translation>API (Recommended for CalTopo Team Account)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="77"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="75"/>
         <source>Use CalTopo Team API with service account credentials.
 Best for Teams accounts with service accounts configured.</source>
         <translation>Use CalTopo Team API with service account credentials.
@@ -2376,14 +2370,14 @@ Best for Teams accounts with service accounts configured.</translation>
         <translation>Browser Login</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="81"/>
         <source>Use browser-based authentication.
 Log in through an embedded browser window.</source>
         <translation>Use browser-based authentication.
 Log in through an embedded browser window.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="98"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="96"/>
         <source>API method requires Team ID and Credential Secret from your
 CalTopo Team Admin page. Browser method uses your regular login.</source>
         <translation>API method requires Team ID and Credential Secret from your
@@ -2413,7 +2407,7 @@ CalTopo Team Admin page. Browser method uses your regular login.</translation>
         <translation>Enable Temporal Voting (reduce flicker)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="42"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="38"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -2429,7 +2423,7 @@ Recommended: ON for all use cases (default).</translation>
         <translation>Window Frames (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="53"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -2447,7 +2441,7 @@ Recommended: 5 for 30fps (~167ms window), 7 for 60fps.</translation>
         <translation>Threshold (N of M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="71"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="66"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -2470,7 +2464,7 @@ Recommended: 3 out of 5 (detection in 60% of frames).</translation>
         <translation>Enable Aspect Ratio Filtering</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="85"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -2484,7 +2478,7 @@ Most users can leave this OFF unless you see many long skinny false detections.<
         <translation>Min Ratio:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="104"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="100"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -2500,7 +2494,7 @@ Example: 0.2 = reject if height is more than 5x width.</translation>
         <translation>Max Ratio:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="116"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="113"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -2519,7 +2513,7 @@ Higher values = allow wider objects such as vehicles or long equipment.</transla
         <translation>Enable Detection Clustering</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="131"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="128"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -2533,7 +2527,7 @@ Most users can leave this OFF unless objects look fragmented.</translation>
         <translation>Clustering Distance (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="142"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -2562,7 +2556,7 @@ Click to change color</source>
 Click to change color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="79"/>
+        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="78"/>
         <source>HSV: ({h}°, {s}%, {v}%)
 RGB: ({r}, {g}, {b})
 Click to change color</source>
@@ -2609,7 +2603,7 @@ Click to change color</translation>
         <translation>Enable Motion Detection</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="153"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="149"/>
         <source>Turn ON to highlight moving objects in the scene.
 Most users can leave all other settings at their defaults.
 Works best for stationary or slow-moving cameras and can be combined
@@ -2645,7 +2639,7 @@ with Color-Based Anomaly Detection for more robust results.</translation>
         <translation>KNN</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="179"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="174"/>
         <source>Motion detection algorithm (advanced setting):
 
 • FRAME_DIFF – Fast and simple; very sensitive to any motion.
@@ -2672,7 +2666,7 @@ If you are unsure, leave this set to MOG2.</translation>
         <translation>Motion Threshold:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="200"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="196"/>
         <source>Minimum pixel intensity change to consider as motion (1-255).
 Lower values = more sensitive, detects subtle motion, more false positives.
 Higher values = less sensitive, only strong motion, fewer false positives.
@@ -2688,7 +2682,7 @@ Recommended: 10 for general use, 5 for subtle motion, 15-20 for high contrast sc
         <translation>Blur Kernel (odd):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="215"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="210"/>
         <source>Gaussian blur kernel size (must be odd: 1, 3, 5, 7, etc.).
 Smooths the frame before motion detection to reduce noise.
 Larger values = more smoothing, less noise, less detail.
@@ -2706,7 +2700,7 @@ Recommended: 5 for general use, 1 for no blur, 7-9 for noisy videos.</translatio
         <translation>Morphology Kernel:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="230"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="225"/>
         <source>Morphological operation kernel size (odd numbers: 1, 3, 5, etc.).
 Removes small noise and fills holes in detections.
 Larger values = remove more noise, merge nearby detections.
@@ -2729,7 +2723,7 @@ Recommended: 3 for general use, 1 for precise edges, 5-7 for noisy videos.</tran
         <translation>Window Frames (M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="251"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="246"/>
         <source>Size of temporal window for persistence filtering (2-30 frames).
 Motion must appear in N out of M consecutive frames to be confirmed.
 Larger values = longer memory, more stable, slower response.
@@ -2747,7 +2741,7 @@ Recommended: 3 for 30fps video (100ms window), 5 for 60fps.</translation>
         <translation>Threshold (N of M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="264"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="259"/>
         <source>Number of frames within window where motion must appear (N of M).
 Higher values = more stringent, filters flickering false positives.
 Lower values = more lenient, detects brief/intermittent motion.
@@ -2770,7 +2764,7 @@ Recommended: 2 (motion in 2 of last 3 frames).</translation>
         <translation>History Frames:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="285"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="280"/>
         <source>Number of frames to learn background model (10-500).
 Only applies to MOG2 and KNN algorithms.
 Longer history = adapts slower to lighting changes, more stable.
@@ -2788,7 +2782,7 @@ Recommended: 50 (~1.7 sec at 30fps) for general use.</translation>
         <translation>Variance Threshold:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="298"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="293"/>
         <source>Variance threshold for background/foreground classification (1.0-100.0).
 Only applies to MOG2 and KNN algorithms.
 Lower values = more sensitive, detects subtle changes, more false positives.
@@ -2806,7 +2800,7 @@ Recommended: 10.0 for indoor, 15-20 for outdoor with varying lighting.</translat
         <translation>Detect Shadows (slower)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="307"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="303"/>
         <source>Enables shadow detection in MOG2 background subtractor.
 Helps distinguish shadows from actual objects (reduces false positives).
 Adds ~10-20% processing overhead.
@@ -2828,7 +2822,7 @@ Recommended: ON for outdoor scenes with strong shadows, OFF for speed.</translat
         <translation>Min Object Area (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="328"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="323"/>
         <source>Minimum detection area in pixels (1-100000).
 Filters out very small detections such as noise, insects, or raindrops.
 Lower values = detect smaller objects (more noise).
@@ -2847,7 +2841,7 @@ Recommended: 5-10 for person-sized motion, 50-100 for vehicles.</translation>
         <translation>Max Object Area (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="341"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="336"/>
         <source>Maximum detection area in pixels (10-1000000).
 Filters out very large regions such as full-frame lighting changes or giant shadows.
 Lower values = only small/medium objects.
@@ -2870,7 +2864,7 @@ Recommended: 1000 for people, 10000 for vehicles, higher for very large objects.
         <translation>Pause on Camera Movement</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="357"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="353"/>
         <source>Automatically pauses motion detection when camera is moving/panning.
 Prevents false positives caused by camera movement (entire scene appears to move).
 Detects camera movement by measuring percentage of frame with motion.
@@ -2886,7 +2880,7 @@ Recommended: ON for handheld/drone footage, OFF for stationary tripod cameras.</
         <translation>Threshold:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="371"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="366"/>
         <source>Percentage of frame with motion to consider as camera movement (1-100%).
 If more than this % of pixels show motion, pause detection.
 Lower values = detect camera movement sooner (more pauses).
@@ -2904,7 +2898,7 @@ Recommended: 15% for drone/handheld, 30% for shaky tripod.</translation>
         <translation>Show Advanced Motion Settings</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="386"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="383"/>
         <source>Advanced users can expand this to adjust the motion algorithm
 and detailed thresholds (sensitivity, filters, background model).
 If you are unsure, leave this unchecked and use the defaults.</source>
@@ -2918,7 +2912,7 @@ If you are unsure, leave this unchecked and use the defaults.</translation>
         <translation>Enable Color-Based Anomaly Detection</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="409"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="405"/>
         <source>Detects pixels whose colors are statistically rare in the frame.
 Conceptually similar to MRMap&apos;s rarity-based detection for images.
 Works well for: bright colored clothing, vehicles, equipment in natural scenes.
@@ -2939,7 +2933,7 @@ Can be combined with Motion Detection for more robust detection.</translation>
         <translation>Color Resolution (bins):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="430"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="424"/>
         <source>Controls how finely colors are grouped into histogram bins (3-8 bits).
 Analogous to MRMap&apos;s color binning.
 Lower values (3-4) = fewer bins → faster, more grouping, fewer but stronger detections.
@@ -2964,7 +2958,7 @@ and higher only when you need to pull out very subtle color differences.</transl
         <translation>Rarity Threshold (% of colors):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="448"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="442"/>
         <source>Sensitivity threshold for how rare a color must be to be flagged (0-100%).
 Computed from the distribution of color-bin counts in the frame, similar in role
 to MRMap&apos;s detection threshold.
@@ -2979,7 +2973,7 @@ Medium values (25-40%) = balanced (recommended for general use).
 Higher values (40-60%) = more sensitive: includes more common colors (more detections).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="464"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="459"/>
         <source>Minimum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s minimum AOI area.
 Lower values = detect smaller colored objects (more noise).
@@ -2992,7 +2986,7 @@ Higher values = only larger colored regions (less noise).
 Recommended: 15 for person-sized targets, 50+ for vehicles or large objects.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="477"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="472"/>
         <source>Maximum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s maximum AOI area.
 Lower values = only detect smaller colored objects.
@@ -3020,7 +3014,7 @@ Recommended: 50000 for general use, 10000 for small-object-only searches.</trans
         <translation>Connected Components</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="491"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="486"/>
         <source>Method for extracting blob regions from the detection mask:
 
 Find Contours: Traditional OpenCV contour detection (default).
@@ -3062,7 +3056,7 @@ Connected Components: Uses cv2.connectedComponentsWithStats.
         <translation>LAB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="518"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="509"/>
         <source>Color space for histogram-based anomaly detection:
 
 RGB: Uses all 3 color channels. Fast, but sensitive to lighting.
@@ -3094,7 +3088,7 @@ LAB (a,b chromaticity): Uses a,b channels - lighting invariant, perceptually uni
         <translation>HSV Min Saturation:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="535"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="529"/>
         <source>Minimum saturation for HSV mode (0-255).
 Pixels below this saturation are ignored (grays, whites, blacks).
 These have undefined/noisy hue values.
@@ -3114,7 +3108,7 @@ Recommended: 30-50 for general use.</translation>
         <translation>LAB Min Chroma:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="555"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="549"/>
         <source>Minimum chroma (color intensity) for LAB mode (0-128).
 Chroma = distance from neutral gray in a,b plane.
 Pixels below this are ignored (near-neutral grays).
@@ -3139,7 +3133,7 @@ Recommended: 10-20 for general use.</translation>
         <translation>Allow Similar Colors (Hue Expansion)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="577"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="573"/>
         <source>Lets the detector treat similar colors as the same object.
 For example, a red jacket that looks slightly orange in some frames will still be grouped together.
 Turn this OFF if you only care about one very specific color shade.
@@ -3155,7 +3149,7 @@ Turn this ON if you want a whole family of colors (e.g., any warm reds/oranges).
         <translation>Color Match Range:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="590"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="586"/>
         <source>How wide to stretch the color match around each detected color.
 Smaller values = stay very close to the original color (more specific).
 Larger values = include a wider range of similar colors (more forgiving).
@@ -3181,7 +3175,7 @@ Recommended: low values for precise colors, higher values when lighting or camer
         <translation>Enable Color Exclusion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="609"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="605"/>
         <source>Exclude specific background colors from color anomaly detection.
 Useful for ignoring dominant scene colors such as grass, sky, or buildings.
 Click on the color wheel below to choose colors to ignore.
@@ -3197,7 +3191,7 @@ Selected colors are highlighted with a dark border.</translation>
         <translation>Click on color wheel to exclude colors (20° steps, 0-360°):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="621"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="618"/>
         <source>Click on any color segment to toggle exclusion on/off.
 Segments represent broad color ranges (e.g., blues, greens, reds).
 Use this to teach the system which background colors to ignore.</source>
@@ -3216,7 +3210,7 @@ Use this to teach the system which background colors to ignore.</translation>
         <translation>Enable Fusion (when both motion and color enabled)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="645"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="641"/>
         <source>Combines motion and color detections when both are enabled.
 Only active when both Motion and Color detection are ON.
 Different modes control how detections are merged.
@@ -3252,7 +3246,7 @@ Recommended: ON for robust multi-modal detection.</translation>
         <translation>MOTION_PRIORITY</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="666"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="657"/>
         <source>How to combine motion and color detections:
 
 • UNION: Show all detections from both (most detections).
@@ -3407,7 +3401,7 @@ Aggressive</translation>
         <translation>Add Color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="115"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="111"/>
         <source>Add a new color range to detect.
 Choose from HSV Color Picker, Image, List, or Recent Colors.
 You can add multiple color ranges to detect different colors simultaneously.</source>
@@ -3421,7 +3415,7 @@ You can add multiple color ranges to detect different colors simultaneously.</tr
         <translation>View Range</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="139"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="134"/>
         <source>View HSV color ranges for all configured colors.
 Opens a viewer dialog for each color range showing
 the hue, saturation, and value ranges that will be detected.
@@ -3442,7 +3436,7 @@ Useful for understanding and fine-tuning multi-color detection.</translation>
         <translation>Min Object Area (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="190"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="184"/>
         <source>Minimum detection area in pixels (10-50000).
 Filters out very small detections (noise, small objects, fragments).
 Lower values = detect smaller objects, more detections, more noise.
@@ -3460,7 +3454,7 @@ Recommended: 100 for general use, 50 for small objects, 200-500 for large object
         <translation>Max Object Area (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="205"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="199"/>
         <source>Maximum detection area in pixels (100-500000).
 Filters out very large detections (shadows, lighting changes, entire scene).
 Lower values = only small/medium objects.
@@ -3478,7 +3472,7 @@ Recommended: 100000 for general use, 50000 for small objects, 200000+ for large 
         <translation>Confidence Threshold:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="224"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="215"/>
         <source>Minimum confidence score to accept a detection (0-100%).
 Confidence is calculated from:
 • Size score: area relative to max area
@@ -3551,7 +3545,7 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>Color Ranges: {count} colors</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="330"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="329"/>
         <source>Please add at least one color to detect.</source>
         <translation>Please add at least one color to detect.</translation>
     </message>
@@ -3564,7 +3558,7 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>Hue Histogram Unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="59"/>
         <source>No color image data is available for the current image.</source>
         <translation>No color image data is available for the current image.</translation>
     </message>
@@ -3602,8 +3596,8 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>Visible Hue Range</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="65"/>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="174"/>
         <location filename="../resources/views/images/viewer/ColorHistogramDialog.ui" line="127"/>
         <source>Hover over the histogram to inspect a hue band.</source>
         <translation>Hover over the histogram to inspect a hue band.</translation>
@@ -3626,7 +3620,7 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>Reset Range</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="30"/>
         <source>No hue histogram data available</source>
         <translation>No hue histogram data available</translation>
     </message>
@@ -3681,8 +3675,8 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="57"/>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="62"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Uses</translation>
     </message>
@@ -3751,7 +3745,7 @@ Recommended: 50% for balanced filtering, 30% for more detections, 70% for strict
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="446"/>
+        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</translation>
     </message>
@@ -3811,7 +3805,7 @@ Use this to see what colors are going to be detected and optimize the color rang
         <translation>No Colors Selected</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="325"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="324"/>
         <source>Please add at least one color to detect.</source>
         <translation>Please add at least one color to detect.</translation>
     </message>
@@ -3839,7 +3833,7 @@ Use this to see what colors are going to be detected and optimize the color rang
         <translation>Original Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="219"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="216"/>
         <source>Original image preview.
 Shows the unmodified input image for reference.
 Use this to compare with the filtered result below.</source>
@@ -3853,7 +3847,7 @@ Use this to compare with the filtered result below.</translation>
         <translation>Filtered Result</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="232"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="228"/>
         <source>Filtered result preview.
 Shows pixels that match your current HSV color range settings.
 Updates in real-time as you adjust the color and range values.
@@ -3869,7 +3863,7 @@ Matching pixels are shown, non-matching pixels appear black.</translation>
         <translation>Show mask only</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="241"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="237"/>
         <source>Toggle between masked color result and grayscale mask.
 • Unchecked (default): Shows the original image with matching colors visible
 • Checked: Shows a black and white mask where white = matching pixels
@@ -3900,7 +3894,7 @@ Use the mask view to clearly see which pixels are being detected.</translation>
         <translation>Test on Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="273"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="270"/>
         <source>Test current HSV range settings on the loaded image.
 Manually triggers a preview update to see detection results.
 Preview updates automatically as you adjust settings.</source>
@@ -3914,7 +3908,7 @@ Preview updates automatically as you adjust settings.</translation>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="284"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="282"/>
         <source>Cancel color selection.
 Discards all changes and closes the dialog without applying the color range.</source>
         <translation>Cancel color selection.
@@ -3926,7 +3920,7 @@ Discards all changes and closes the dialog without applying the color range.</tr
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="292"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="289"/>
         <source>Apply color selection.
 Saves the current HSV color range settings and closes the dialog.
 The selected color range will be used for image analysis.</source>
@@ -4012,7 +4006,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>View Range</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="259"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="258"/>
         <source>Please add at least one color to detect.</source>
         <translation>Please add at least one color to detect.</translation>
     </message>
@@ -4096,7 +4090,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>North-Oriented View (Rotated {angle:.1f}°)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="445"/>
+        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="444"/>
         <source>Original bearing: {bearing:.1f}° | Rotation applied: {rotation:.1f}°</source>
         <translation>Original bearing: {bearing:.1f}° | Rotation applied: {rotation:.1f}°</translation>
     </message>
@@ -4144,7 +4138,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>Add Batches to Search</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="79"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="78"/>
         <source>Add more batch XML files to the current search project</source>
         <translation>Add more batch XML files to the current search project</translation>
     </message>
@@ -4169,7 +4163,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>Review Selected Batch</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="118"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="116"/>
         <source>Open the selected batch&apos;s results in the Viewer to review (same as double-clicking the batch).</source>
         <translation>Open the selected batch&apos;s results in the Viewer to review (same as double-clicking the batch).</translation>
     </message>
@@ -4288,7 +4282,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>No reviewers yet</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="315"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="312"/>
         <source>Batch review status and assignments. Load reviewer XMLs to update progress. Double-click a batch to open its results in the Viewer.</source>
         <translation>Batch review status and assignments. Load reviewer XMLs to update progress. Double-click a batch to open its results in the Viewer.</translation>
     </message>
@@ -4313,12 +4307,12 @@ Click on images to move them to the Selected section above.</translation>
         <translation>Reviews</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="329"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="328"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="350"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="349"/>
         <source>Consolidated AOI data from all reviews. Shows flag counts and reviewer comments.</source>
         <translation>Consolidated AOI data from all reviews. Shows flag counts and reviewer comments.</translation>
     </message>
@@ -4338,7 +4332,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>Flag Count</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="363"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="362"/>
         <source>Comments</source>
         <translation>Comments</translation>
     </message>
@@ -4348,7 +4342,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>New Search Project</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="381"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="380"/>
         <source>Enter project name:</source>
         <translation>Enter project name:</translation>
     </message>
@@ -4358,7 +4352,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>Coordinator Information</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="391"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="390"/>
         <source>Enter your name:</source>
         <translation>Enter your name:</translation>
     </message>
@@ -4373,7 +4367,7 @@ Click on images to move them to the Selected section above.</translation>
         <translation>Select Initial Batch XML Files</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="409"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="403"/>
         <source>You can select multiple ADIAT_Data.xml files from different folders.
 
 Tips:
@@ -4393,11 +4387,11 @@ Tips:
         <translation>Select Batch ADIAT_Data.xml Files (Hold Ctrl to select multiple)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="420"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="435"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="559"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="606"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="661"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="419"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="434"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="558"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="605"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="660"/>
         <source>XML Files (*.xml)</source>
         <translation>XML Files (*.xml)</translation>
     </message>
@@ -4433,7 +4427,7 @@ Tips:
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="454"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="453"/>
         <source>Failed to save project file.</source>
         <translation>Failed to save project file.</translation>
     </message>
@@ -4448,12 +4442,12 @@ Tips:
         <translation>Open Search Project</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="465"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="464"/>
         <source>Search Project Files (ADIAT_Search_*.xml);;All XML Files (*.xml)</source>
         <translation>Search Project Files (ADIAT_Search_*.xml);;All XML Files (*.xml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="475"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="474"/>
         <source>Project loaded successfully!</source>
         <translation>Project loaded successfully!</translation>
     </message>
@@ -4465,12 +4459,12 @@ Tips:
 {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="508"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="507"/>
         <source>Failed to load project file.</source>
         <translation>Failed to load project file.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="519"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="518"/>
         <source>Project saved successfully!</source>
         <translation>Project saved successfully!</translation>
     </message>
@@ -4485,7 +4479,7 @@ Tips:
         <translation>No Project</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="530"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="529"/>
         <source>Please create or open a project first.</source>
         <translation>Please create or open a project first.</translation>
     </message>
@@ -4500,7 +4494,7 @@ Tips:
         <translation>Add More Batch XML Files</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="547"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="540"/>
         <source>Select additional ADIAT_Data.xml batch files to add to this search.
 
 Tips:
@@ -4522,7 +4516,7 @@ Tips:
         <translation>Select Batch ADIAT_Data.xml Files to Add (Hold Ctrl to select multiple)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="581"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="579"/>
         <source>Successfully added {count} batch(es) to the project!
 Total batches: {total}</source>
         <translation>Successfully added {count} batch(es) to the project!
@@ -4534,7 +4528,7 @@ Total batches: {total}</translation>
         <translation>No Batches Added</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="593"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="591"/>
         <source>No batches were added. Check that the XML files are valid ADIAT_Data.xml files.</source>
         <translation>No batches were added. Check that the XML files are valid ADIAT_Data.xml files.</translation>
     </message>
@@ -4549,7 +4543,7 @@ Total batches: {total}</translation>
         <translation>No Batches</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="618"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="617"/>
         <source>No batches found in project.</source>
         <translation>No batches found in project.</translation>
     </message>
@@ -4564,12 +4558,12 @@ Total batches: {total}</translation>
         <translation>Which batch does this review belong to?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="643"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="642"/>
         <source>Review data loaded and merged successfully!</source>
         <translation>Review data loaded and merged successfully!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="649"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="648"/>
         <source>Failed to load review data.</source>
         <translation>Failed to load review data.</translation>
     </message>
@@ -4596,7 +4590,7 @@ Total batches: {total}</translation>
         <translation>No Batch Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="760"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="759"/>
         <source>Select a batch in the table, then click Review Selected Batch.</source>
         <translation>Select a batch in the table, then click Review Selected Batch.</translation>
     </message>
@@ -4609,7 +4603,7 @@ Total batches: {total}</translation>
         <translation>Generate Coverage Extent KML</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="131"/>
         <source>Generate a KML file showing the geographic coverage extent of all images?
 
 This will create polygon(s) representing the area covered by all images. Overlapping image areas will be merged into a single polygon.</source>
@@ -4623,7 +4617,7 @@ This will create polygon(s) representing the area covered by all images. Overlap
         <translation>Save Coverage Extent KML</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="148"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="147"/>
         <source>KML files (*.kml)</source>
         <translation>KML files (*.kml)</translation>
     </message>
@@ -4677,7 +4671,7 @@ This will create polygon(s) representing the area covered by all images. Overlap
         <translation>Coverage Extent</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="285"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="278"/>
         <source>Could not calculate coverage extent.
 
 Images processed: {processed}
@@ -4686,36 +4680,29 @@ Images skipped: {skipped}
 Images may be skipped for the following reasons:
   • Missing GPS data in EXIF
   • No valid GSD (missing altitude/focal length)
-  • Gimbal not nadir (must be -85° to -95°)</source>
-        <translation>Could not calculate coverage extent.
-
-Images processed: {processed}
-Images skipped: {skipped}
-
-Images may be skipped for the following reasons:
-  • Missing GPS data in EXIF
-  • No valid GSD (missing altitude/focal length)
-  • Gimbal not nadir (must be -85° to -95°)</translation>
+  • Gimbal not nadir (must be -85° to -95°;
+    WALDO: boresight within 40° of nadir)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="300"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="302"/>
         <source>{value:.2f} acres</source>
         <translation>{value:.2f} acres</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="305"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="306"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="307"/>
         <source>{value:.3f} km²</source>
         <translation>{value:.3f} km²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="309"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="310"/>
         <source>Coverage extent KML saved: {area}</source>
         <translation>Coverage extent KML saved: {area}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="324"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="319"/>
         <source>
 
 Images may be skipped for:
@@ -4730,12 +4717,12 @@ Images may be skipped for:
   • Gimbal not nadir</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="327"/>
         <source>Coverage Extent KML Generated</source>
         <translation>Coverage Extent KML Generated</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="334"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="329"/>
         <source>Coverage extent KML file created successfully!
 
 File: {file}
@@ -4883,7 +4870,7 @@ thumb</translation>
 <context>
     <name>FlightMapView</name>
     <message>
-        <location filename="../app/core/views/components/FlightMapView.py" line="553"/>
+        <location filename="../app/core/views/components/FlightMapView.py" line="550"/>
         <source>QtWebEngine not available — install PySide6-Addons for the interactive map. Showing list view instead.</source>
         <translation type="unfinished">QtWebEngine not available — install PySide6-Addons for the interactive map. Showing list view instead.</translation>
     </message>
@@ -4942,7 +4929,7 @@ thumb</translation>
         <translation>drone has {current}/{limit} viewers</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="99"/>
+        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="98"/>
         <source>known device — same fingerprint as last pair</source>
         <translation>known device — same fingerprint as last pair</translation>
     </message>
@@ -4991,7 +4978,7 @@ thumb</translation>
         <translation>Rename Feed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightTile.py" line="526"/>
+        <location filename="../app/core/views/flight/FlightTile.py" line="524"/>
         <source>Nickname for this drone (persists across new pairing codes via the aircraft serial number). Leave blank to clear.</source>
         <translation>Nickname for this drone (persists across new pairing codes via the aircraft serial number). Leave blank to clear.</translation>
     </message>
@@ -5123,7 +5110,7 @@ thumb</translation>
 <context>
     <name>FlightTileController</name>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="219"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="218"/>
         <source>Looking up code {code} and connecting to the drone.</source>
         <translation>Looking up code {code} and connecting to the drone.</translation>
     </message>
@@ -5133,12 +5120,12 @@ thumb</translation>
         <translation>Name this device</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="297"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="295"/>
         <source>Give this publisher a name so you can recognise it next time (e.g. &apos;Operator A&apos;s M4E&apos;).</source>
         <translation>Give this publisher a name so you can recognise it next time (e.g. &apos;Operator A&apos;s M4E&apos;).</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="318"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="313"/>
         <source>Device &apos;{label}&apos; presented a different DTLS fingerprint than the last time you paired with it. This could mean the controller was reset, a different controller is using the label, or somebody is impersonating it.
 
 Reject if you weren&apos;t expecting this.</source>
@@ -5147,12 +5134,12 @@ Reject if you weren&apos;t expecting this.</source>
 Reject if you weren&apos;t expecting this.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="483"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="480"/>
         <source>Pairing ended before video could start. Ask the operator to generate a new code and try again.</source>
         <translation>Pairing ended before video could start. Ask the operator to generate a new code and try again.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1007"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1006"/>
         <source>Waiting for video before recording can start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5172,7 +5159,7 @@ Reject if you weren&apos;t expecting this.</translation>
         <translation type="unfinished">Recording saved</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1157"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1156"/>
         <source>No finished recording to replay yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5192,12 +5179,12 @@ Reject if you weren&apos;t expecting this.</translation>
         <translation>Fingerprint mismatch — &apos;{label}&apos;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="332"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="330"/>
         <source>Fingerprint changed on {ts}; previous identity was overwritten after operator review.</source>
         <translation>Fingerprint changed on {ts}; previous identity was overwritten after operator review.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="425"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="422"/>
         <source>This drone already has {current} viewers connected (maximum {limit}). Ask one to disconnect, or try again later.</source>
         <translation>This drone already has {current} viewers connected (maximum {limit}). Ask one to disconnect, or try again later.</translation>
     </message>
@@ -5210,7 +5197,7 @@ Reject if you weren&apos;t expecting this.</translation>
         <translation>New flight session</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="558"/>
+        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="555"/>
         <source>Mobile started a new flight under code {code}. The previous session&apos;s detections are still saved on this computer. Discard them, or keep them archived?</source>
         <translation>Mobile started a new flight under code {code}. The previous session&apos;s detections are still saved on this computer. Discard them, or keep them archived?</translation>
     </message>
@@ -5378,7 +5365,7 @@ Reject if you weren&apos;t expecting this.</translation>
         <translation>Enable Processing Region Mask</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="55"/>
         <source>Enable to restrict detection processing to a specific region of the video.
 Useful for excluding edges, UI overlays, or focusing on specific areas.
 Improves performance by not processing masked regions.</source>
@@ -5392,7 +5379,7 @@ Improves performance by not processing masked regions.</translation>
         <translation>Enable Frame Buffer</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="72"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="69"/>
         <source>Exclude a uniform border from all edges of the video.
 Enter the number of pixels to exclude from each edge.
 The inner area will be processed for detections.</source>
@@ -5411,7 +5398,7 @@ The inner area will be processed for detections.</translation>
         <translation>Buffer (pixels):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="91"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="87"/>
         <source>Number of pixels to exclude from all edges (0-1000).
 A value of 50 excludes 50 pixels from top, bottom, left, and right.
 Useful for removing UI overlays or camera lens distortion at edges.
@@ -5427,7 +5414,7 @@ This value is based on the original video resolution.</translation>
         <translation>Enable Image Mask</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="102"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="99"/>
         <source>Load a black/white image as a custom mask.
 White areas will be processed, black areas excluded.
 The mask will be scaled to match the video resolution.</source>
@@ -5483,7 +5470,7 @@ The mask will be scaled to match the video resolution.</translation>
         <translation>Show mask overlay on video</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="142"/>
         <source>Display the processing region on the rendered video.
 Frame mode: Shows a cyan rectangle outline of the processed area.
 Image mask: Shows a semi-transparent overlay of excluded regions.</source>
@@ -5502,7 +5489,7 @@ Image mask: Shows a semi-transparent overlay of excluded regions.</translation>
         <translation>{error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="231"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="229"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>Could not load the selected image. Please choose a valid image file.</translation>
     </message>
@@ -5512,7 +5499,7 @@ Image mask: Shows a semi-transparent overlay of excluded regions.</translation>
         <translation>Aspect Ratio Mismatch</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="243"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="240"/>
         <source>{error}
 
 The mask will be scaled to fit, which may cause distortion.
@@ -5533,7 +5520,7 @@ Do you want to continue?</translation>
         <translation>No GPS data found in images</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="192"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="191"/>
         <source>POD overlay cleared — the elevation/canopy source changed. Recalculate to refresh it.</source>
         <translation>POD overlay cleared — the elevation/canopy source changed. Recalculate to refresh it.</translation>
     </message>
@@ -5548,17 +5535,17 @@ Do you want to continue?</translation>
         <translation>Calculate POD Coverage?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="235"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="234"/>
         <source>Coverage data is ready. Calculate the probability-of-detection heatmap for this mission now? (May take several minutes.)</source>
         <translation>Coverage data is ready. Calculate the probability-of-detection heatmap for this mission now? (May take several minutes.)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="293"/>
         <source>Your local USGS 3DEP tiles only partially cover this mission.</source>
         <translation>Your local USGS 3DEP tiles only partially cover this mission.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
         <source>Your local USGS 3DEP tiles do not cover this mission.</source>
         <translation>Your local USGS 3DEP tiles do not cover this mission.</translation>
     </message>
@@ -5568,7 +5555,7 @@ Do you want to continue?</translation>
         <translation>Local Elevation Coverage</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="302"/>
         <source>Frames outside the local tiles will use online AWS Terrain Tiles (~30 m) elevation instead. You can download 1 m tiles for this area first, or continue with the fallback.</source>
         <translation>Frames outside the local tiles will use online AWS Terrain Tiles (~30 m) elevation instead. You can download 1 m tiles for this area first, or continue with the fallback.</translation>
     </message>
@@ -5598,7 +5585,7 @@ Do you want to continue?</translation>
         <translation>Download Canopy Data?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="391"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="386"/>
         <source>No canopy-height data is configured for this mission.
 
 Download elevation and canopy tiles for this area now so the canopy overlay and terrain-aware detection coverage can use them?
@@ -5641,7 +5628,7 @@ This downloads Meta/WRI canopy height (1 m) and sets it as the canopy source, re
         <translation>Unknown</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="603"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="602"/>
         <source>Altitude basis: reported ATO (approximate over terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5683,7 +5670,7 @@ This downloads Meta/WRI canopy height (1 m) and sets it as the canopy source, re
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1297"/>
         <source>Move this AOI to {lat:.6f}, {lon:.6f}?
 
 That is {dist:.1f} m from its previous position. The corrected location is saved with the results and used for exports.</source>
@@ -5804,17 +5791,17 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Calculate POD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Compute the terrain-aware probability-of-detection heatmap for this mission (may take several minutes)</source>
         <translation>Compute the terrain-aware probability-of-detection heatmap for this mission (may take several minutes)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="189"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="188"/>
         <source>Click point to select • Drag to pan • Scroll to zoom • Drag AOI marker to correct its location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="274"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="273"/>
         <source>Downloading tiles is disabled in Offline Only mode</source>
         <translation>Downloading tiles is disabled in Offline Only mode</translation>
     </message>
@@ -5839,7 +5826,7 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Map Tile Loading Issue</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="394"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5861,12 +5848,12 @@ The map will continue to work with cached tiles where available.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1422"/>
         <source>Position corrected by user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1424"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
         <source>Drag to correct the location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5890,7 +5877,7 @@ The map will continue to work with cached tiles where available.</translation>
         <translation>AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="411"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="410"/>
         <source>AOIs</source>
         <translation>AOIs</translation>
     </message>
@@ -5901,12 +5888,12 @@ The map will continue to work with cached tiles where available.</translation>
         <translation>{count} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="431"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="430"/>
         <source>Area of Interest</source>
         <translation>Area of Interest</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="433"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="432"/>
         <source>Areas of Interest</source>
         <translation>Areas of Interest</translation>
     </message>
@@ -5914,7 +5901,7 @@ The map will continue to work with cached tiles where available.</translation>
 <context>
     <name>GeneralSettingsPage</name>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="122"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="121"/>
         <source>Select AOI Highlight Color</source>
         <translation>Select AOI Highlight Color</translation>
     </message>
@@ -5924,7 +5911,7 @@ The map will continue to work with cached tiles where available.</translation>
         <translation>Benchmark Complete</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="164"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="161"/>
         <source>Detected {count} CPU core(s).
 
 Recommended number of processes: {recommended}
@@ -5955,7 +5942,7 @@ The slider has been set to {recommended} processes.</translation>
         <translation>Apply Grid to All Images</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="322"/>
         <source>{n} image(s) already have review progress recorded at a different grid size.
 
 Reset their progress and apply {rows}×{cols} to them too?
@@ -5973,7 +5960,7 @@ Yes resets them; No keeps them at their current size.</translation>
         <translation>Image fully reviewed — advancing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="629"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="628"/>
         <source>cell {cell}/{cells} — image {image}/{images} — run {percent}% reviewed</source>
         <translation>cell {cell}/{cells} — image {image}/{images} — run {percent}% reviewed</translation>
     </message>
@@ -5981,7 +5968,7 @@ Yes resets them; No keeps them at their current size.</translation>
 <context>
     <name>GridReviewDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="52"/>
         <source>Suggested: {rows}×{cols} (person ≈ {px} px on screen at cell zoom)</source>
         <translation>Suggested: {rows}×{cols} (person ≈ {px} px on screen at cell zoom)</translation>
     </message>
@@ -6265,7 +6252,7 @@ Use this to see what colors are going to be detected and optimize the color rang
         <translation>HSV Color Range Assistant - Click Selection</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="709"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="694"/>
         <source>Interactive image viewer with color selection.
 
 NAVIGATION:
@@ -6309,7 +6296,7 @@ DISPLAY:
         <translation>Browse...</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="748"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="743"/>
         <source>Browse for an image file to load.
 Opens a file dialog to select an image from your computer.
 • Supported formats: PNG, JPG, JPEG, BMP
@@ -6327,7 +6314,7 @@ The image will be displayed in the main viewer on the left.</translation>
         <translation>Reset</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="761"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="755"/>
         <source>Reset all selections and start over.
 • Clears all selected pixels (white overlay)
 • Resets HSV ranges to defaults
@@ -6347,14 +6334,14 @@ Use this to start fresh without reloading the image.</translation>
         <translation>Selection Radius:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="770"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="768"/>
         <source>Size of the circular selection cursor.
 Determines how many pixels are sampled when you CTRL+Click.</source>
         <translation>Size of the circular selection cursor.
 Determines how many pixels are sampled when you CTRL+Click.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="788"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="777"/>
         <source>Set the selection cursor radius in pixels.
 • Range: 1-50 pixels
 • Default: 1 pixel (single pixel selection)
@@ -6384,14 +6371,14 @@ Keyboard shortcuts: [ decrease, ] increase by 2 pixels</translation>
         <translation>Color Tolerance:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="797"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="795"/>
         <source>HSV color matching tolerance.
 Controls how similar colors must be to get selected.</source>
         <translation>HSV color matching tolerance.
 Controls how similar colors must be to get selected.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="817"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="803"/>
         <source>Set color tolerance for similar pixel detection.
 • Range: 0-50
 • Default: 2
@@ -6422,7 +6409,7 @@ Lower tolerance:
 • May miss some pixels of target color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="826"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="825"/>
         <source>CTRL+Click: Select similar colors | CTRL+SHIFT+Click: Remove | [ ] : Radius</source>
         <translation>CTRL+Click: Select similar colors | CTRL+SHIFT+Click: Remove | [ ] : Radius</translation>
     </message>
@@ -6432,7 +6419,7 @@ Lower tolerance:
         <translation>Help</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="840"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="833"/>
         <source>Show detailed help and instructions.
 Opens a dialog with:
 • Step-by-step usage instructions
@@ -6454,7 +6441,7 @@ Click here if you&apos;re unsure how to use this tool.</translation>
         <translation>Selected Color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="863"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="861"/>
         <source>Average color of all selected pixels.
 Shows the center/mean color that will be used for HSV range detection.</source>
         <translation>Average color of all selected pixels.
@@ -6466,14 +6453,14 @@ Shows the center/mean color that will be used for HSV range detection.</translat
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="870"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="868"/>
         <source>Visual preview of the average selected color.
 This is the center color calculated from all selected pixels.</source>
         <translation>Visual preview of the average selected color.
 This is the center color calculated from all selected pixels.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="878"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="876"/>
         <source>Color swatch showing the average of all selected pixels.
 This becomes the center color for HSV range detection.</source>
         <translation>Color swatch showing the average of all selected pixels.
@@ -6485,14 +6472,14 @@ This becomes the center color for HSV range detection.</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="885"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="883"/>
         <source>Hexadecimal representation of the selected color.
 Format: #RRGGBB</source>
         <translation>Hexadecimal representation of the selected color.
 Format: #RRGGBB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="891"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="889"/>
         <source>Hex color code of the average selected color.
 Can be used to identify the exact RGB color value.</source>
         <translation>Hex color code of the average selected color.
@@ -6504,14 +6491,14 @@ Can be used to identify the exact RGB color value.</translation>
         <translation>HSV:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="898"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="896"/>
         <source>HSV values of the selected color.
 H = Hue (0-360°), S = Saturation (0-100%), V = Value (0-100%)</source>
         <translation>HSV values of the selected color.
 H = Hue (0-360°), S = Saturation (0-100%), V = Value (0-100%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="904"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="902"/>
         <source>HSV color values of the average selected color.
 This is the center point of your color range.</source>
         <translation>HSV color values of the average selected color.
@@ -6523,7 +6510,7 @@ This is the center point of your color range.</translation>
         <translation>HSV Ranges</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="916"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="912"/>
         <source>HSV color range configuration.
 Defines the detection range for each HSV channel.
 Center values are calculated from selected pixels.
@@ -6594,7 +6581,7 @@ Buffer values add extra tolerance to catch color variations.</translation>
         <translation>Hue channel (color type): 0-360 degrees on color wheel</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="950"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="947"/>
         <source>Center hue value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-360° (red=0°, green=120°, blue=240°)</source>
@@ -6603,7 +6590,7 @@ Automatically calculated from your selection.
 Range: 0-360° (red=0°, green=120°, blue=240°)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="963"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="957"/>
         <source>Hue lower bound buffer (subtract from center).
 • Range: 0-360°
 • Adds tolerance below the center hue
@@ -6618,7 +6605,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="977"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="971"/>
         <source>Hue upper bound buffer (add to center).
 • Range: 0-360°
 • Adds tolerance above the center hue
@@ -6633,7 +6620,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="986"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="983"/>
         <source>Final hue detection range.
 Shows the complete min-max hue range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6647,7 +6634,7 @@ Calculated as: (center - minus buffer) to (center + plus buffer)</translation>
         <translation>WARNING: Too wide of a Hue range can result in false positives!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="998"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="994"/>
         <source>Hue range warning.
 Your total hue range exceeds 60°.
 Wide hue ranges may detect many different colors.
@@ -6668,7 +6655,7 @@ Consider narrowing the buffers for more accurate detection.</translation>
         <translation>Saturation channel (color intensity): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1011"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1008"/>
         <source>Center saturation value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=gray, 100%=vivid color)</source>
@@ -6677,7 +6664,7 @@ Automatically calculated from your selection.
 Range: 0-100% (0%=gray, 100%=vivid color)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1024"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1018"/>
         <source>Saturation lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center saturation
@@ -6692,7 +6679,7 @@ WARNING: Lower bound &lt; 25% may include unwanted gray/desaturated colors</sour
 WARNING: Lower bound &lt; 25% may include unwanted gray/desaturated colors</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1037"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1032"/>
         <source>Saturation upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center saturation
@@ -6705,7 +6692,7 @@ WARNING: Lower bound &lt; 25% may include unwanted gray/desaturated colors</tran
 • Higher saturation generally safe to increase</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1046"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1043"/>
         <source>Final saturation detection range.
 Shows the complete min-max saturation range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6719,7 +6706,7 @@ Calculated as: (center - minus buffer) to (center + plus buffer)</translation>
         <translation>WARNING: Too low of a Saturation level can result in false positives!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1058"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1054"/>
         <source>Saturation range warning.
 Your lower saturation bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -6740,7 +6727,7 @@ May detect unwanted gray or desaturated objects.</translation>
         <translation>Value channel (brightness): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1071"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1068"/>
         <source>Center value/brightness (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=black, 100%=bright)</source>
@@ -6749,7 +6736,7 @@ Automatically calculated from your selection.
 Range: 0-100% (0%=black, 100%=bright)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1084"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1078"/>
         <source>Value lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center brightness
@@ -6764,7 +6751,7 @@ WARNING: Lower bound &lt; 25% may include unwanted shadows or dark objects</sour
 WARNING: Lower bound &lt; 25% may include unwanted shadows or dark objects</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1097"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1092"/>
         <source>Value upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center brightness
@@ -6777,7 +6764,7 @@ WARNING: Lower bound &lt; 25% may include unwanted shadows or dark objects</tran
 • Higher brightness generally safe to increase</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1106"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1103"/>
         <source>Final value/brightness detection range.
 Shows the complete min-max brightness range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6791,7 +6778,7 @@ Calculated as: (center - minus buffer) to (center + plus buffer)</translation>
         <translation>WARNING: Too low of a Value level can result in false positives!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1118"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1114"/>
         <source>Value range warning.
 Your lower value bound is below 25%.
 Low value includes very dark colors.
@@ -6807,7 +6794,7 @@ May detect unwanted shadows or dark objects.</translation>
         <translation>Statistics</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1128"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1126"/>
         <source>Statistics about your current selection.
 Shows how many pixels are selected and what percentage of the image they represent.</source>
         <translation>Statistics about your current selection.
@@ -6820,7 +6807,7 @@ Shows how many pixels are selected and what percentage of the image they represe
         <translation>Selected Pixels: 0</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1135"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1132"/>
         <source>Number of pixels currently selected.
 Shows the total count of white-highlighted pixels in the main viewer.
 Updates in real-time as you select colors.</source>
@@ -6835,7 +6822,7 @@ Updates in real-time as you select colors.</translation>
         <translation>Coverage: 0%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1143"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1139"/>
         <source>Percentage of image covered by selection.
 Shows what portion of the total image is selected.
 • Low %: Precise selection, may miss some target pixels
@@ -6851,14 +6838,14 @@ Shows what portion of the total image is selected.
         <translation>Mask Preview</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1152"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1150"/>
         <source>Black and white preview of the detection mask.
 Shows what pixels will be detected with current HSV ranges and buffers.</source>
         <translation>Black and white preview of the detection mask.
 Shows what pixels will be detected with current HSV ranges and buffers.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1166"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1161"/>
         <source>Grayscale mask preview.
 • White pixels: Will be detected with current settings
 • Black pixels: Will NOT be detected
@@ -6876,7 +6863,7 @@ Use this to verify your HSV range captures the target without false positives.</
         <translation>Select Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1180"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp)</source>
         <translation>Images (*.png *.jpg *.jpeg *.bmp)</translation>
     </message>
@@ -6891,7 +6878,7 @@ Use this to verify your HSV range captures the target without false positives.</
         <translation>Coverage: {0:.1f}%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1503"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1476"/>
         <source>
 &lt;h2&gt;HSV Color Range Assistant - Help&lt;/h2&gt;
 
@@ -6959,8 +6946,8 @@ Click on the BROWSE button to open an image.&lt;/p&gt;
         <translation>No Colors Selected</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="121"/>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="126"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="125"/>
         <source>Add Color</source>
         <translation>Add Color</translation>
     </message>
@@ -6970,7 +6957,7 @@ Click on the BROWSE button to open an image.&lt;/p&gt;
         <translation>Hue Expansion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="178"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -6979,7 +6966,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 Pixels with saturation below {1}% or value below {2}% are excluded.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="469"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="468"/>
         <source>Please add at least one color to detect.</source>
         <translation>Please add at least one color to detect.</translation>
     </message>
@@ -7010,7 +6997,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</translation
         <translation>Hue Expansion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="104"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="101"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -7019,7 +7006,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 Pixels with saturation below {1}% or value below {2}% are excluded.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="409"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="408"/>
         <source>Please add at least one color to detect.</source>
         <translation>Please add at least one color to detect.</translation>
     </message>
@@ -7048,14 +7035,14 @@ Tolerance:</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="95"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="93"/>
         <source>Hexadecimal color code input.
 Enter colors as hex codes (e.g., #FF0000 for red).</source>
         <translation>Hexadecimal color code input.
 Enter colors as hex codes (e.g., #FF0000 for red).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="107"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="102"/>
         <source>Enter a hexadecimal color code.
 • Format: #RRGGBB (e.g., #FF0000 for red, #00FF00 for green)
 • Also accepts short format: #RGB (e.g., #F00 for red)
@@ -7073,7 +7060,7 @@ The color will be converted to HSV automatically.</translation>
         <translation>Reset to Default</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="114"/>
         <source>Reset to default color and ranges.
 • Color: Pure red (H:0°, S:100%, V:100%)
 • Hue range: ±20° (total 40° range)
@@ -7093,7 +7080,7 @@ Use this to start over with standard settings.</translation>
         <translation>Saturation / Value</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="144"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="141"/>
         <source>Saturation and Value (brightness) selector.
 Saturation controls color intensity (left=gray, right=vivid).
 Value controls brightness (bottom=dark, top=bright).</source>
@@ -7102,7 +7089,7 @@ Saturation controls color intensity (left=gray, right=vivid).
 Value controls brightness (bottom=dark, top=bright).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="157"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="149"/>
         <source>Interactive Saturation/Value selector.
 • Click anywhere to set the center color&apos;s saturation and brightness
 • White circle = current center color position
@@ -7126,14 +7113,14 @@ Larger ranges detect more color variations but may include unwanted colors.</tra
         <translation>Hue</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="171"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="169"/>
         <source>Hue (color type) selector.
 Hue represents the actual color: red, orange, yellow, green, cyan, blue, purple, magenta.</source>
         <translation>Hue (color type) selector.
 Hue represents the actual color: red, orange, yellow, green, cyan, blue, purple, magenta.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="184"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="176"/>
         <source>Interactive Hue color ring selector.
 • Click on the ring to select a hue (color type)
 • White line = current center hue
@@ -7157,7 +7144,7 @@ Warning: Hue ranges wider than 60° may detect too many colors.</translation>
         <translation>Use Image</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="215"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="208"/>
         <source>Open HSV Color Range Assistant.
 Advanced tool for selecting colors from an image:
 • Load an image from your input folder
@@ -7179,7 +7166,7 @@ Recommended for finding the best color range for your target.</translation>
         <translation>Pick Screen Color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="228"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="222"/>
         <source>Pick a color from anywhere on your screen.
 Opens a color picker that lets you:
 • Click anywhere on your screen to sample a color
@@ -7199,7 +7186,7 @@ Ranges remain unchanged - adjust manually after picking.</translation>
         <translation>Add to Custom Colors</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="241"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="235"/>
         <source>Save current color to Custom Colors palette.
 Adds the current center color to the first empty slot in Custom Colors.
 • Only saves the color, not the ranges
@@ -7219,7 +7206,7 @@ Useful for building a palette of frequently used colors.</translation>
         <translation>Basic Colors:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="259"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="256"/>
         <source>Preset basic color palette.
 Quick access to common colors like red, orange, yellow, green, cyan, blue, purple, and grayscale.
 Click any color swatch to set it as the center color.</source>
@@ -7228,7 +7215,7 @@ Quick access to common colors like red, orange, yellow, green, cyan, blue, purpl
 Click any color swatch to set it as the center color.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="269"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="264"/>
         <source>Basic color swatches.
 Click any color to quickly set it as your center color.
 • Top row: Primary colors and tints
@@ -7246,7 +7233,7 @@ Useful for quickly selecting standard colors.</translation>
         <translation>Custom Colors:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="280"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="277"/>
         <source>Your saved custom color palette.
 Colors you&apos;ve saved using &apos;Add to Custom Colors&apos; button.
 Click any saved color to reuse it.</source>
@@ -7255,7 +7242,7 @@ Colors you&apos;ve saved using &apos;Add to Custom Colors&apos; button.
 Click any saved color to reuse it.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="291"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="285"/>
         <source>Custom color swatches.
 Click any color to set it as your center color.
 • Empty slots shown as gray
@@ -7270,7 +7257,7 @@ Click any color to set it as your center color.
 Build your own palette of frequently used colors.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="464"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="461"/>
         <source>Current HSV color range summary.
 Shows the center color and detection ranges in real-time.
 Warning indicators appear when ranges may cause detection issues.</source>
@@ -7294,7 +7281,7 @@ Warning indicators appear when ranges may cause detection issues.</translation>
         <translation>Sat Range:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="471"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="470"/>
         <source>Val Range:</source>
         <translation>Val Range:</translation>
     </message>
@@ -7320,7 +7307,7 @@ Warning shown if lower bound &lt; 25%.</source>
 Warning shown if lower bound &lt; 25%.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="477"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="475"/>
         <source>Value detection range (minus/plus from center).
 Warning shown if lower bound &lt; 25%.</source>
         <translation>Value detection range (minus/plus from center).
@@ -7332,7 +7319,7 @@ Warning shown if lower bound &lt; 25%.</translation>
         <translation>⚠ Too wide!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="506"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="502"/>
         <source>Hue range warning.
 Your hue range is wider than 60° total.
 Wide hue ranges may detect too many different colors.
@@ -7349,7 +7336,7 @@ Consider narrowing the range for more accurate detection.</translation>
         <translation>⚠ Too low!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="519"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="515"/>
         <source>Saturation range warning.
 Your saturation lower bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -7360,7 +7347,7 @@ Low saturation includes grayish/washed out colors.
 May detect unintended gray or desaturated colors.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="532"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="528"/>
         <source>Value range warning.
 Your value lower bound is below 25%.
 Low value includes very dark colors.
@@ -7409,7 +7396,7 @@ May detect shadows or dark unintended objects.</translation>
         <translation>High (400)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="117"/>
+        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="114"/>
         <source>Hot zones (colored) show high-density detection areas. Gray zones are below the threshold. Adjust the threshold to control what counts as a hot zone.</source>
         <translation>Hot zones (colored) show high-density detection areas. Gray zones are below the threshold. Adjust the threshold to control what counts as a hot zone.</translation>
     </message>
@@ -7783,7 +7770,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>• Focal length is required (available from image EXIF data)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="486"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="485"/>
         <source>GSD calculation requires an actual image file to extract focal length.</source>
         <translation>GSD calculation requires an actual image file to extract focal length.</translation>
     </message>
@@ -7803,7 +7790,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Primary</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="529"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="527"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
@@ -7844,7 +7831,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Custom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="65"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="61"/>
         <source>Select a preset resolution for processing. Lower resolutions are faster but less detailed.
 &apos;Original&apos; uses the video&apos;s native resolution (no downsampling).
 720P (1280x720) provides excellent balance between speed and detection accuracy.
@@ -7860,7 +7847,7 @@ Select &apos;Custom&apos; to manually set width and height.</translation>
         <translation>Width:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="81"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="78"/>
         <source>Custom processing width in pixels (320-3840).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7874,7 +7861,7 @@ Lower values = faster processing, less detail.</translation>
         <translation>Height:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="94"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="91"/>
         <source>Custom processing height in pixels (240-2160).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7898,7 +7885,7 @@ Lower values = faster processing, less detail.</translation>
         <translation>Source FPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="143"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="133"/>
         <source>Limit the frame rate for processing.
 
 • Source FPS - Follow the source cadence (live sources may apply a safety cap)
@@ -7930,7 +7917,7 @@ Detections persist between skipped frames for visual continuity.</translation>
         <translation>Render at Processing Resolution (faster for high-res)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="155"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="151"/>
         <source>Renders detection overlays at processing resolution instead of original video resolution.
 Significantly faster for high-resolution videos (1080p+) with minimal visual impact.
 Example: Processing at 720p but video is 4K - renders at 720p then upscales.
@@ -8180,7 +8167,7 @@ Lower values = more sensitive detection.</translation>
         <translation>Threshold Expansion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="53"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="50"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8194,7 +8181,7 @@ pixels outside are added if they are connected through other qualifying pixels.<
         <translation>Hue Expansion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="62"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="59"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -8273,7 +8260,7 @@ Aggressive</translation>
         <translation>Threshold Expansion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="72"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="69"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8287,7 +8274,7 @@ pixels outside are added if they are connected through other qualifying pixels.<
         <translation>Hue Expansion</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="81"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="78"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -9306,12 +9293,12 @@ Ask questions, report issues, and suggest new features.</translation>
         <translation>YouTube Channel</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="90"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="89"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="326"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="288"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -9388,7 +9375,7 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
   • Limitation: Only detects people, slower processing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="385"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="384"/>
         <source>Select AOI Highlight Color</source>
         <translation>Select AOI Highlight Color</translation>
     </message>
@@ -9404,7 +9391,7 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>Select a Reference Image</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="435"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Images (*.png *.jpg)</translation>
     </message>
@@ -9415,21 +9402,21 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>Value Adjusted</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="500"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="498"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="532"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="530"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="645"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="644"/>
         <source>Please set the input and output directories.</source>
         <translation>Please set the input and output directories.</translation>
     </message>
@@ -9439,12 +9426,12 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>--- Starting image processing ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="886"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="909"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="908"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Area of Interest Limit ({limit}) exceeded. Continue?</translation>
     </message>
@@ -9507,7 +9494,7 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>Select File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1155"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>XML Files (*.xml);;All Files (*)</translation>
     </message>
@@ -9527,7 +9514,7 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>No Results Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1232"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1231"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>No ADIAT_DATA.XML files were found in the selected folder.</translation>
     </message>
@@ -9611,12 +9598,12 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation> Open Search Coordinator</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1779"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1778"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Open the Search Coordinator to review every batch in this run.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1785"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1784"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Open the Results Viewer to review detection results.</translation>
     </message>
@@ -9727,7 +9714,7 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>POD coverage heatmap (terrain-aware)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
         <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). KML exports embed the heatmap in the KML/KMZ as an image overlay; the GeoTIFF products (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json) are also written — the GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
         <translation>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). KML exports embed the heatmap in the KML/KMZ as an image overlay; the GeoTIFF products (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json) are also written — the GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</translation>
     </message>
@@ -9772,7 +9759,7 @@ AI PERSON DETECTOR: Deep learning model for accurate people detection
         <translation>Both</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="145"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="142"/>
         <source>Large Image uploads the same multi-zoom composite used in the PDF report
 (full image with 3x and 6x insets). AOI Thumbnail uploads a zoomed crop
 centered on the detection. Both uploads each.</source>
@@ -9841,7 +9828,7 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>No Colors Selected</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="300"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="299"/>
         <source>Please add at least one color to detect.</source>
         <translation>Please add at least one color to detect.</translation>
     </message>
@@ -9867,7 +9854,7 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>View Range</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="219"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="218"/>
         <source>Please add at least one target color to detect.</source>
         <translation>Please add at least one target color to detect.</translation>
     </message>
@@ -9886,7 +9873,7 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>Measure Shadow</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="90"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="87"/>
         <source>When checked, the two clicks estimate the height of a vertical object from its shadow. Click the base of the object first, then the tip of its shadow.</source>
         <translation>When checked, the two clicks estimate the height of a vertical object from its shadow. Click the base of the object first, then the tip of its shadow.</translation>
     </message>
@@ -9937,17 +9924,17 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>Use Anyway</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="140"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="137"/>
         <source>Force the estimate with the current base/tip clicks even though the drawn line doesn&apos;t match the expected shadow direction. Use only when you&apos;re confident the geometry is correct.</source>
         <translation>Force the estimate with the current base/tip clicks even though the drawn line doesn&apos;t match the expected shadow direction. Use only when you&apos;re confident the geometry is correct.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="181"/>
         <source>Click the BASE of the object first, then the TIP of its shadow.</source>
         <translation>Click the BASE of the object first, then the TIP of its shadow.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="187"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="185"/>
         <source>Click on the image to place the first point,
 then click again to place the second point.</source>
         <translation>Click on the image to place the first point,
@@ -9975,7 +9962,7 @@ then click again to place the second point.</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="467"/>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="553"/>
         <source>Rejected</source>
         <translation>Rejected</translation>
     </message>
@@ -10107,7 +10094,7 @@ then click again to place the second point.</translation>
         <translation type="unfinished">Unknown</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="177"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="175"/>
         <source> (Current)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10129,7 +10116,7 @@ then click again to place the second point.</translation>
         <translation>No Images to Export</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="156"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="153"/>
         <source>There are no images available to include in the PDF report.
 
 All images may be hidden or there are no images in the dataset.</source>
@@ -10138,7 +10125,7 @@ All images may be hidden or there are no images in the dataset.</source>
 All images may be hidden or there are no images in the dataset.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="166"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="162"/>
         <source>There are no images with flagged AOIs to include in the PDF report.
 
 Please flag at least one AOI, or check &apos;Include images without flagged AOIs&apos; to include all images in the report.</source>
@@ -10152,7 +10139,7 @@ Please flag at least one AOI, or check &apos;Include images without flagged AOIs
         <translation>Save PDF File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="175"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="174"/>
         <source>PDF files (*.pdf)</source>
         <translation>PDF files (*.pdf)</translation>
     </message>
@@ -10177,7 +10164,7 @@ Please flag at least one AOI, or check &apos;Include images without flagged AOIs
         <translation>Success</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="278"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="277"/>
         <source>PDF report generated successfully!</source>
         <translation>PDF report generated successfully!</translation>
     </message>
@@ -10235,7 +10222,7 @@ Please flag at least one AOI, or check &apos;Include images without flagged AOIs
         <translation>Include images without flagged AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="62"/>
         <source>When checked, all images will be included in the PDF report, even if they don&apos;t have any flagged AOIs. When unchecked, only images with flagged AOIs will be included.</source>
         <translation>When checked, all images will be included in the PDF report, even if they don&apos;t have any flagged AOIs. When unchecked, only images with flagged AOIs will be included.</translation>
     </message>
@@ -10280,7 +10267,7 @@ Please flag at least one AOI, or check &apos;Include images without flagged AOIs
   ... and {count} more</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10308,7 +10295,7 @@ Please select the folder containing the source images.</translation>
         <translation>Some Images Still Missing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="168"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10326,7 +10313,7 @@ Please select the folder containing the mask files.</translation>
         <translation>Detection Masks Not Found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="140"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10337,7 +10324,7 @@ Still missing:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10358,7 +10345,7 @@ Expected to find files named:
         <translation>Some Masks Still Missing</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="174"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="172"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10369,7 +10356,7 @@ Still missing:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="179"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="176"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10390,7 +10377,7 @@ Expected to find files named:
         <translation>Continue Anyway</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="414"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="410"/>
         <source>
 
 {count} of these appear more than once in that folder, so which capture they belong to cannot be determined:
@@ -10438,7 +10425,7 @@ Choose the specific flight/sortie folder rather than a folder containing several
         <translation>Use terrain elevation (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Rotate the person on the ground to line it up with an object</translation>
     </message>
@@ -10474,173 +10461,193 @@ Choose the specific flight/sortie folder rather than a folder containing several
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="402"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1247"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1254"/>
+        <source>Flight track log...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <source>Attach a ForeFlight track log CSV to stamp true aircraft attitude (bank/pitch) and GPS-accurate capture times onto these images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="411"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1371"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="419"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="427"/>
         <source>Recenter</source>
         <translation>Recenter</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="420"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="429"/>
         <source>Bring the reference person to the center of the current view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="421"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="430"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="487"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="497"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation>No camera clock fault or applied correction was found for this folder.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="539"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="596"/>
+        <source>Select ForeFlight track log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <source>Track logs (*.csv);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="709"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation>Zoomed to the reference person: at this altitude a person spans only a few pixels.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="638"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>no image loaded</source>
         <translation>no image loaded</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="643"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="758"/>
         <source>image metadata could not be read</source>
         <translation>image metadata could not be read</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="762"/>
         <source>image has no GPS coordinates</source>
         <translation>image has no GPS coordinates</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="659"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="774"/>
         <source>capture time / timezone not in metadata</source>
         <translation>capture time / timezone not in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="670"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="785"/>
         <source>sun position could not be computed</source>
         <translation>sun position could not be computed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="684"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="799"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="688"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="804"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Capture time zone estimated from GPS location.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="691"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="807"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation>Using repaired capture time (camera clock fault).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="694"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="810"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="699"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="815"/>
         <source>the sun was below the horizon at capture</source>
         <translation>the sun was below the horizon at capture</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="701"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="817"/>
         <source>sun position unavailable</source>
         <translation>sun position unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="702"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="818"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Shadow unavailable: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="801"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Place the person and shadow on the DEM terrain surface</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="805"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="921"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terrain (DEM) data is not available for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1065"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1181"/>
         <source>Choose Overlay Color</source>
         <translation>Choose Overlay Color</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1339"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1341"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1265"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1382"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1467"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1357"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1473"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1373"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1488"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1493"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1380"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1495"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1502"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1391"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1506"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11049,7 +11056,7 @@ All changes are saved automatically when modified.</translation>
         <translation>Language:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="105"/>
+        <location filename="../app/core/controllers/Preferences.py" line="104"/>
         <source>AWS Terrain Tiles (online, ~30 m) is always available as the baseline; local USGS 3DEP adds 1 m detail where downloaded.</source>
         <translation>AWS Terrain Tiles (online, ~30 m) is always available as the baseline; local USGS 3DEP adds 1 m detail where downloaded.</translation>
     </message>
@@ -11090,8 +11097,8 @@ All changes are saved automatically when modified.</translation>
         <translation>Folder containing the GeoTIFF tiles</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="146"/>
-        <location filename="../app/core/controllers/Preferences.py" line="400"/>
+        <location filename="../app/core/controllers/Preferences.py" line="145"/>
+        <location filename="../app/core/controllers/Preferences.py" line="399"/>
         <source>3DEP is inactive until both paths are set — the AWS Terrain Tiles baseline is used. Use Download tiles… or Browse.</source>
         <translation>3DEP is inactive until both paths are set — the AWS Terrain Tiles baseline is used. Use Download tiles… or Browse.</translation>
     </message>
@@ -11116,8 +11123,8 @@ All changes are saved automatically when modified.</translation>
         <translation>Path to the canopy manifest CSV</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="230"/>
-        <location filename="../app/core/controllers/Preferences.py" line="480"/>
+        <location filename="../app/core/controllers/Preferences.py" line="229"/>
+        <location filename="../app/core/controllers/Preferences.py" line="479"/>
         <source>Canopy is disabled until both paths are set — use Download tiles… or Browse.</source>
         <translation>Canopy is disabled until both paths are set — use Download tiles… or Browse.</translation>
     </message>
@@ -11127,7 +11134,7 @@ All changes are saved automatically when modified.</translation>
         <translation>Download tiles...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="242"/>
+        <location filename="../app/core/controllers/Preferences.py" line="241"/>
         <source>Download DEM and/or canopy tiles for an area of interest and register them here. Note: the canopy download uses Meta/WRI data and registers it as the canopy source.</source>
         <translation>Download DEM and/or canopy tiles for an area of interest and register them here. Note: the canopy download uses Meta/WRI data and registers it as the canopy source.</translation>
     </message>
@@ -11138,7 +11145,7 @@ All changes are saved automatically when modified.</translation>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="406"/>
+        <location filename="../app/core/controllers/Preferences.py" line="405"/>
         <source>The registered 3DEP files no longer exist on disk — the AWS Terrain Tiles baseline is used. Re-download or fix the paths.</source>
         <translation>The registered 3DEP files no longer exist on disk — the AWS Terrain Tiles baseline is used. Re-download or fix the paths.</translation>
     </message>
@@ -11159,7 +11166,7 @@ All changes are saved automatically when modified.</translation>
         <translation>Select 3DEP tiles directory</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="486"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>The registered canopy files no longer exist on disk — canopy is disabled. Re-download or fix the paths.</source>
         <translation>The registered canopy files no longer exist on disk — canopy is disabled. Re-download or fix the paths.</translation>
     </message>
@@ -11208,7 +11215,7 @@ All changes are saved automatically when modified.</translation>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="625"/>
+        <location filename="../app/core/controllers/Preferences.py" line="624"/>
         <source>Terrain service not available.</source>
         <translation>Terrain service not available.</translation>
     </message>
@@ -11218,7 +11225,7 @@ All changes are saved automatically when modified.</translation>
         <translation>Clear Terrain Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="634"/>
+        <location filename="../app/core/controllers/Preferences.py" line="632"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -11247,7 +11254,7 @@ This will require re-downloading tiles when terrain elevation is used.</translat
         <translation>Select a Drone Sensor File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="662"/>
+        <location filename="../app/core/controllers/Preferences.py" line="661"/>
         <source>CSV Files (*.csv)</source>
         <translation>CSV Files (*.csv)</translation>
     </message>
@@ -11257,7 +11264,7 @@ This will require re-downloading tiles when terrain elevation is used.</translat
         <translation>Restart Required</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="689"/>
+        <location filename="../app/core/controllers/Preferences.py" line="688"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Please restart the application for language changes to take effect.</translation>
     </message>
@@ -11632,7 +11639,7 @@ Aggressive</translation>
         <translation>Off</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="64"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="55"/>
         <source>Shape to draw around detections:
 
 • Box: Rectangle around detection bounding box.
@@ -11671,7 +11678,7 @@ Aggressive</translation>
         <translation>Show Text Labels (slower)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="79"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="75"/>
         <source>Displays text labels near detections showing detection information.
 Adds ~5-15ms processing overhead depending on detection count.
 Labels show: detection type, confidence, area.
@@ -11687,7 +11694,7 @@ Recommended: OFF for speed, ON for debugging/analysis.</translation>
         <translation>Show Contours (slowest)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="84"/>
         <source>Draws exact detection contours (pixel-precise boundaries).
 Adds ~10-20ms processing overhead (very expensive).
 Shows exact shape detected by algorithm.
@@ -11703,7 +11710,7 @@ Recommended: OFF for speed, ON only for detailed analysis.</translation>
         <translation>Use Detection Color (hue @ 100% sat/val for color anomalies)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="100"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="95"/>
         <source>Color the detection overlay based on detected color.
 For color anomalies: Uses the detected hue at 100% saturation/value.
 For motion detections: Uses default color (green/blue).
@@ -11726,7 +11733,7 @@ Recommended: ON for color detection, OFF for motion-only.</translation>
         <translation>Max Detections:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="120"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="115"/>
         <source>Maximum number of detections to render on screen (0-1000).
 Prevents rendering slowdown when hundreds of detections occur.
 Shows highest confidence detections first.
@@ -11749,7 +11756,7 @@ Recommended: 10 for general use, 50 for complex rendering (text+contours).</tran
         <translation>Enable Temporal Voting (reduce flicker)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="136"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="132"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -11765,7 +11772,7 @@ Recommended: ON for all use cases (default).</translation>
         <translation>Window Frames (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="152"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="147"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -11783,7 +11790,7 @@ Recommended: 5 for 30fps (~167ms window), 7 for 60fps.</translation>
         <translation>Threshold (N of M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="165"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="160"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -11806,7 +11813,7 @@ Recommended: 3 out of 5 (detection in 60% of frames).</translation>
         <translation>Enable Aspect Ratio Filtering</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="183"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="180"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -11820,7 +11827,7 @@ Most users can leave this OFF unless you see many long skinny false detections.<
         <translation>Min Ratio:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="199"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="195"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -11836,7 +11843,7 @@ Example: 0.2 ≈ reject if height is more than 5× width.</translation>
         <translation>Max Ratio:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="211"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="208"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -11855,7 +11862,7 @@ Higher values = allow wider objects such as vehicles or long equipment.</transla
         <translation>Enable Detection Clustering</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="226"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="223"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -11869,7 +11876,7 @@ Most users can leave this OFF unless objects look fragmented.</translation>
         <translation>Clustering Distance (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="240"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="237"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -11896,7 +11903,7 @@ Higher values = merge detections that are farther apart (may over-merge).</trans
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="363"/>
         <source>Export finished with problems - see the log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11994,7 +12001,7 @@ Higher values = merge detections that are farther apart (may over-merge).</trans
         <translation>Map</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="134"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="133"/>
         <source>View</source>
         <translation>View</translation>
     </message>
@@ -12055,7 +12062,7 @@ Higher values = merge detections that are farther apart (may over-merge).</trans
         <translation>Select ADIAT Results File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="117"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="116"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>XML Files (*.xml);;All Files (*)</translation>
     </message>
@@ -12065,7 +12072,7 @@ Higher values = merge detections that are farther apart (may over-merge).</trans
         <translation>File Name Warning</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="131"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="128"/>
         <source>The selected file does not appear to be an ADIAT_Data.xml result or an ADIAT_Search project file.
 
 Do you want to continue with this file?</source>
@@ -12087,7 +12094,7 @@ Do you want to continue with this file?</translation>
         <translation>Review Tracking</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="51"/>
         <source>Enter your name to track your review activity.
 This helps coordinate reviews across multiple reviewers.</source>
         <translation>Enter your name to track your review activity.
@@ -12114,7 +12121,7 @@ This helps coordinate reviews across multiple reviewers.</translation>
         <translation>Remember my name</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="76"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="74"/>
         <source>Save your name for future review sessions.
 You can change it later in Preferences or by clicking the reviewer name in the viewer.</source>
         <translation>Save your name for future review sessions.
@@ -12136,7 +12143,7 @@ You can change it later in Preferences or by clicking the reviewer name in the v
         <translation>Name Required</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="124"/>
         <source>Please enter your name to continue.</source>
         <translation>Please enter your name to continue.</translation>
     </message>
@@ -12152,12 +12159,12 @@ You can change it later in Preferences or by clicking the reviewer name in the v
 <context>
     <name>SimilarityGalleryView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="173"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
         <source>Reference</source>
         <translation>Reference</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
@@ -12233,12 +12240,12 @@ You can change it later in Preferences or by clicking the reviewer name in the v
 <context>
     <name>StreamAlgorithmPage</name>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="91"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="90"/>
         <source>Are you primarily looking for a person?</source>
         <translation>Are you primarily looking for a person?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="157"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="156"/>
         <source>Do you know a distinctive target color?</source>
         <translation>Do you know a distinctive target color?</translation>
     </message>
@@ -12263,7 +12270,7 @@ You can change it later in Preferences or by clicking the reviewer name in the v
         <translation>Selected Algorithm: {algorithm}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="192"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="191"/>
         <source>{result}
 Secondary Recommendation: {secondary}</source>
         <translation>{result}
@@ -12336,7 +12343,7 @@ Secondary Recommendation: {secondary}</translation>
         <translation>Click Browse to select a video file...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="341"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="340"/>
         <source>Click Scan to detect available capture devices, then select one from the dropdown.</source>
         <translation>Click Scan to detect available capture devices, then select one from the dropdown.</translation>
     </message>
@@ -12367,14 +12374,14 @@ Secondary Recommendation: {secondary}</translation>
         <translation>No capture devices found</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="332"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="327"/>
         <source>Choose the video file you want to analyze. Use Browse to pick a file from disk.
 
 Location data is optional and usually detected automatically — ADIAT reads an .SRT sitting next to the video, or telemetry embedded in the video, on its own. Set it only to override that, or to supply location data the video does not have: a DJI .SRT or a .CSV flight log.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="350"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="349"/>
         <source>Enter the RTMP URL provided by your streaming server (rtmp://server:port/app/key).</source>
         <translation>Enter the RTMP URL provided by your streaming server (rtmp://server:port/app/key).</translation>
     </message>
@@ -12389,7 +12396,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>rtmp://server:port/app/streamKey</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="358"/>
         <source>You&apos;ll be prompted for the pairing code when you connect — pairing codes expire about 30 seconds after ADIAT Flight shows them, so don&apos;t generate one until you&apos;re ready.
 
 Finish this setup first, then start sharing in ADIAT Flight and enter the code. Detections reported by ADIAT Flight are ignored — this desktop runs its own analysis on the video.</source>
@@ -12417,7 +12424,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Select Video File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="494"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="493"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;All Files (*)</source>
         <translation>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;All Files (*)</translation>
     </message>
@@ -12427,7 +12434,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation type="unfinished">Select a Metadata File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="517"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="515"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12437,7 +12444,6 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
     <message>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="862"/>
         <source>Stream Connection</source>
-        <extracomment>Gap between the HUD and the bottom of the video pane. Flush against the edge reads as an artifact of the window rather than an overlay.</extracomment>
         <translation>Stream Connection</translation>
     </message>
     <message>
@@ -12461,7 +12467,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>RTMP Stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="887"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="879"/>
         <source>Select the type of video source:
 • File: Pre-recorded video file with timeline controls
 • HDMI Capture: Live capture from HDMI capture device
@@ -12500,7 +12506,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Browse...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="930"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="927"/>
         <source>Open file browser to select a video file for analysis.
 Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</source>
         <translation>Open file browser to select a video file for analysis.
@@ -12517,7 +12523,7 @@ Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <translation>Scan for available HDMI capture devices</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="966"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="957"/>
         <source>Optional. ADIAT already finds location data on its own, from:
 • an .SRT file sitting next to the video
 • telemetry embedded in the video (newer DJI aircraft)
@@ -12531,12 +12537,12 @@ Choose a file here only to override that, or to supply location data the video d
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="974"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="973"/>
         <source>Optional - usually detected automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="982"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="980"/>
         <source>Browse for an SRT or CSV file with the flight&apos;s location data.
 Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
@@ -12547,7 +12553,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Connect</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="993"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="992"/>
         <source>Connect to the specified video source and begin processing.</source>
         <translation>Connect to the specified video source and begin processing.</translation>
     </message>
@@ -12557,7 +12563,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Disconnect</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="999"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="998"/>
         <source>Disconnect from the current video source and stop processing.</source>
         <translation>Disconnect from the current video source and stop processing.</translation>
     </message>
@@ -12597,7 +12603,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Processing: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1020"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1019"/>
         <source>Resolution used for detection processing</source>
         <translation>Resolution used for detection processing</translation>
     </message>
@@ -12617,7 +12623,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Proc FPS: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1028"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1027"/>
         <source>Actual frames per second being processed</source>
         <translation>Actual frames per second being processed</translation>
     </message>
@@ -12627,7 +12633,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Time: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1034"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1033"/>
         <source>Time in milliseconds to process each frame</source>
         <translation>Time in milliseconds to process each frame</translation>
     </message>
@@ -12637,7 +12643,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Latency: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1038"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1037"/>
         <source>End-to-end latency from frame capture to display</source>
         <translation>End-to-end latency from frame capture to display</translation>
     </message>
@@ -12672,7 +12678,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Start Recording</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1067"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1066"/>
         <source>Start recording the video stream with detection overlays.</source>
         <translation>Start recording the video stream with detection overlays.</translation>
     </message>
@@ -12682,7 +12688,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Stop Recording</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1072"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1071"/>
         <source>Stop the current recording and save to file.</source>
         <translation>Stop the current recording and save to file.</translation>
     </message>
@@ -12693,7 +12699,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Status: Not Recording</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1082"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1081"/>
         <source>Current recording status and output file path</source>
         <translation>Current recording status and output file path</translation>
     </message>
@@ -12704,7 +12710,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Duration: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1088"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1087"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Recording statistics: Duration, FPS, Frames</translation>
     </message>
@@ -12714,12 +12720,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Save to:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1100"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1099"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Directory where video recordings will be saved.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1104"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1103"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Choose a folder to store recordings.</translation>
     </message>
@@ -12729,7 +12735,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>rtmp://server:port/app/stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1174"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1173"/>
         <source>Click Connect to enter your pairing code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12739,7 +12745,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Invalid Device</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1196"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1195"/>
         <source>Please select a valid HDMI capture device.</source>
         <translation>Please select a valid HDMI capture device.</translation>
     </message>
@@ -12749,7 +12755,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Invalid URL</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1217"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1216"/>
         <source>Please enter a valid stream URL.</source>
         <translation>Please enter a valid stream URL.</translation>
     </message>
@@ -12806,7 +12812,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished">Select a Metadata File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1506"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1503"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12816,7 +12822,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Device {index} ({backend})</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="868"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="865"/>
         <source>Configure and connect to video source (file, HDMI capture, RTMP stream, or ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12826,12 +12832,12 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="891"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="890"/>
         <source>• ADIAT Flight: Live feed paired with the ADIAT Flight app</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="912"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="907"/>
         <source>Enter or browse for the video source:
 • File: Click to browse for video file (MP4, AVI, MOV, etc.)
 • RTMP Stream: Enter RTMP URL (rtmp://server:port/app/stream)
@@ -12884,7 +12890,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Select Video File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1484"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1482"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</translation>
     </message>
@@ -12927,7 +12933,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>-- (Missing camera data)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="547"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="546"/>
         <source>Unable to calculate GSD. Sensor dimensions are required.</source>
         <translation>Unable to calculate GSD. Sensor dimensions are required.</translation>
     </message>
@@ -12947,7 +12953,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Primary</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="588"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="587"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
@@ -12995,12 +13001,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>More Examples:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>sqm</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>sqft</translation>
     </message>
@@ -13008,7 +13014,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamTelemetryCoordinator</name>
     <message>
-        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="101"/>
+        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="100"/>
         <source>Waiting for telemetry from ADIAT Flight...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +13062,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamViewerWindow</name>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="130"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="129"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</translation>
     </message>
@@ -13132,7 +13138,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Status: Not Recording</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="392"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="391"/>
         <source>Current recording status and output file path</source>
         <translation>Current recording status and output file path</translation>
     </message>
@@ -13143,7 +13149,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Duration: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="398"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="397"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Recording statistics: Duration, FPS, Frames</translation>
     </message>
@@ -13153,7 +13159,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Save to:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="407"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="406"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Directory where video recordings will be saved.</translation>
     </message>
@@ -13163,7 +13169,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Browse...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="411"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="410"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Choose a folder to store recordings.</translation>
     </message>
@@ -13173,7 +13179,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="426"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="423"/>
         <source>Save each confirmed detection with the recording: a thumbnail, its position, and a results file that opens in the Image Analysis window.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13183,7 +13189,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="433"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="430"/>
         <source>Save the flight path and detection locations as a map and a KML file. Requires location data from the video or a live ADIAT Flight feed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13193,7 +13199,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="442"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="441"/>
         <source>Watch this recording: video, detections, telemetry and map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13203,7 +13209,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="447"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="446"/>
         <source>Open the folder holding the last recording and its detections.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13223,12 +13229,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Algorithm:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="610"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="609"/>
         <source>Select which streaming detection algorithm to use</source>
         <translation>Select which streaming detection algorithm to use</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="619"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="615"/>
         <source>Choose which streaming detection algorithm to run.
 • Color Anomaly &amp; Motion Detection: fused anomaly detectors
 • Color Detection: color-based highlighting</source>
@@ -13242,7 +13248,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Gallery Threshold:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="655"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="653"/>
         <source>Number of frames a detection must be seen before appearing in the Gallery tab</source>
         <translation>Number of frames a detection must be seen before appearing in the Gallery tab</translation>
     </message>
@@ -13252,7 +13258,7 @@ Not needed for most videos, which already carry it.</source>
         <translation> frames</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="667"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="663"/>
         <source>Detections must be seen for this many consecutive frames
 before appearing in the Gallery. Higher values reduce
 false positives but delay detection appearance.</source>
@@ -13363,27 +13369,27 @@ false positives but delay detection appearance.</translation>
         <translation>{state} - {message}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1913"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1912"/>
         <source>Connected</source>
         <translation>Connected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="537"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="534"/>
         <source>Save the flight path and detection locations as a map and a KML file. Location data is available for this source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="544"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="541"/>
         <source>Save the flight path and detection locations as a map and a KML file. Nothing is saved unless location data arrives while recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1915"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1914"/>
         <source>Disconnected</source>
         <translation>Disconnected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1917"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1916"/>
         <source>Connecting</source>
         <translation type="unfinished">Connecting</translation>
     </message>
@@ -13413,7 +13419,7 @@ false positives but delay detection appearance.</translation>
         <translation>Detection Results ({count} found):</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2239"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2238"/>
         <source>#{index}: Type({cls}) Pos({x},{y}) Size({w}x{h})</source>
         <translation>#{index}: Type({cls}) Pos({x},{y}) Size({w}x{h})</translation>
     </message>
@@ -13478,7 +13484,7 @@ false positives but delay detection appearance.</translation>
         <translation>Live Stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2514"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2512"/>
         <source>Cannot seek in live stream.
 
 Detection was first seen at frame {frame}.</source>
@@ -13823,12 +13829,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>More Examples:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>sqm</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>sqft</translation>
     </message>
@@ -13841,7 +13847,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>No Flagged AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="52"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="49"/>
         <source>There are no flagged AOIs to assign.
 
 Flag at least one AOI in the viewer before using Plan Verification.</source>
@@ -13865,7 +13871,7 @@ Flag at least one AOI in the viewer before using Plan Verification.</translation
         <translation>No AOIs Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="223"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="221"/>
         <source>Select one or more AOIs on the map first.
 Click on markers, or use Rectangle Select for area selection.</source>
         <translation>Select one or more AOIs on the map first.
@@ -14000,7 +14006,7 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>Assign Selection ▶</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="146"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="145"/>
         <source>Assign the selected AOIs on the map to the chosen team</source>
         <translation>Assign the selected AOIs on the map to the chosen team</translation>
     </message>
@@ -14015,7 +14021,7 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>Export Team PDF</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="174"/>
         <source>Generate a PDF report for the selected team only</source>
         <translation>Generate a PDF report for the selected team only</translation>
     </message>
@@ -14025,7 +14031,7 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>Export All PDFs</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="181"/>
         <source>Generate one PDF per team plus a master summary PDF</source>
         <translation>Generate one PDF per team plus a master summary PDF</translation>
     </message>
@@ -14050,7 +14056,7 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>Rectangle Select</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="97"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="96"/>
         <source>Draw a rectangle on the map to select multiple AOIs</source>
         <translation>Draw a rectangle on the map to select multiple AOIs</translation>
     </message>
@@ -14066,12 +14072,12 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>Map View</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="198"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="195"/>
         <source>Click to select AOI • Ctrl+Click to multi-select • Use Rectangle Select for area selection • Scroll to zoom</source>
         <translation>Click to select AOI • Ctrl+Click to multi-select • Use Rectangle Select for area selection • Scroll to zoom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="223"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="222"/>
         <source>Team</source>
         <translation>Team</translation>
     </message>
@@ -14145,18 +14151,18 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>stale {age}s</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="265"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="264"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="57"/>
         <source>ALT —</source>
         <translation>ALT —</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="299"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="297"/>
         <source>no AGL yet - ADIAT Flight found no terrain source here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="301"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="300"/>
         <source>no terrain-referenced AGL available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14176,47 +14182,47 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="307"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="306"/>
         <source>AGL — above the terrain beneath the aircraft; what clearance and image scale depend on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="309"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="308"/>
         <source>ATO — above the takeoff point (the drone&apos;s own reading); equal to AGL only over flat ground</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="325"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="324"/>
         <source>ADIAT Flight (fused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="327"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="326"/>
         <source>laser rangefinder (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="329"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="328"/>
         <source>downward sensor (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="331"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="330"/>
         <source>terrain DEM (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="333"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="332"/>
         <source>desktop DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="335"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="334"/>
         <source>no terrain source — this is the takeoff-relative reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="341"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="339"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="91"/>
         <source>HDG —</source>
         <translation>HDG —</translation>
@@ -14227,7 +14233,7 @@ Click on markers, or use Rectangle Select for area selection.</translation>
         <translation>HDG {bearing:03d}° {cardinal}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="354"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="349"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="98"/>
         <source>SPD —</source>
         <translation>SPD —</translation>
@@ -14547,18 +14553,18 @@ Aggressive</translation>
 <context>
     <name>ThermalHistogramChart</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="98"/>
         <source>No histogram data available</source>
         <translation>No histogram data available</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="435"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="434"/>
         <source>All Pixels</source>
         <translation>All Pixels</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="446"/>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="457"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="445"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="456"/>
         <source>AOI Pixels</source>
         <translation>AOI Pixels</translation>
     </message>
@@ -14571,7 +14577,7 @@ Aggressive</translation>
         <translation>Thermal Histogram Unavailable</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="34"/>
+        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="33"/>
         <source>No thermal temperature data is available for the current image.</source>
         <translation>No thermal temperature data is available for the current image.</translation>
     </message>
@@ -14628,7 +14634,7 @@ Aggressive</translation>
         <translation>Hover over the histogram to inspect a temperature band.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="30"/>
         <source>No thermal histogram data available</source>
         <translation>No thermal histogram data available</translation>
     </message>
@@ -14974,7 +14980,7 @@ Aggressive</translation>
         <translation>Replace Canopy Source?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="361"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="359"/>
         <source>A LANDFIRE canopy source is currently configured.
 
 Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay on disk; only the selected source changes.)</source>
@@ -14988,7 +14994,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Elevation (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="370"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="368"/>
         <source>Canopy height</source>
         <translation>Canopy height</translation>
     </message>
@@ -15119,7 +15125,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Footprint buffer (m):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="110"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
         <translation>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</translation>
     </message>
@@ -15134,7 +15140,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>USGS 3DEP DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="123"/>
         <source>USGS 3DEP provides 1 m local elevation. Optional when you already have a terrain source configured (AWS Terrain Tiles online, or downloaded 3DEP) — enable it to download higher-resolution data.</source>
         <translation>USGS 3DEP provides 1 m local elevation. Optional when you already have a terrain source configured (AWS Terrain Tiles online, or downloaded 3DEP) — enable it to download higher-resolution data.</translation>
     </message>
@@ -15164,7 +15170,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Custom folder...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="152"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="149"/>
         <source>The central library collects tiles from all missions in one place (they merge, nothing gets replaced) and registers automatically. Choose the results folder or a custom folder to keep tiles beside a specific mission instead.</source>
         <translation>The central library collects tiles from all missions in one place (they merge, nothing gets replaced) and registers automatically. Choose the results folder or a custom folder to keep tiles beside a specific mission instead.</translation>
     </message>
@@ -15194,32 +15200,32 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="207"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="206"/>
         <source>This area is already covered by your registered tiles.</source>
         <translation>This area is already covered by your registered tiles.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="210"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="208"/>
         <source>Partially covered by your registered tiles — downloading fills the gaps.</source>
         <translation>Partially covered by your registered tiles — downloading fills the gaps.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="214"/>
         <source>Your downloaded 1 m tiles don&apos;t include this area — without this download, online AWS Terrain Tiles (~30 m) are used here instead.</source>
         <translation>Your downloaded 1 m tiles don&apos;t include this area — without this download, online AWS Terrain Tiles (~30 m) are used here instead.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="220"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
         <source>Your downloaded canopy tiles don&apos;t include this area — without this download, POD runs with no canopy attenuation here.</source>
         <translation>Your downloaded canopy tiles don&apos;t include this area — without this download, POD runs with no canopy attenuation here.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="222"/>
         <source>No local elevation tiles registered — online AWS Terrain Tiles (~30 m) serve as the baseline.</source>
         <translation>No local elevation tiles registered — online AWS Terrain Tiles (~30 m) serve as the baseline.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
         <source>No canopy source is configured yet.</source>
         <translation>No canopy source is configured yet.</translation>
     </message>
@@ -15260,7 +15266,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>No Data Selected</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="441"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="440"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Please select at least one type of data to export.</translation>
     </message>
@@ -15291,7 +15297,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Save Map Export</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="500"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="499"/>
         <source>KML files (*.kml);;KMZ files (*.kmz)</source>
         <translation>KML files (*.kml);;KMZ files (*.kmz)</translation>
     </message>
@@ -15317,12 +15323,12 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="704"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="716"/>
         <source>POD coverage complete</source>
         <translation>POD coverage complete</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
         <source>POD coverage complete — {count} frame(s) used online elevation (outside local DEM)</source>
         <translation>POD coverage complete — {count} frame(s) used online elevation (outside local DEM)</translation>
     </message>
@@ -15342,7 +15348,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>(canopy data covered {pct}% of the searched area)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="808"/>
         <source>Terrain and canopy aware probability-of-detection heatmap.</source>
         <translation>Terrain and canopy aware probability-of-detection heatmap.</translation>
     </message>
@@ -15362,7 +15368,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>POD Overlay</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="826"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="824"/>
         <source>The POD coverage was computed, but embedding it into the exported file failed:
 {error}
 
@@ -15415,7 +15421,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
         <source>(no takeoff elevation — POD is approximate over changing terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15433,12 +15439,12 @@ The POD GeoTIFF products were still written next to the export.</translation>
 <context>
     <name>UpdateController</name>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="53"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="52"/>
         <source>Disabled while Offline Only mode is enabled.</source>
         <translation>Disabled while Offline Only mode is enabled.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="57"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="56"/>
         <source>Check the update feed for a newer ADIAT installer.</source>
         <translation>Check the update feed for a newer ADIAT installer.</translation>
     </message>
@@ -15448,7 +15454,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>Updates Disabled</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="88"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="87"/>
         <source>Update checks are disabled while Offline Only mode is enabled.</source>
         <translation>Update checks are disabled while Offline Only mode is enabled.</translation>
     </message>
@@ -15470,7 +15476,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>No Updates Available</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="113"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="112"/>
         <source>You are already running the latest available version of ADIAT.</source>
         <translation>You are already running the latest available version of ADIAT.</translation>
     </message>
@@ -15492,7 +15498,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>Installer Started</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="140"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="139"/>
         <source>The installer has been launched. Close ADIAT when you are ready to continue the update.</source>
         <translation>The installer has been launched. Close ADIAT when you are ready to continue the update.</translation>
     </message>
@@ -15507,7 +15513,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>ADIAT {new_version} is available. You are running {current_version}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="157"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="156"/>
         <source>Do you want to download and launch the installer now?</source>
         <translation>Do you want to download and launch the installer now?</translation>
     </message>
@@ -15538,7 +15544,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>{value} MB</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="194"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="193"/>
         <source>unknown</source>
         <translation>unknown</translation>
     </message>
@@ -15551,7 +15557,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/UpdateController.py" line="204"/>
-        <location filename="../app/core/controllers/UpdateController.py" line="211"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="210"/>
         <source>Update download canceled.</source>
         <translation>Update download canceled.</translation>
     </message>
@@ -15617,7 +15623,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>Close this upscale window</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="306"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="302"/>
         <source>Resolution: {width} × {height} pixels | Original: {orig_w} × {orig_h} pixels | Upscale: {level}x | Use mouse wheel to zoom, right-click to pan</source>
         <translation>Resolution: {width} × {height} pixels | Original: {orig_w} × {orig_h} pixels | Upscale: {level}x | Use mouse wheel to zoom, right-click to pan</translation>
     </message>
@@ -15636,7 +15642,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>Error during initial upscale: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="388"/>
         <source>Unable to extract visible image portion.</source>
         <translation>Unable to extract visible image portion.</translation>
     </message>
@@ -15646,7 +15652,7 @@ The POD GeoTIFF products were still written next to the export.</translation>
         <translation>Maximum Upscale Reached</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="401"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="399"/>
         <source>Maximum upscale level of {level}x has been reached.
 Further upscaling is not allowed to prevent memory issues.</source>
         <translation>Maximum upscale level of {level}x has been reached.
@@ -15658,7 +15664,7 @@ Further upscaling is not allowed to prevent memory issues.</translation>
         <translation>Image Too Large</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="415"/>
         <source>Upscaling would result in an image of {width}×{height} pixels.
 Maximum allowed dimension is {max_dim} pixels.
 
@@ -15674,7 +15680,7 @@ Try zooming in to a smaller area before upscaling.</translation>
         <translation>Image Too Small</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="430"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="428"/>
         <source>Visible portion is too small ({width}×{height} pixels).
 Please zoom in to a larger area before upscaling.</source>
         <translation>Visible portion is too small ({width}×{height} pixels).
@@ -15689,7 +15695,7 @@ Please zoom in to a larger area before upscaling.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="487"/>
         <source>Upscaling image with AI enhancement...
 From {width}×{height} to {new_width}×{new_height} pixels
 This may take a few seconds.</source>
@@ -15721,7 +15727,7 @@ This may take a few seconds.</translation>
         <translation>Method Not Available</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="605"/>
         <source>Real-ESRGAN is not yet implemented.
 Falling back to Lanczos interpolation.</source>
         <translation>Real-ESRGAN is not yet implemented.
@@ -15931,7 +15937,7 @@ Displays real-time information during frame extraction:
 Shows total frames extracted when complete.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="58"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="57"/>
         <source>Select a Video File</source>
         <translation>Select a Video File</translation>
     </message>
@@ -15941,7 +15947,7 @@ Shows total frames extracted when complete.</translation>
         <translation>Select a Metadata File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="74"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="73"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)</source>
         <translation>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)</translation>
     </message>
@@ -15951,7 +15957,7 @@ Shows total frames extracted when complete.</translation>
         <translation>Select Directory</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="111"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="110"/>
         <source>Please set the video file and output directory.</source>
         <translation>Please set the video file and output directory.</translation>
     </message>
@@ -16024,7 +16030,7 @@ Use to compare original image with detection results.</translation>
         <translation>Show Overlay</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1346"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1343"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -16042,7 +16048,7 @@ Shows all AOIs from all images in a grid view</translation>
         <translation>Show AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1364"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1363"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="328"/>
         <source>Open Histogram</source>
         <translation>Open Histogram</translation>
@@ -16090,7 +16096,7 @@ Shows all AOIs from all images in a grid view</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2158"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2157"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="427"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation>Person Size Reference (Ctrl+P)</translation>
@@ -16294,7 +16300,7 @@ Sorting helps prioritize review of larger or closer objects.</translation>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="139"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="138"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</translation>
     </message>
@@ -16319,7 +16325,7 @@ Sorting helps prioritize review of larger or closer objects.</translation>
         <translation>Load Results Failed</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="189"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -16349,7 +16355,7 @@ The viewer will now close.</translation>
         <translation>Loading detection results from {n} images...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="307"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="304"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Image metadata and information.
@@ -16371,7 +16377,7 @@ Click on GPS Coordinates to copy, share, or open in mapping applications.</trans
         <translation>No Dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="721"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>No dataset is currently loaded.</source>
         <translation>No dataset is currently loaded.</translation>
     </message>
@@ -16381,7 +16387,7 @@ Click on GPS Coordinates to copy, share, or open in mapping applications.</trans
         <translation>Generate Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="732"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="729"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -16426,7 +16432,7 @@ Continue?</translation>
         <translation>Cache Generated</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="806"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -16444,7 +16450,7 @@ The viewer will now load thumbnails and colors much faster.</translation>
         <translation>Cache Generation Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="840"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="839"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -16458,7 +16464,7 @@ The viewer will now load thumbnails and colors much faster.</translation>
         <translation>AOI Not Visible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1028"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -16472,7 +16478,7 @@ To select this AOI, please clear or adjust your filters.</translation>
         <translation>Update Image Dimensions</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1228"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1224"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -16486,7 +16492,7 @@ Would you like to read dimensions from the image files and update the results fi
         <translation>Reading image dimensions ({done}/{total})...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1355"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1354"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Show Pixels of Interest (H or Ctrl+I)</translation>
     </message>
@@ -16506,7 +16512,7 @@ Would you like to read dimensions from the image files and update the results fi
         <translation>Missing Dependency</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1797"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1794"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>The qimage2ndarray module is required for the upscale feature.
@@ -16518,19 +16524,19 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Upscale Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1806"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1805"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>An error occurred while opening the upscale dialog:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2161"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation>Person Size Reference is unavailable: no GSD for this image</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2261"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2258"/>
         <source>Unknown Reviewer</source>
         <translation>Unknown Reviewer</translation>
     </message>
@@ -16553,7 +16559,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>The camera clock on these images appears to be misconfigured:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
         <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
         <translation>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</translation>
     </message>
@@ -16568,7 +16574,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Clock face error to remove:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="129"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
         <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
         <translation>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</translation>
     </message>
@@ -16649,6 +16655,124 @@ Please install it using: pip install qimage2ndarray</translation>
     </message>
 </context>
 <context>
+    <name>WaldoFlightLogDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="126"/>
+        <source>WALDO Flight Track Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="150"/>
+        <source>An aircraft track log can supply the true per-image camera attitude (bank and pitch) and a GPS-accurate capture time, making image footprints and AOI positions substantially more accurate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="162"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished">Remember my choice for this folder</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="171"/>
+        <source>Reading image metadata...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="182"/>
+        <source>Apply Flight Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="186"/>
+        <source>Not Now</source>
+        <translation type="unfinished">Not Now</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="190"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="193"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="246"/>
+        <source>The track log does not match these images: {reason}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="258"/>
+        <source>Camera clock is {n:.1f} s {direction} of GPS time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>behind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="261"/>
+        <source>Track log: {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="263"/>
+        <source>Images sit {d:.0f} m from the flight track on average ({p:.0%} matched)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="269"/>
+        <source>Attitude channel verified against turn physics (correlation {c:.2f}, recorded {lag:+.0f} s late)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="273"/>
+        <source>Bank during capture: {lo:+.1f}° to {hi:+.1f}°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="277"/>
+        <source>Attitude channel is NOT reliable (correlation {c:.2f}) - only the capture-time refinement will be stamped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="305"/>
+        <source>Stamping flight-log attitude...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="324"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished">Cancelling...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="347"/>
+        <source>Stamped:          {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="348"/>
+        <source>Already current:  {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="349"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Errors:           {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="355"/>
+        <source>Cancelled - remaining images are unstamped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WaldoPrePassDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="58"/>
@@ -16681,7 +16805,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>WALDO Pre-Pass Complete</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="148"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="147"/>
         <source>WALDO Pre-Pass Cancelled</source>
         <translation>WALDO Pre-Pass Cancelled</translation>
     </message>
@@ -16739,7 +16863,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Import Summary</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="61"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="58"/>
         <source>&lt;b&gt;Matched images:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;CSV entries without match:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Result images without CSV data:&lt;/b&gt; {unmatched_images}</source>
         <translation>&lt;b&gt;Matched images:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;CSV entries without match:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Result images without CSV data:&lt;/b&gt; {unmatched_images}</translation>
     </message>
@@ -16749,12 +16873,12 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Altitude &amp; GSD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="78"/>
         <source>&lt;b&gt;AGL computed from terrain:&lt;/b&gt; {agl_count} of {matched_count} images&lt;br&gt;&lt;br&gt;Per-image AGL is derived from the CSV altitude (ASL) minus terrain elevation at each GPS location. GSD will be calculated automatically using the camera sensor data and focal length.</source>
         <translation>&lt;b&gt;AGL computed from terrain:&lt;/b&gt; {agl_count} of {matched_count} images&lt;br&gt;&lt;br&gt;Per-image AGL is derived from the CSV altitude (ASL) minus terrain elevation at each GPS location. GSD will be calculated automatically using the camera sensor data and focal length.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="89"/>
         <source>&lt;b&gt;Terrain data unavailable&lt;/b&gt; - AGL could not be computed.&lt;br&gt;&lt;br&gt;Orientation (yaw/pitch/roll) will still be applied from the CSV. GSD and altitude displays require terrain data or a manual altitude override (Shift+O) after import.</source>
         <translation>&lt;b&gt;Terrain data unavailable&lt;/b&gt; - AGL could not be computed.&lt;br&gt;&lt;br&gt;Orientation (yaw/pitch/roll) will still be applied from the CSV. GSD and altitude displays require terrain data or a manual altitude override (Shift+O) after import.</translation>
     </message>
@@ -16777,7 +16901,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Save Zip File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="132"/>
         <source>Zip files (*.zip)</source>
         <translation>Zip files (*.zip)</translation>
     </message>
@@ -16810,7 +16934,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>ZIP Export Options</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="30"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="26"/>
         <source>Choose what to export:
 
 - Native: Original images, TIFF masks, and XML (paths made portable).
@@ -16836,7 +16960,7 @@ Please install it using: pip install qimage2ndarray</translation>
         <translation>Include images without flagged AOIs</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="53"/>
         <source>When unchecked, only images with at least one flagged AOI will be exported.
 When checked, all images will be exported regardless of flagged AOI status.</source>
         <translation>When unchecked, only images with at least one flagged AOI will be exported.
@@ -16851,6 +16975,24 @@ When checked, all images will be exported regardless of flagged AOI status.</tra
         <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="60"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
+    </message>
+</context>
+<context>
+    <name>_CalibrateWorker</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="66"/>
+        <source>No images with resolvable GPS + capture time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="68"/>
+        <source>No ForeFlight track log found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="73"/>
+        <source>Calibrating {name}...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_es.ts
+++ b/translations/app_es.ts
@@ -125,12 +125,12 @@ La aceleración por GPU mejora significativamente la velocidad de procesamiento 
 <context>
     <name>AIPersonDetectorController</name>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="82"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="81"/>
         <source>GPU Not Available</source>
         <translation>GPU no disponible</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="88"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="87"/>
         <source>GPU Available</source>
         <translation>GPU disponible</translation>
     </message>
@@ -203,7 +203,7 @@ permisivo</translation>
         <translation>Comentario de AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="38"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="37"/>
         <source>Add a comment for this flagged AOI (max 256 characters):</source>
         <translation>Añadir un comentario para este AOI marcado (máx. 256 caracteres):</translation>
     </message>
@@ -287,7 +287,7 @@ permisivo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1092"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1091"/>
         <source>Terrain-corrected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -297,12 +297,12 @@ permisivo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1105"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1102"/>
         <source>Flat terrain assumed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1538"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Ordenación por temperatura no disponible (no existen datos térmicos)</translation>
     </message>
@@ -312,7 +312,7 @@ permisivo</translation>
         <translation>No se puede eliminar el AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1895"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1892"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Solo se pueden eliminar los AOI creados manualmente. Los AOI detectados por el algoritmo no se pueden eliminar.</translation>
     </message>
@@ -322,7 +322,7 @@ permisivo</translation>
         <translation>Eliminar AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1904"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1903"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>¿Está seguro de que desea eliminar este AOI? Esta acción no se puede deshacer.</translation>
     </message>
@@ -596,7 +596,7 @@ permisivo</translation>
         <translation>Seleccionar imagen de máscara</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="610"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="609"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)</source>
         <translation>Imágenes (*.png *.jpg *.jpeg *.bmp *.tiff);;Todos los archivos (*)</translation>
     </message>
@@ -606,7 +606,7 @@ permisivo</translation>
         <translation>Imagen no válida</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="620"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="619"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>No se pudo cargar la imagen seleccionada. Elija un archivo de imagen válido.</translation>
     </message>
@@ -659,12 +659,12 @@ permisivo</translation>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="380"/>
         <source>Showing the {count} nearest images containing this AOI; there are more. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="385"/>
         <source>Found AOI in {count} image(s). Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,7 +677,7 @@ permisivo</translation>
         <translation>Ningún AOI seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="194"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="193"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Primero seleccione un AOI haciendo clic sobre él en el panel de miniaturas.</translation>
     </message>
@@ -687,7 +687,7 @@ permisivo</translation>
         <translation>No se puede calcular GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="406"/>
         <source>Unable to calculate GPS coordinates for this AOI.
 
 This may be due to missing image metadata (GPS, altitude, or camera info).</source>
@@ -728,7 +728,7 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
         <translation>No se encontraron imágenes vecinas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="437"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>El AOI no se encontró en ninguna imagen vecina.</translation>
     </message>
@@ -745,7 +745,7 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="587"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="584"/>
         <source> (no detections)</source>
         <translation> (sin detecciones)</translation>
     </message>
@@ -770,7 +770,7 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
         <translation>No se ha seleccionado ningún AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="142"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Seleccione primero un AOI haciendo clic en él en el panel de miniaturas.</translation>
     </message>
@@ -813,7 +813,7 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
         <translation>No hay AOI similares</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="280"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="279"/>
         <source>No other AOIs could be analyzed for similarity.</source>
         <translation>No se pudo analizar ningún otro AOI para buscar similitud.</translation>
     </message>
@@ -865,7 +865,7 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
         <translation>AOI similares</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="479"/>
         <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
         <translation>Los {shown} primeros de {total} AOI ordenados por similitud con {reference}. Use la rueda del ratón para hacer zoom, arrastre con clic derecho para desplazar la vista. Haga clic en una miniatura para ir a ese AOI.</translation>
     </message>
@@ -936,7 +936,7 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
         <translation>AOI #{number}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="584"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="582"/>
         <source>the selected AOI</source>
         <translation>el AOI seleccionado</translation>
     </message>
@@ -944,15 +944,15 @@ Puede deberse a la falta de metadatos de imagen (GPS, altitud o información de 
 <context>
     <name>AOIUIComponent</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="251"/>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="347"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="250"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="346"/>
         <source>AOI Information
 Right-click to copy data to clipboard</source>
         <translation>Información del AOI
 Clic derecho para copiar los datos al portapapeles</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="257"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="256"/>
         <source>
 
 Score Type: {type}
@@ -973,7 +973,7 @@ Puntaje bruto: {score} ({method})</translation>
         <translation>Desmarcar AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="387"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="386"/>
         <source>Flag AOI</source>
         <translation>Marcar AOI</translation>
     </message>
@@ -989,7 +989,7 @@ Click to edit comment</source>
 Haga clic para editar el comentario</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="415"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="411"/>
         <source>No comment yet.
 Click to add a comment for this AOI.
 
@@ -1002,7 +1002,7 @@ Use los comentarios para anotar detalles importantes, observaciones
 o acciones necesarias para esta detección.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="429"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="428"/>
         <source>Calculate and show GPS location for this AOI</source>
         <translation>Calcular y mostrar la ubicación GPS de este AOI</translation>
     </message>
@@ -1017,7 +1017,7 @@ o acciones necesarias para esta detección.</translation>
         <translation>Área</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="485"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="484"/>
         <source>Areas</source>
         <translation>Áreas</translation>
     </message>
@@ -1027,12 +1027,12 @@ o acciones necesarias para esta detección.</translation>
         <translation>{filtered} de {total} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="496"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="495"/>
         <source>Area of Interest</source>
         <translation>Área de interés</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="498"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="497"/>
         <source>Areas of Interest</source>
         <translation>Áreas de interés</translation>
     </message>
@@ -1055,7 +1055,7 @@ o acciones necesarias para esta detección.</translation>
 <context>
     <name>AlertManager</name>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="295"/>
+        <location filename="../app/core/services/AlertService.py" line="294"/>
         <source>ADIAT - Color Detection Alerts</source>
         <translation>ADIAT - Alertas de detección de color</translation>
     </message>
@@ -1065,7 +1065,7 @@ o acciones necesarias para esta detección.</translation>
         <translation>ADIAT - Alerta de detección de color</translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="613"/>
+        <location filename="../app/core/services/AlertService.py" line="610"/>
         <source>Detected {count} object(s)
 Average confidence: {avg_confidence:.2f}
 Total area: {area:.0f} pixels
@@ -1076,7 +1076,7 @@ Confianza media: {avg_confidence:.2f}
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="621"/>
+        <location filename="../app/core/services/AlertService.py" line="620"/>
         <source>
 Details:
 </source>
@@ -1085,7 +1085,7 @@ Detalles:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="625"/>
+        <location filename="../app/core/services/AlertService.py" line="624"/>
         <source>  #{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
 </source>
         <translation>  n.º{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
@@ -1113,7 +1113,7 @@ Detalles:
         <translation>¿Está usando imágenes térmicas?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="157"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="156"/>
         <source>Are you looking for anomalies within a specific temperature range?</source>
         <translation>¿Está buscando anomalías dentro de un rango de temperatura específico?</translation>
     </message>
@@ -1123,7 +1123,7 @@ Detalles:
         <translation>¿Quiere detectar personas específicamente?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="169"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="168"/>
         <source>Do you want to detect anomalies relative to local surroundings?</source>
         <translation>¿Quiere detectar anomalías relativas al entorno local?</translation>
     </message>
@@ -1138,12 +1138,12 @@ Detalles:
         <translation>¿Quiere ajustar manualmente el rango de color?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="194"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="193"/>
         <source>Do your images contain complex backgrounds or structures?</source>
         <translation>¿Sus imágenes contienen fondos o estructuras complejas?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="201"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="200"/>
         <source>Do your images include shadows or areas with uneven lighting?</source>
         <translation>¿Sus imágenes incluyen sombras o áreas con iluminación desigual?</translation>
     </message>
@@ -1179,7 +1179,7 @@ Detalles:
 <context>
     <name>AlignImageDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="53"/>
         <source>This saved alignment looks mirrored - re-place each corner handle on its matching photo corner (coloured squares).</source>
         <translation>Esta alineación guardada parece estar invertida: vuelva a colocar cada tirador de esquina sobre la esquina correspondiente de la foto (cuadros de color).</translation>
     </message>
@@ -1189,7 +1189,7 @@ Detalles:
         <translation>Alinear imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="136"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="130"/>
         <source>Rotate the drone image to line it up with the map. The small coloured squares mark the photo&apos;s corners - drag each corner handle onto the map where its matching-coloured photo corner belongs. For extra accuracy, add tie points: put the IMAGE end on a feature in the drone photo and the MAP end on the same feature on the map.</source>
         <translation>Gire la imagen del dron para alinearla con el mapa. Los cuadros de color pequeños marcan las esquinas de la foto: arrastre cada tirador de esquina en el mapa hasta el lugar donde corresponde la esquina de la foto del mismo color. Para mayor precisión, añada puntos de amarre: coloque el extremo IMAGEN sobre un rasgo de la foto del dron y el extremo MAPA sobre el mismo rasgo en el mapa.</translation>
     </message>
@@ -1235,7 +1235,7 @@ Detalles:
         <translation>Las esquinas parecen invertidas</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="220"/>
         <source>The four corners appear mirrored - the drone image would map to the ground flipped.
 
 Each corner handle is colour-matched to a corner of the drone photo (the small coloured squares). Make sure every handle sits where its matching photo corner belongs.</source>
@@ -1275,7 +1275,7 @@ Cada tirador de esquina tiene el mismo color que una esquina de la foto del dron
         <translation>metros</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="100"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="98"/>
         <source>feet</source>
         <translation>pies</translation>
     </message>
@@ -1285,7 +1285,7 @@ Cada tirador de esquina tiene el mismo color que una esquina de la foto del dron
         <translation>Altitud negativa detectada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="113"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="111"/>
         <source>WARNING! Relative Altitude is negative. Enter an AGL altitude to be used for GSD calculations (in {unit}):</source>
         <translation>¡ADVERTENCIA! La altitud relativa es negativa. Introduzca una altitud AGL para usarla en los cálculos de GSD (en {unit}):</translation>
     </message>
@@ -1295,7 +1295,7 @@ Cada tirador de esquina tiene el mismo color que una esquina de la foto del dron
         <translation>Reemplazar altitud</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="132"/>
         <source>Enter a custom AGL altitude to be used for GSD calculations for all images (in {unit}):</source>
         <translation>Introduzca una altitud AGL personalizada para usarla en los cálculos de GSD de todas las imágenes (en {unit}):</translation>
     </message>
@@ -1367,7 +1367,7 @@ Cada tirador de esquina tiene el mismo color que una esquina de la foto del dron
         <translation>Rumbos faltantes detectados</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="135"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="132"/>
         <source>Some images are missing bearing/heading information. We can estimate bearings from a flight track file (KML/GPX/CSV) or calculate them automatically from image GPS coordinates.</source>
         <translation>A algunas imágenes les falta información de rumbo/dirección. Podemos estimar los rumbos a partir de un archivo de ruta de vuelo (KML/GPX/CSV) o calcularlos automáticamente a partir de las coordenadas GPS de las imágenes.</translation>
     </message>
@@ -1402,7 +1402,7 @@ Cada tirador de esquina tiene el mismo color que una esquina de la foto del dron
         <translation>Seleccionar archivo de ruta</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="262"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="261"/>
         <source>Track Files (*.kml *.gpx *.csv);;KML Files (*.kml);;GPX Files (*.gpx);;CSV Files (*.csv);;All Files (*.*)</source>
         <translation>Archivos de ruta (*.kml *.gpx *.csv);;Archivos KML (*.kml);;Archivos GPX (*.gpx);;Archivos CSV (*.csv);;Todos los archivos (*.*)</translation>
     </message>
@@ -1442,7 +1442,7 @@ Cada tirador de esquina tiene el mismo color que una esquina de la foto del dron
         <translation>Error en el cálculo de rumbo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="393"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="391"/>
         <source>An error occurred during bearing calculation:
 
 {error}
@@ -1470,7 +1470,7 @@ Compruebe sus archivos de entrada e inténtelo de nuevo.</translation>
         <translation>Recuperación de rumbo no necesaria</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="440"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="437"/>
         <source>Bearing recovery requires multiple images to calculate direction of travel.
 
 With only one image, bearing recovery cannot be performed.</source>
@@ -1479,7 +1479,7 @@ With only one image, bearing recovery cannot be performed.</source>
 Con solo una imagen, no se puede realizar la recuperación de rumbo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="452"/>
         <source>
 &lt;h3&gt;What is Bearing Recovery?&lt;/h3&gt;
 
@@ -1558,14 +1558,14 @@ Continuar sin recuperación de rumbo. Es posible que algunas funciones no funcio
         <translation>Datos en caché no encontrados</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="57"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="56"/>
         <source>The following cached items were not found:
 </source>
         <translation>No se encontraron los siguientes elementos en caché:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="71"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="66"/>
         <source>Without cached data, thumbnails and colors will be generated on-demand, which may cause delays when viewing results.
 
 If you have previously processed this dataset and have an ADIAT_Results folder with cached data, you can locate it now to improve performance.</source>
@@ -1594,7 +1594,7 @@ Si ha procesado previamente este conjunto de datos y tiene una carpeta ADIAT_Res
         <translation>Carpeta de caché no válida</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="143"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="138"/>
         <source>The selected folder does not contain thumbnail cache directory.
 
 Expected to find:
@@ -1658,7 +1658,7 @@ Seleccione una carpeta ADIAT_Results válida.</translation>
         <translation>Credenciales actualizadas</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="517"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="516"/>
         <source>Credentials have been updated and the map list has been refreshed.</source>
         <translation>Las credenciales se han actualizado y la lista de mapas se ha renovado.</translation>
     </message>
@@ -1668,7 +1668,7 @@ Seleccione una carpeta ADIAT_Results válida.</translation>
         <translation>Error de actualización</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="526"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="523"/>
         <source>Failed to refresh account data with new credentials.
 
 Please check your credentials and try again.</source>
@@ -1691,7 +1691,7 @@ Compruebe sus credenciales e inténtelo de nuevo.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="544"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="542"/>
         <source>Credentials have been updated. Please close and reopen this dialog to refresh the map list.</source>
         <translation>Las credenciales se han actualizado. Cierre y vuelva a abrir este diálogo para renovar la lista de mapas.</translation>
     </message>
@@ -1701,7 +1701,7 @@ Compruebe sus credenciales e inténtelo de nuevo.</translation>
         <translation>Ningún mapa seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="560"/>
         <source>Please select a map from the list.</source>
         <translation>Seleccione un mapa de la lista.</translation>
     </message>
@@ -1757,7 +1757,7 @@ Compruebe sus credenciales e inténtelo de nuevo.</translation>
         <translation>Error al cargar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Error al cargar CalTopo. Compruebe su conexión a Internet e inténtelo de nuevo.</translation>
     </message>
@@ -1772,7 +1772,7 @@ Compruebe sus credenciales e inténtelo de nuevo.</translation>
         <translation>Ningún mapa seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="480"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1786,7 +1786,7 @@ La URL del mapa debe contener un ID de mapa (p. ej., /m/ABC123 o #id=ABC123).</t
         <translation>Navegador no listo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="488"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>El navegador de CalTopo aún se está cargando. Espere un momento e inténtelo de nuevo.</translation>
     </message>
@@ -1802,12 +1802,12 @@ La URL del mapa debe contener un ID de mapa (p. ej., /m/ABC123 o #id=ABC123).</t
         <translation>Error de autenticación</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Navegador no inicializado. Inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="768"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1834,7 +1834,7 @@ Asegúrese de haber iniciado sesión en CalTopo en esta ventana y de haber abier
         <translation>Credenciales de API de equipo CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="87"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="85"/>
         <source>Enter your CalTopo Team API credentials.
 These can be found in the Team Admin page under Service Accounts.</source>
         <translation>Introduzca sus credenciales de API de equipo de CalTopo.
@@ -1945,7 +1945,7 @@ Puede encontrarlas en la página de administración del equipo en Servicios de C
         <translation>Secreto de credencial no válido</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="268"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="263"/>
         <source>The Credential Secret cannot be used to sign a CalTopo request.
 
 Copy it exactly as shown on the CalTopo Team Admin page under Service Accounts - it is a long base64 string, not the Credential ID or the Team ID.
@@ -1968,7 +1968,7 @@ Detalles: {error}</translation>
         <translation>Credenciales válidas</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="319"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="318"/>
         <source>The credentials are valid and successfully authenticated with CalTopo API.</source>
         <translation>Las credenciales son válidas y se autenticaron correctamente con la API de CalTopo.</translation>
     </message>
@@ -1978,7 +1978,7 @@ Detalles: {error}</translation>
         <translation>Credenciales no válidas</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="332"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="325"/>
         <source>The credentials failed to authenticate with CalTopo API.
 
 Please check:
@@ -2013,13 +2013,13 @@ Compruebe:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="488"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1297"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1298"/>
         <source>Offline Mode Enabled</source>
         <translation>Modo sin conexión habilitado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="495"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1304"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1300"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2035,13 +2035,13 @@ Desactive Solo sin conexión para exportar a CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="501"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1310"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1311"/>
         <source>Nothing Selected</source>
         <translation>Nada seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="505"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="503"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1313"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Seleccione al menos un tipo de datos (AOI marcados, ubicaciones de dron/imagen o área de cobertura) para exportar.</translation>
     </message>
@@ -2066,7 +2066,7 @@ Desactive Solo sin conexión para exportar a CalTopo.</translation>
         <translation>Error de preparación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="563"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="562"/>
         <source>An error occurred while preparing export data:
 
 {error}</source>
@@ -2090,14 +2090,14 @@ Desactive Solo sin conexión para exportar a CalTopo.</translation>
         <translation>área de cobertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="582"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="579"/>
         <source>No flagged AOIs, geotagged image locations, or coverage areas are available.
 Flag some AOIs with the &apos;F&apos; key or ensure your images have GPS metadata.</source>
         <translation>No hay AOI marcados, ubicaciones de imágenes geoetiquetadas ni áreas de cobertura disponibles.
 Marque algunos AOI con la tecla &apos;F&apos; o asegúrese de que sus imágenes tengan metadatos GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="590"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="585"/>
         <source>Found {count} flagged AOI(s), but could not extract GPS coordinates.
 
 This usually means:
@@ -2114,30 +2114,11 @@ Esto normalmente significa:
 Asegúrese de que sus imágenes tengan coordenadas GPS incrustadas.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="593"/>
         <source>No geotagged drone/image locations were found.
 Ensure your images contain GPS metadata and try again.</source>
         <translation>No se encontraron ubicaciones geoetiquetadas del dron/imagen.
 Asegúrese de que sus imágenes contengan metadatos GPS e inténtelo de nuevo.</translation>
-    </message>
-    <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="605"/>
-        <source>No coverage area polygons could be calculated.
-
-This usually means:
-• The images don&apos;t have GPS data in their EXIF metadata
-• The images are not nadir (gimbal pitch must be between -85° and -95°)
-• GSD (ground sample distance) could not be calculated
-
-Please ensure your images have GPS coordinates and are nadir shots.</source>
-        <translation>No se pudieron calcular polígonos de área de cobertura.
-
-Esto normalmente significa:
-• Las imágenes no tienen datos GPS en sus metadatos EXIF
-• Las imágenes no son nadir (la inclinación del gimbal debe estar entre -85° y -95°)
-• No se pudo calcular el GSD (distancia de muestreo del suelo)
-
-Asegúrese de que sus imágenes tengan coordenadas GPS y sean tomas nadir.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="608"/>
@@ -2145,18 +2126,18 @@ Asegúrese de que sus imágenes tengan coordenadas GPS y sean tomas nadir.</tran
         <translation>No hay {types} disponibles para exportar.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="613"/>
         <source>Nothing to Export</source>
         <translation>Nada para exportar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="637"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="680"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="638"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No Map Selected</source>
         <translation>Ningún mapa seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="643"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="640"/>
         <source>Please navigate to a CalTopo map before clicking &apos;I&apos;m Logged In&apos;.
 
 The map URL should look like:
@@ -2167,7 +2148,7 @@ La URL del mapa debería verse así:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="686"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2176,7 +2157,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Abra su mapa en la ventana de CalTopo antes de hacer clic en &apos;He iniciado sesión - Exportar datos&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1615"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1613"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2190,7 +2171,7 @@ El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consol
         <translation>Fotos subidas: {uploaded} de {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1630"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2199,7 +2180,7 @@ The items should now be visible on your map.</source>
 Los elementos ya deberían aparecer en su mapa.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1641"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1639"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2208,24 +2189,24 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Los detalles de lo que falló se registraron en el archivo de registro (adiat_logs.txt) y en la consola.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1628"/>
         <source>Export Successful</source>
         <translation>Exportación exitosa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1636"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1637"/>
         <source>Partial Success</source>
         <translation>Éxito parcial</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1610"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1611"/>
         <source>Export Failed</source>
         <translation>Exportación fallida</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="718"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1377"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1572"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1378"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1573"/>
         <source>Export Error</source>
         <translation>Error de exportación</translation>
     </message>
@@ -2240,7 +2221,7 @@ Los detalles de lo que falló se registraron en el archivo de registro (adiat_lo
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1057"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1055"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2249,14 +2230,27 @@ Number of corners: {count}</source>
 Número de esquinas: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1534"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1535"/>
         <source>Exporting to CalTopo</source>
         <translation>Exportando a CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1265"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1266"/>
         <source>Logged Out</source>
         <translation>Sesión cerrada</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="598"/>
+        <source>No coverage area polygons could be calculated.
+
+This usually means:
+• The images don&apos;t have GPS data in their EXIF metadata
+• The images are not nadir (gimbal pitch must be between -85° and -95°;
+  WALDO images: boresight within 40° of nadir)
+• GSD (ground sample distance) could not be calculated
+
+Please ensure your images have GPS coordinates and are near-nadir shots.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1267"/>
@@ -2264,17 +2258,17 @@ Número de esquinas: {count}</translation>
         <translation>Sesión cerrada correctamente en CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1425"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1426"/>
         <source>Loading CalTopo Maps</source>
         <translation>Cargando mapas de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
         <source>Connecting to CalTopo...</source>
         <translation>Conectando a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1430"/>
         <source>Fetching account data and maps...</source>
         <translation>Obteniendo datos de la cuenta y mapas...</translation>
     </message>
@@ -2293,7 +2287,7 @@ Número de esquinas: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="696"/>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
         <source>Authentication Failed</source>
         <translation>Error de autenticación</translation>
@@ -2313,7 +2307,7 @@ Número de esquinas: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1497"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1492"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2326,12 +2320,12 @@ El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consol
 ¿Desea volver a introducir su ID de equipo, ID de credencial y secreto de credencial?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1537"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exportando a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1539"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparando datos y exportando...</translation>
     </message>
@@ -2349,7 +2343,7 @@ El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consol
         <translation>Seleccionar método de exportación de CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="62"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="61"/>
         <source>Choose how you want to authenticate with CalTopo:</source>
         <translation>Elija cómo desea autenticarse con CalTopo:</translation>
     </message>
@@ -2364,7 +2358,7 @@ El motivo se registró en el archivo de registro (adiat_logs.txt) y en la consol
         <translation>API (recomendado para cuenta de equipo CalTopo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="77"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="75"/>
         <source>Use CalTopo Team API with service account credentials.
 Best for Teams accounts with service accounts configured.</source>
         <translation>Usar la API de equipo de CalTopo con credenciales de cuenta de servicio.
@@ -2376,14 +2370,14 @@ Ideal para cuentas de equipo con cuentas de servicio configuradas.</translation>
         <translation>Inicio de sesión por navegador</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="81"/>
         <source>Use browser-based authentication.
 Log in through an embedded browser window.</source>
         <translation>Usar autenticación basada en navegador.
 Inicie sesión a través de una ventana de navegador incrustada.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="98"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="96"/>
         <source>API method requires Team ID and Credential Secret from your
 CalTopo Team Admin page. Browser method uses your regular login.</source>
         <translation>El método API requiere el ID de equipo y el secreto de credencial de su
@@ -2413,7 +2407,7 @@ página de administración de equipo CalTopo. El método navegador usa su inicio
         <translation>Activar votación temporal (reducir parpadeo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="42"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="38"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -2429,7 +2423,7 @@ Recomendado: activado para todos los casos de uso (predeterminado).</translation
         <translation>Fotogramas de ventana (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="53"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -2447,7 +2441,7 @@ Recomendado: 5 para video de 30 fps (ventana de ~167 ms), 7 para 60 fps.</transl
         <translation>Umbral (N de M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="71"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="66"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -2470,7 +2464,7 @@ Recomendado: 3 de 5 (detección en el 60% de los fotogramas).</translation>
         <translation>Activar filtro de relación de aspecto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="85"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -2484,7 +2478,7 @@ La mayoría de los usuarios puede dejarlo desactivado salvo que vea muchos falso
         <translation>Relación mín.:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="104"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="100"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -2500,7 +2494,7 @@ Ejemplo: 0,2 = rechazar si la altura es más de 5 veces el ancho.</translation>
         <translation>Relación máx.:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="116"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="113"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -2519,7 +2513,7 @@ Valores mayores = permiten objetos más anchos, como vehículos o equipos largos
         <translation>Activar agrupación de detecciones</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="131"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="128"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -2533,7 +2527,7 @@ La mayoría de los usuarios puede dejarlo desactivado salvo que los objetos se v
         <translation>Distancia de agrupación (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="142"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -2562,7 +2556,7 @@ Click to change color</source>
 Haga clic para cambiar el color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="79"/>
+        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="78"/>
         <source>HSV: ({h}°, {s}%, {v}%)
 RGB: ({r}, {g}, {b})
 Click to change color</source>
@@ -2609,7 +2603,7 @@ Haga clic para cambiar el color</translation>
         <translation>Activar detección de movimiento</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="153"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="149"/>
         <source>Turn ON to highlight moving objects in the scene.
 Most users can leave all other settings at their defaults.
 Works best for stationary or slow-moving cameras and can be combined
@@ -2645,7 +2639,7 @@ con la detección de anomalías por color para obtener resultados más robustos.
         <translation>KNN</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="179"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="174"/>
         <source>Motion detection algorithm (advanced setting):
 
 • FRAME_DIFF – Fast and simple; very sensitive to any motion.
@@ -2672,7 +2666,7 @@ Si no está seguro, déjelo en MOG2.</translation>
         <translation>Umbral de movimiento:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="200"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="196"/>
         <source>Minimum pixel intensity change to consider as motion (1-255).
 Lower values = more sensitive, detects subtle motion, more false positives.
 Higher values = less sensitive, only strong motion, fewer false positives.
@@ -2688,7 +2682,7 @@ Recomendado: 10 para uso general, 5 para movimiento sutil, 15-20 para escenas de
         <translation>Kernel de desenfoque (impar):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="215"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="210"/>
         <source>Gaussian blur kernel size (must be odd: 1, 3, 5, 7, etc.).
 Smooths the frame before motion detection to reduce noise.
 Larger values = more smoothing, less noise, less detail.
@@ -2706,7 +2700,7 @@ Recomendado: 5 para uso general, 1 sin desenfoque, 7-9 para videos con ruido.</t
         <translation>Kernel morfológico:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="230"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="225"/>
         <source>Morphological operation kernel size (odd numbers: 1, 3, 5, etc.).
 Removes small noise and fills holes in detections.
 Larger values = remove more noise, merge nearby detections.
@@ -2729,7 +2723,7 @@ Recomendado: 3 para uso general, 1 para bordes precisos, 5-7 para videos con rui
         <translation>Fotogramas de ventana (M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="251"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="246"/>
         <source>Size of temporal window for persistence filtering (2-30 frames).
 Motion must appear in N out of M consecutive frames to be confirmed.
 Larger values = longer memory, more stable, slower response.
@@ -2747,7 +2741,7 @@ Recomendado: 3 para video de 30 fps (ventana de 100 ms), 5 para 60 fps.</transla
         <translation>Umbral (N de M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="264"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="259"/>
         <source>Number of frames within window where motion must appear (N of M).
 Higher values = more stringent, filters flickering false positives.
 Lower values = more lenient, detects brief/intermittent motion.
@@ -2770,7 +2764,7 @@ Recomendado: 2 (movimiento en 2 de los últimos 3 fotogramas).</translation>
         <translation>Fotogramas de historial:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="285"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="280"/>
         <source>Number of frames to learn background model (10-500).
 Only applies to MOG2 and KNN algorithms.
 Longer history = adapts slower to lighting changes, more stable.
@@ -2788,7 +2782,7 @@ Recomendado: 50 (~1,7 s a 30 fps) para uso general.</translation>
         <translation>Umbral de varianza:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="298"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="293"/>
         <source>Variance threshold for background/foreground classification (1.0-100.0).
 Only applies to MOG2 and KNN algorithms.
 Lower values = more sensitive, detects subtle changes, more false positives.
@@ -2806,7 +2800,7 @@ Recomendado: 10,0 para interiores, 15-20 para exteriores con iluminación variab
         <translation>Detectar sombras (más lento)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="307"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="303"/>
         <source>Enables shadow detection in MOG2 background subtractor.
 Helps distinguish shadows from actual objects (reduces false positives).
 Adds ~10-20% processing overhead.
@@ -2828,7 +2822,7 @@ Recomendado: activado en exteriores con sombras marcadas; desactivado para mayor
         <translation>Área mín. del objeto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="328"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="323"/>
         <source>Minimum detection area in pixels (1-100000).
 Filters out very small detections such as noise, insects, or raindrops.
 Lower values = detect smaller objects (more noise).
@@ -2847,7 +2841,7 @@ Recomendado: 5-10 para movimiento de tamaño humano, 50-100 para vehículos.</tr
         <translation>Área máx. del objeto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="341"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="336"/>
         <source>Maximum detection area in pixels (10-1000000).
 Filters out very large regions such as full-frame lighting changes or giant shadows.
 Lower values = only small/medium objects.
@@ -2870,7 +2864,7 @@ Recomendado: 1000 para personas, 10000 para vehículos, más alto para objetos m
         <translation>Pausar si la cámara se mueve</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="357"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="353"/>
         <source>Automatically pauses motion detection when camera is moving/panning.
 Prevents false positives caused by camera movement (entire scene appears to move).
 Detects camera movement by measuring percentage of frame with motion.
@@ -2886,7 +2880,7 @@ Recomendado: activado para video de mano/dron; desactivado para cámaras fijas e
         <translation>Umbral:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="371"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="366"/>
         <source>Percentage of frame with motion to consider as camera movement (1-100%).
 If more than this % of pixels show motion, pause detection.
 Lower values = detect camera movement sooner (more pauses).
@@ -2904,7 +2898,7 @@ Recomendado: 15% para dron/mano, 30% para trípode inestable.</translation>
         <translation>Mostrar ajustes avanzados de movimiento</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="386"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="383"/>
         <source>Advanced users can expand this to adjust the motion algorithm
 and detailed thresholds (sensitivity, filters, background model).
 If you are unsure, leave this unchecked and use the defaults.</source>
@@ -2918,7 +2912,7 @@ Si no está seguro, déjelo sin marcar y use los valores predeterminados.</trans
         <translation>Activar detección de anomalías por color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="409"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="405"/>
         <source>Detects pixels whose colors are statistically rare in the frame.
 Conceptually similar to MRMap&apos;s rarity-based detection for images.
 Works well for: bright colored clothing, vehicles, equipment in natural scenes.
@@ -2939,7 +2933,7 @@ Puede combinarse con la detección de movimiento para obtener detecciones más r
         <translation>Resolución de color (intervalos):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="430"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="424"/>
         <source>Controls how finely colors are grouped into histogram bins (3-8 bits).
 Analogous to MRMap&apos;s color binning.
 Lower values (3-4) = fewer bins → faster, more grouping, fewer but stronger detections.
@@ -2964,7 +2958,7 @@ y valores mayores solo cuando necesite distinguir diferencias de color muy sutil
         <translation>Umbral de rareza (% de colores):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="448"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="442"/>
         <source>Sensitivity threshold for how rare a color must be to be flagged (0-100%).
 Computed from the distribution of color-bin counts in the frame, similar in role
 to MRMap&apos;s detection threshold.
@@ -2979,7 +2973,7 @@ Valores medios (25-40%) = equilibrado (recomendado para uso general).
 Valores mayores (40-60%) = más sensible: incluye colores más comunes (más detecciones).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="464"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="459"/>
         <source>Minimum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s minimum AOI area.
 Lower values = detect smaller colored objects (more noise).
@@ -2992,7 +2986,7 @@ Valores mayores = solo regiones de color más grandes (menos ruido).
 Recomendado: 15 para objetivos de tamaño humano, 50+ para vehículos u objetos grandes.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="477"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="472"/>
         <source>Maximum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s maximum AOI area.
 Lower values = only detect smaller colored objects.
@@ -3020,7 +3014,7 @@ Recomendado: 50000 para uso general, 10000 para búsquedas solo de objetos peque
         <translation>Componentes conectados</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="491"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="486"/>
         <source>Method for extracting blob regions from the detection mask:
 
 Find Contours: Traditional OpenCV contour detection (default).
@@ -3062,7 +3056,7 @@ Connected Components: usa cv2.connectedComponentsWithStats.
         <translation>LAB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="518"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="509"/>
         <source>Color space for histogram-based anomaly detection:
 
 RGB: Uses all 3 color channels. Fast, but sensitive to lighting.
@@ -3094,7 +3088,7 @@ LAB (cromaticidad a,b): usa los canales a,b; es invariante a la iluminación y p
         <translation>Saturación mín. HSV:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="535"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="529"/>
         <source>Minimum saturation for HSV mode (0-255).
 Pixels below this saturation are ignored (grays, whites, blacks).
 These have undefined/noisy hue values.
@@ -3114,7 +3108,7 @@ Recomendado: 30-50 para uso general.</translation>
         <translation>Croma mín. LAB:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="555"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="549"/>
         <source>Minimum chroma (color intensity) for LAB mode (0-128).
 Chroma = distance from neutral gray in a,b plane.
 Pixels below this are ignored (near-neutral grays).
@@ -3139,7 +3133,7 @@ Recomendado: 10-20 para uso general.</translation>
         <translation>Permitir colores similares (expansión de tono)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="577"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="573"/>
         <source>Lets the detector treat similar colors as the same object.
 For example, a red jacket that looks slightly orange in some frames will still be grouped together.
 Turn this OFF if you only care about one very specific color shade.
@@ -3155,7 +3149,7 @@ Actívelo si desea una familia completa de colores (por ejemplo, cualquier rojo/
         <translation>Rango de coincidencia de color:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="590"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="586"/>
         <source>How wide to stretch the color match around each detected color.
 Smaller values = stay very close to the original color (more specific).
 Larger values = include a wider range of similar colors (more forgiving).
@@ -3181,7 +3175,7 @@ Recomendado: valores bajos para colores precisos; valores mayores cuando la ilum
         <translation>Activar exclusión de color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="609"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="605"/>
         <source>Exclude specific background colors from color anomaly detection.
 Useful for ignoring dominant scene colors such as grass, sky, or buildings.
 Click on the color wheel below to choose colors to ignore.
@@ -3197,7 +3191,7 @@ Los colores seleccionados se resaltan con un borde oscuro.</translation>
         <translation>Haga clic en la rueda de color para excluir colores (pasos de 20°, 0-360°):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="621"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="618"/>
         <source>Click on any color segment to toggle exclusion on/off.
 Segments represent broad color ranges (e.g., blues, greens, reds).
 Use this to teach the system which background colors to ignore.</source>
@@ -3216,7 +3210,7 @@ Use esta opción para indicar al sistema qué colores de fondo debe ignorar.</tr
         <translation>Activar fusión (cuando movimiento y color estén activados)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="645"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="641"/>
         <source>Combines motion and color detections when both are enabled.
 Only active when both Motion and Color detection are ON.
 Different modes control how detections are merged.
@@ -3252,7 +3246,7 @@ Recomendado: activado para una detección multimodal robusta.</translation>
         <translation>MOTION_PRIORITY</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="666"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="657"/>
         <source>How to combine motion and color detections:
 
 • UNION: Show all detections from both (most detections).
@@ -3407,7 +3401,7 @@ agresivo</translation>
         <translation>Añadir color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="115"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="111"/>
         <source>Add a new color range to detect.
 Choose from HSV Color Picker, Image, List, or Recent Colors.
 You can add multiple color ranges to detect different colors simultaneously.</source>
@@ -3421,7 +3415,7 @@ Puede añadir varios rangos de color para detectar distintos colores simultánea
         <translation>Ver rango</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="139"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="134"/>
         <source>View HSV color ranges for all configured colors.
 Opens a viewer dialog for each color range showing
 the hue, saturation, and value ranges that will be detected.
@@ -3442,7 +3436,7 @@ los rangos de tono, saturación y valor que se detectarán.
         <translation>Área mín. del objeto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="190"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="184"/>
         <source>Minimum detection area in pixels (10-50000).
 Filters out very small detections (noise, small objects, fragments).
 Lower values = detect smaller objects, more detections, more noise.
@@ -3460,7 +3454,7 @@ Recomendado: 100 para uso general, 50 para objetos pequeños, 200-500 para objet
         <translation>Área máx. del objeto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="205"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="199"/>
         <source>Maximum detection area in pixels (100-500000).
 Filters out very large detections (shadows, lighting changes, entire scene).
 Lower values = only small/medium objects.
@@ -3478,7 +3472,7 @@ Recomendado: 100000 para uso general, 50000 para objetos pequeños, 200000+ para
         <translation>Umbral de confianza:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="224"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="215"/>
         <source>Minimum confidence score to accept a detection (0-100%).
 Confidence is calculated from:
 • Size score: area relative to max area
@@ -3551,7 +3545,7 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>Rangos de color: {count} colores</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="330"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="329"/>
         <source>Please add at least one color to detect.</source>
         <translation>Añada al menos un color para detectar.</translation>
     </message>
@@ -3564,7 +3558,7 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>Histograma de matiz no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="59"/>
         <source>No color image data is available for the current image.</source>
         <translation>No hay datos de imagen en color disponibles para la imagen actual.</translation>
     </message>
@@ -3619,14 +3613,14 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>Restablecer rango</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="65"/>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="174"/>
         <location filename="../resources/views/images/viewer/ColorHistogramDialog.ui" line="127"/>
         <source>Hover over the histogram to inspect a hue band.</source>
         <translation>Pase el cursor sobre el histograma para inspeccionar una banda de la matiz.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="30"/>
         <source>No hue histogram data available</source>
         <translation>No hay datos de histograma disponible de la matiz</translation>
     </message>
@@ -3681,8 +3675,8 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="57"/>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="62"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Usos</translation>
     </message>
@@ -3751,7 +3745,7 @@ Recomendado: 50% para un filtrado equilibrado, 30% para más detecciones, 70% pa
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="446"/>
+        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (cursor)</translation>
     </message>
@@ -3811,7 +3805,7 @@ Use this to see what colors are going to be detected and optimize the color rang
         <translation>Ningún color seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="325"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="324"/>
         <source>Please add at least one color to detect.</source>
         <translation>Añada al menos un color para detectar.</translation>
     </message>
@@ -3839,7 +3833,7 @@ Use this to see what colors are going to be detected and optimize the color rang
         <translation>Imagen original</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="219"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="216"/>
         <source>Original image preview.
 Shows the unmodified input image for reference.
 Use this to compare with the filtered result below.</source>
@@ -3853,7 +3847,7 @@ Muestra la imagen de entrada sin modificar como referencia.
         <translation>Resultado filtrado</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="232"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="228"/>
         <source>Filtered result preview.
 Shows pixels that match your current HSV color range settings.
 Updates in real-time as you adjust the color and range values.
@@ -3869,7 +3863,7 @@ Los píxeles coincidentes se muestran; los no coincidentes aparecen en negro.</t
         <translation>Mostrar solo máscara</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="241"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="237"/>
         <source>Toggle between masked color result and grayscale mask.
 • Unchecked (default): Shows the original image with matching colors visible
 • Checked: Shows a black and white mask where white = matching pixels
@@ -3900,7 +3894,7 @@ Use la vista de máscara para ver claramente qué píxeles se detectan.</transla
         <translation>Probar en imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="273"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="270"/>
         <source>Test current HSV range settings on the loaded image.
 Manually triggers a preview update to see detection results.
 Preview updates automatically as you adjust settings.</source>
@@ -3914,7 +3908,7 @@ La vista previa se actualiza automáticamente al ajustar la configuración.</tra
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="284"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="282"/>
         <source>Cancel color selection.
 Discards all changes and closes the dialog without applying the color range.</source>
         <translation>Cancela la selección de color.
@@ -3926,7 +3920,7 @@ Descarta todos los cambios y cierra el cuadro de diálogo sin aplicar el rango d
         <translation>Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="292"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="289"/>
         <source>Apply color selection.
 Saves the current HSV color range settings and closes the dialog.
 The selected color range will be used for image analysis.</source>
@@ -4012,7 +4006,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Ver rango</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="259"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="258"/>
         <source>Please add at least one color to detect.</source>
         <translation>Añada al menos un color para detectar.</translation>
     </message>
@@ -4096,7 +4090,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Vista orientada al norte (rotada {angle:.1f}°)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="445"/>
+        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="444"/>
         <source>Original bearing: {bearing:.1f}° | Rotation applied: {rotation:.1f}°</source>
         <translation>Rumbo original: {bearing:.1f}° | Rotación aplicada: {rotation:.1f}°</translation>
     </message>
@@ -4144,7 +4138,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Añadir lotes a la búsqueda</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="79"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="78"/>
         <source>Add more batch XML files to the current search project</source>
         <translation>Añadir más archivos XML de lotes al proyecto de búsqueda actual</translation>
     </message>
@@ -4169,7 +4163,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Revisar lote seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="118"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="116"/>
         <source>Open the selected batch&apos;s results in the Viewer to review (same as double-clicking the batch).</source>
         <translation>Abrir los resultados del lote seleccionado en el Visor para revisarlos (igual que al hacer doble clic en el lote).</translation>
     </message>
@@ -4288,7 +4282,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Todavía no hay revisores</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="315"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="312"/>
         <source>Batch review status and assignments. Load reviewer XMLs to update progress. Double-click a batch to open its results in the Viewer.</source>
         <translation>Estado y asignaciones de la revisión por lotes. Cargue los XML de los revisores para actualizar el progreso. Haga doble clic en un lote para abrir sus resultados en el visor.</translation>
     </message>
@@ -4313,12 +4307,12 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Revisiones</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="329"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="328"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="350"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="349"/>
         <source>Consolidated AOI data from all reviews. Shows flag counts and reviewer comments.</source>
         <translation>Datos consolidados de AOI de todas las revisiones. Muestra los recuentos de marcas y comentarios de revisores.</translation>
     </message>
@@ -4338,7 +4332,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Recuento de marcas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="363"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="362"/>
         <source>Comments</source>
         <translation>Comentarios</translation>
     </message>
@@ -4348,7 +4342,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Nuevo proyecto de búsqueda</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="381"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="380"/>
         <source>Enter project name:</source>
         <translation>Introduzca el nombre del proyecto:</translation>
     </message>
@@ -4358,7 +4352,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Información del coordinador</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="391"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="390"/>
         <source>Enter your name:</source>
         <translation>Introduzca su nombre:</translation>
     </message>
@@ -4373,7 +4367,7 @@ Haga clic en las imágenes para moverlas a la sección Seleccionadas de arriba.<
         <translation>Seleccionar archivos XML de lote inicial</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="409"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="403"/>
         <source>You can select multiple ADIAT_Data.xml files from different folders.
 
 Tips:
@@ -4393,11 +4387,11 @@ Consejos:
         <translation>Seleccionar archivos ADIAT_Data.xml de lotes (Mantenga Ctrl para seleccionar varios)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="420"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="435"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="559"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="606"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="661"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="419"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="434"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="558"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="605"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="660"/>
         <source>XML Files (*.xml)</source>
         <translation>Archivos XML (*.xml)</translation>
     </message>
@@ -4433,7 +4427,7 @@ Consejos:
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="454"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="453"/>
         <source>Failed to save project file.</source>
         <translation>Error al guardar el archivo del proyecto.</translation>
     </message>
@@ -4448,12 +4442,12 @@ Consejos:
         <translation>Abrir proyecto de búsqueda</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="465"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="464"/>
         <source>Search Project Files (ADIAT_Search_*.xml);;All XML Files (*.xml)</source>
         <translation>Archivos de proyecto de búsqueda (ADIAT_Search_*.xml);;Todos los archivos XML (*.xml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="475"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="474"/>
         <source>Project loaded successfully!</source>
         <translation>¡Proyecto cargado correctamente!</translation>
     </message>
@@ -4465,12 +4459,12 @@ Consejos:
 {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="508"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="507"/>
         <source>Failed to load project file.</source>
         <translation>Error al cargar el archivo del proyecto.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="519"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="518"/>
         <source>Project saved successfully!</source>
         <translation>¡Proyecto guardado correctamente!</translation>
     </message>
@@ -4485,7 +4479,7 @@ Consejos:
         <translation>Sin proyecto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="530"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="529"/>
         <source>Please create or open a project first.</source>
         <translation>Primero cree o abra un proyecto.</translation>
     </message>
@@ -4500,7 +4494,7 @@ Consejos:
         <translation>Añadir más archivos XML de lotes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="547"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="540"/>
         <source>Select additional ADIAT_Data.xml batch files to add to this search.
 
 Tips:
@@ -4522,7 +4516,7 @@ Consejos:
         <translation>Seleccionar archivos ADIAT_Data.xml de lotes para añadir (Mantenga Ctrl para seleccionar varios)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="581"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="579"/>
         <source>Successfully added {count} batch(es) to the project!
 Total batches: {total}</source>
         <translation>¡Se añadieron correctamente {count} lotes al proyecto!
@@ -4534,7 +4528,7 @@ Lotes totales: {total}</translation>
         <translation>No se añadieron lotes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="593"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="591"/>
         <source>No batches were added. Check that the XML files are valid ADIAT_Data.xml files.</source>
         <translation>No se añadió ningún lote. Compruebe que los archivos XML sean archivos ADIAT_Data.xml válidos.</translation>
     </message>
@@ -4549,7 +4543,7 @@ Lotes totales: {total}</translation>
         <translation>Sin lotes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="618"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="617"/>
         <source>No batches found in project.</source>
         <translation>No se encontraron lotes en el proyecto.</translation>
     </message>
@@ -4564,12 +4558,12 @@ Lotes totales: {total}</translation>
         <translation>¿A qué lote pertenece esta revisión?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="643"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="642"/>
         <source>Review data loaded and merged successfully!</source>
         <translation>¡Datos de revisión cargados y combinados correctamente!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="649"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="648"/>
         <source>Failed to load review data.</source>
         <translation>Error al cargar los datos de revisión.</translation>
     </message>
@@ -4596,7 +4590,7 @@ Lotes totales: {total}</translation>
         <translation>Ningún lote seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="760"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="759"/>
         <source>Select a batch in the table, then click Review Selected Batch.</source>
         <translation>Seleccione un lote de la tabla y, a continuación, haga clic en Revisar lote seleccionado.</translation>
     </message>
@@ -4609,7 +4603,7 @@ Lotes totales: {total}</translation>
         <translation>Generar KML de extensión de cobertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="131"/>
         <source>Generate a KML file showing the geographic coverage extent of all images?
 
 This will create polygon(s) representing the area covered by all images. Overlapping image areas will be merged into a single polygon.</source>
@@ -4623,7 +4617,7 @@ Esto creará polígonos que representan el área cubierta por todas las imágene
         <translation>Guardar KML de extensión de cobertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="148"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="147"/>
         <source>KML files (*.kml)</source>
         <translation>Archivos KML (*.kml)</translation>
     </message>
@@ -4677,7 +4671,7 @@ Esto creará polígonos que representan el área cubierta por todas las imágene
         <translation>Extensión de cobertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="285"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="278"/>
         <source>Could not calculate coverage extent.
 
 Images processed: {processed}
@@ -4686,36 +4680,29 @@ Images skipped: {skipped}
 Images may be skipped for the following reasons:
   • Missing GPS data in EXIF
   • No valid GSD (missing altitude/focal length)
-  • Gimbal not nadir (must be -85° to -95°)</source>
-        <translation>No se pudo calcular la extensión de cobertura.
-
-Imágenes procesadas: {processed}
-Imágenes omitidas: {skipped}
-
-Las imágenes pueden omitirse por los siguientes motivos:
-  • Faltan datos GPS en EXIF
-  • GSD no válido (falta altitud/distancia focal)
-  • Gimbal no en posición nadir (debe estar entre -85° y -95°)</translation>
+  • Gimbal not nadir (must be -85° to -95°;
+    WALDO: boresight within 40° of nadir)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="300"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="302"/>
         <source>{value:.2f} acres</source>
         <translation>{value:.2f} acres</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="305"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="306"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="307"/>
         <source>{value:.3f} km²</source>
         <translation>{value:.3f} km²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="309"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="310"/>
         <source>Coverage extent KML saved: {area}</source>
         <translation>KML de extensión de cobertura guardado: {area}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="324"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="319"/>
         <source>
 
 Images may be skipped for:
@@ -4730,12 +4717,12 @@ Las imágenes pueden omitirse por:
   • Gimbal no en posición nadir</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="327"/>
         <source>Coverage Extent KML Generated</source>
         <translation>KML de extensión de cobertura generado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="334"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="329"/>
         <source>Coverage extent KML file created successfully!
 
 File: {file}
@@ -4883,7 +4870,7 @@ inválida</translation>
 <context>
     <name>FlightMapView</name>
     <message>
-        <location filename="../app/core/views/components/FlightMapView.py" line="553"/>
+        <location filename="../app/core/views/components/FlightMapView.py" line="550"/>
         <source>QtWebEngine not available — install PySide6-Addons for the interactive map. Showing list view instead.</source>
         <translation type="unfinished">QtWebEngine no está disponible — instale PySide6-Addons para usar el mapa interactivo. Se mostrará la vista de lista.</translation>
     </message>
@@ -4942,7 +4929,7 @@ inválida</translation>
         <translation>el dron tiene {current}/{limit} visores conectados</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="99"/>
+        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="98"/>
         <source>known device — same fingerprint as last pair</source>
         <translation>dispositivo conocido — misma huella que en el último emparejamiento</translation>
     </message>
@@ -4991,7 +4978,7 @@ inválida</translation>
         <translation>Cambiar nombre de transmisión</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightTile.py" line="526"/>
+        <location filename="../app/core/views/flight/FlightTile.py" line="524"/>
         <source>Nickname for this drone (persists across new pairing codes via the aircraft serial number). Leave blank to clear.</source>
         <translation>Alias de este dron (se conserva aunque cambie el código de emparejamiento, mediante el número de serie de la aeronave). Déjelo en blanco para borrarlo.</translation>
     </message>
@@ -5123,7 +5110,7 @@ inválida</translation>
 <context>
     <name>FlightTileController</name>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="219"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="218"/>
         <source>Looking up code {code} and connecting to the drone.</source>
         <translation>Buscando el código {code} y conectando con el dron.</translation>
     </message>
@@ -5133,12 +5120,12 @@ inválida</translation>
         <translation>Nombrar este dispositivo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="297"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="295"/>
         <source>Give this publisher a name so you can recognise it next time (e.g. &apos;Operator A&apos;s M4E&apos;).</source>
         <translation>Asigne un nombre a este emisor para reconocerlo la próxima vez (p. ej., &apos;M4E del operador A&apos;).</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="318"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="313"/>
         <source>Device &apos;{label}&apos; presented a different DTLS fingerprint than the last time you paired with it. This could mean the controller was reset, a different controller is using the label, or somebody is impersonating it.
 
 Reject if you weren&apos;t expecting this.</source>
@@ -5147,12 +5134,12 @@ Reject if you weren&apos;t expecting this.</source>
 Rechácelo si no esperaba este cambio.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="483"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="480"/>
         <source>Pairing ended before video could start. Ask the operator to generate a new code and try again.</source>
         <translation>El emparejamiento terminó antes de que pudiera iniciarse el video. Pida al operador que genere un código nuevo e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1007"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1006"/>
         <source>Waiting for video before recording can start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5172,7 +5159,7 @@ Rechácelo si no esperaba este cambio.</translation>
         <translation type="unfinished">Grabación guardada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1157"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1156"/>
         <source>No finished recording to replay yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5192,12 +5179,12 @@ Rechácelo si no esperaba este cambio.</translation>
         <translation>Huella no coincidente — &apos;{label}&apos;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="332"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="330"/>
         <source>Fingerprint changed on {ts}; previous identity was overwritten after operator review.</source>
         <translation>La huella cambió el {ts}; la identidad anterior se sobrescribió tras la revisión del operador.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="425"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="422"/>
         <source>This drone already has {current} viewers connected (maximum {limit}). Ask one to disconnect, or try again later.</source>
         <translation>Este dron ya tiene {current} visores conectados (máximo {limit}). Pida a uno que se desconecte o inténtelo más tarde.</translation>
     </message>
@@ -5210,7 +5197,7 @@ Rechácelo si no esperaba este cambio.</translation>
         <translation>Nueva sesión de vuelo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="558"/>
+        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="555"/>
         <source>Mobile started a new flight under code {code}. The previous session&apos;s detections are still saved on this computer. Discard them, or keep them archived?</source>
         <translation>La app móvil inició un vuelo nuevo con el código {code}. Las detecciones de la sesión anterior siguen guardadas en este equipo. ¿Desea descartarlas o mantenerlas archivadas?</translation>
     </message>
@@ -5378,7 +5365,7 @@ Rechácelo si no esperaba este cambio.</translation>
         <translation>Activar máscara de región de procesamiento</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="55"/>
         <source>Enable to restrict detection processing to a specific region of the video.
 Useful for excluding edges, UI overlays, or focusing on specific areas.
 Improves performance by not processing masked regions.</source>
@@ -5392,7 +5379,7 @@ Mejora el rendimiento al no procesar las regiones enmascaradas.</translation>
         <translation>Activar margen de fotograma</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="72"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="69"/>
         <source>Exclude a uniform border from all edges of the video.
 Enter the number of pixels to exclude from each edge.
 The inner area will be processed for detections.</source>
@@ -5411,7 +5398,7 @@ El área interior se procesará para buscar detecciones.</translation>
         <translation>Margen (píxeles):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="91"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="87"/>
         <source>Number of pixels to exclude from all edges (0-1000).
 A value of 50 excludes 50 pixels from top, bottom, left, and right.
 Useful for removing UI overlays or camera lens distortion at edges.
@@ -5427,7 +5414,7 @@ Este valor se basa en la resolución original del video.</translation>
         <translation>Activar máscara de imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="102"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="99"/>
         <source>Load a black/white image as a custom mask.
 White areas will be processed, black areas excluded.
 The mask will be scaled to match the video resolution.</source>
@@ -5483,7 +5470,7 @@ La máscara se escalará para coincidir con la resolución del video.</translati
         <translation>Mostrar superposición de máscara en el video</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="142"/>
         <source>Display the processing region on the rendered video.
 Frame mode: Shows a cyan rectangle outline of the processed area.
 Image mask: Shows a semi-transparent overlay of excluded regions.</source>
@@ -5502,7 +5489,7 @@ Máscara de imagen: muestra una superposición semitransparente de las regiones 
         <translation>{error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="231"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="229"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>No se pudo cargar la imagen seleccionada. Elija un archivo de imagen válido.</translation>
     </message>
@@ -5512,7 +5499,7 @@ Máscara de imagen: muestra una superposición semitransparente de las regiones 
         <translation>Discrepancia de relación de aspecto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="243"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="240"/>
         <source>{error}
 
 The mask will be scaled to fit, which may cause distortion.
@@ -5533,7 +5520,7 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
         <translation>No se encontraron datos GPS en las imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="192"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="191"/>
         <source>POD overlay cleared — the elevation/canopy source changed. Recalculate to refresh it.</source>
         <translation>Superposición POD borrada: la fuente de elevación/dosel cambió. Recalcule para actualizarla.</translation>
     </message>
@@ -5548,17 +5535,17 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
         <translation>¿Calcular la cobertura POD?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="235"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="234"/>
         <source>Coverage data is ready. Calculate the probability-of-detection heatmap for this mission now? (May take several minutes.)</source>
         <translation>Los datos de cobertura están listos. ¿Calcular ahora el mapa de calor de probabilidad de detección para esta misión? (Puede tardar varios minutos.)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="293"/>
         <source>Your local USGS 3DEP tiles only partially cover this mission.</source>
         <translation>Sus teselas locales USGS 3DEP solo cubren parcialmente esta misión.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
         <source>Your local USGS 3DEP tiles do not cover this mission.</source>
         <translation>Sus teselas locales USGS 3DEP no cubren esta misión.</translation>
     </message>
@@ -5568,7 +5555,7 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
         <translation>Cobertura de elevación local</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="302"/>
         <source>Frames outside the local tiles will use online AWS Terrain Tiles (~30 m) elevation instead. You can download 1 m tiles for this area first, or continue with the fallback.</source>
         <translation>Los fotogramas fuera de las teselas locales usarán la elevación en línea de AWS Terrain Tiles (~30 m). Puede descargar primero teselas de 1 m para esta área o continuar con la alternativa.</translation>
     </message>
@@ -5598,7 +5585,7 @@ La máscara se escalará para ajustarse, lo que puede causar distorsión.
         <translation>¿Descargar datos de dosel?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="391"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="386"/>
         <source>No canopy-height data is configured for this mission.
 
 Download elevation and canopy tiles for this area now so the canopy overlay and terrain-aware detection coverage can use them?
@@ -5641,7 +5628,7 @@ Esto descarga la altura del dosel Meta/WRI (1 m) y la establece como fuente de d
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="603"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="602"/>
         <source>Altitude basis: reported ATO (approximate over terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5683,7 +5670,7 @@ Esto descarga la altura del dosel Meta/WRI (1 m) y la establece como fuente de d
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1297"/>
         <source>Move this AOI to {lat:.6f}, {lon:.6f}?
 
 That is {dist:.1f} m from its previous position. The corrected location is saved with the results and used for exports.</source>
@@ -5804,17 +5791,17 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Calcular POD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Compute the terrain-aware probability-of-detection heatmap for this mission (may take several minutes)</source>
         <translation>Calcular el mapa de calor de probabilidad de detección que considera el terreno para esta misión (puede tardar varios minutos)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="189"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="188"/>
         <source>Click point to select • Drag to pan • Scroll to zoom • Drag AOI marker to correct its location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="274"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="273"/>
         <source>Downloading tiles is disabled in Offline Only mode</source>
         <translation>La descarga de teselas está deshabilitada en el modo solo sin conexión</translation>
     </message>
@@ -5839,7 +5826,7 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Problema al cargar los mosaicos del mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="394"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5861,12 +5848,12 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1422"/>
         <source>Position corrected by user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1424"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
         <source>Drag to correct the location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5890,7 +5877,7 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
         <translation>AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="411"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="410"/>
         <source>AOIs</source>
         <translation>AOI</translation>
     </message>
@@ -5901,12 +5888,12 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
         <translation>{count} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="431"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="430"/>
         <source>Area of Interest</source>
         <translation>Área de interés</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="433"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="432"/>
         <source>Areas of Interest</source>
         <translation>Áreas de interés</translation>
     </message>
@@ -5914,7 +5901,7 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
 <context>
     <name>GeneralSettingsPage</name>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="122"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="121"/>
         <source>Select AOI Highlight Color</source>
         <translation>Seleccionar color de resaltado del AOI</translation>
     </message>
@@ -5924,7 +5911,7 @@ El mapa seguirá funcionando con los mosaicos en caché donde estén disponibles
         <translation>Evaluación completada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="164"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="161"/>
         <source>Detected {count} CPU core(s).
 
 Recommended number of processes: {recommended}
@@ -5955,7 +5942,7 @@ El deslizador se ha establecido en {recommended} procesos.</translation>
         <translation>Aplicar cuadrícula a todas las imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="322"/>
         <source>{n} image(s) already have review progress recorded at a different grid size.
 
 Reset their progress and apply {rows}×{cols} to them too?
@@ -5973,7 +5960,7 @@ Sí las restablece; No las mantiene en su tamaño actual.</translation>
         <translation>Imagen completamente revisada; avanzando</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="629"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="628"/>
         <source>cell {cell}/{cells} — image {image}/{images} — run {percent}% reviewed</source>
         <translation>celda {cell}/{cells} — imagen {image}/{images} — conjunto {percent}% revisado</translation>
     </message>
@@ -5981,7 +5968,7 @@ Sí las restablece; No las mantiene en su tamaño actual.</translation>
 <context>
     <name>GridReviewDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="52"/>
         <source>Suggested: {rows}×{cols} (person ≈ {px} px on screen at cell zoom)</source>
         <translation>Sugerido: {rows}×{cols} (persona ≈ {px} px en pantalla con zoom de celda)</translation>
     </message>
@@ -6265,7 +6252,7 @@ Use this to see what colors are going to be detected and optimize the color rang
         <translation>Asistente de rango de color HSV - Selección por clic</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="709"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="694"/>
         <source>Interactive image viewer with color selection.
 
 NAVIGATION:
@@ -6309,7 +6296,7 @@ VISUALIZACIÓN:
         <translation>Examinar...</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="748"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="743"/>
         <source>Browse for an image file to load.
 Opens a file dialog to select an image from your computer.
 • Supported formats: PNG, JPG, JPEG, BMP
@@ -6327,7 +6314,7 @@ La imagen se mostrará en el visor principal de la izquierda.</translation>
         <translation>Restablecer</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="761"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="755"/>
         <source>Reset all selections and start over.
 • Clears all selected pixels (white overlay)
 • Resets HSV ranges to defaults
@@ -6347,14 +6334,14 @@ Use esta opción para empezar de cero sin volver a cargar la imagen.</translatio
         <translation>Radio de selección:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="770"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="768"/>
         <source>Size of the circular selection cursor.
 Determines how many pixels are sampled when you CTRL+Click.</source>
         <translation>Tamaño del cursor circular de selección.
 Determina cuántos píxeles se muestrean al hacer CTRL+clic.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="788"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="777"/>
         <source>Set the selection cursor radius in pixels.
 • Range: 1-50 pixels
 • Default: 1 pixel (single pixel selection)
@@ -6384,14 +6371,14 @@ Atajos de teclado: [ disminuye, ] aumenta 2 píxeles</translation>
         <translation>Tolerancia de color:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="797"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="795"/>
         <source>HSV color matching tolerance.
 Controls how similar colors must be to get selected.</source>
         <translation>Tolerancia de coincidencia de color HSV.
 Controla qué tan similares deben ser los colores para seleccionarse.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="817"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="803"/>
         <source>Set color tolerance for similar pixel detection.
 • Range: 0-50
 • Default: 2
@@ -6422,7 +6409,7 @@ Tolerancia menor:
 • Puede omitir algunos píxeles del color objetivo</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="826"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="825"/>
         <source>CTRL+Click: Select similar colors | CTRL+SHIFT+Click: Remove | [ ] : Radius</source>
         <translation>CTRL+clic: seleccionar colores similares | CTRL+MAYÚS+clic: quitar | [ ]: radio</translation>
     </message>
@@ -6432,7 +6419,7 @@ Tolerancia menor:
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="840"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="833"/>
         <source>Show detailed help and instructions.
 Opens a dialog with:
 • Step-by-step usage instructions
@@ -6454,7 +6441,7 @@ Haga clic aquí si no sabe cómo usar esta herramienta.</translation>
         <translation>Color seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="863"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="861"/>
         <source>Average color of all selected pixels.
 Shows the center/mean color that will be used for HSV range detection.</source>
         <translation>Color promedio de todos los píxeles seleccionados.
@@ -6466,14 +6453,14 @@ Muestra el color central/promedio que se usará para la detección por rango HSV
         <translation>Color:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="870"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="868"/>
         <source>Visual preview of the average selected color.
 This is the center color calculated from all selected pixels.</source>
         <translation>Vista previa visual del color seleccionado promedio.
 Es el color central calculado a partir de todos los píxeles seleccionados.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="878"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="876"/>
         <source>Color swatch showing the average of all selected pixels.
 This becomes the center color for HSV range detection.</source>
         <translation>Muestra de color con el promedio de todos los píxeles seleccionados.
@@ -6485,14 +6472,14 @@ Este será el color central para la detección por rango HSV.</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="885"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="883"/>
         <source>Hexadecimal representation of the selected color.
 Format: #RRGGBB</source>
         <translation>Representación hexadecimal del color seleccionado.
 Formato: #RRGGBB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="891"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="889"/>
         <source>Hex color code of the average selected color.
 Can be used to identify the exact RGB color value.</source>
         <translation>Código de color hexadecimal del color seleccionado promedio.
@@ -6504,14 +6491,14 @@ Puede usarse para identificar el valor RGB exacto.</translation>
         <translation>HSV:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="898"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="896"/>
         <source>HSV values of the selected color.
 H = Hue (0-360°), S = Saturation (0-100%), V = Value (0-100%)</source>
         <translation>Valores HSV del color seleccionado.
 H = tono (0-360°), S = saturación (0-100%), V = valor (0-100%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="904"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="902"/>
         <source>HSV color values of the average selected color.
 This is the center point of your color range.</source>
         <translation>Valores HSV del color seleccionado promedio.
@@ -6523,7 +6510,7 @@ Este es el punto central del rango de color.</translation>
         <translation>Rangos HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="916"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="912"/>
         <source>HSV color range configuration.
 Defines the detection range for each HSV channel.
 Center values are calculated from selected pixels.
@@ -6594,7 +6581,7 @@ Los márgenes añaden tolerancia adicional para captar variaciones de color.</tr
         <translation>Canal de tono (tipo de color): 0-360 grados en la rueda de color</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="950"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="947"/>
         <source>Center hue value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-360° (red=0°, green=120°, blue=240°)</source>
@@ -6603,7 +6590,7 @@ Se calcula automáticamente a partir de la selección.
 Rango: 0-360° (rojo=0°, verde=120°, azul=240°)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="963"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="957"/>
         <source>Hue lower bound buffer (subtract from center).
 • Range: 0-360°
 • Adds tolerance below the center hue
@@ -6618,7 +6605,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 ADVERTENCIA: un rango total de tono (menos + más) &gt; 60° puede causar falsos positivos</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="977"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="971"/>
         <source>Hue upper bound buffer (add to center).
 • Range: 0-360°
 • Adds tolerance above the center hue
@@ -6633,7 +6620,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 ADVERTENCIA: un rango total de tono (menos + más) &gt; 60° puede causar falsos positivos</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="986"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="983"/>
         <source>Final hue detection range.
 Shows the complete min-max hue range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6647,7 +6634,7 @@ Se calcula como: (centro - margen negativo) a (centro + margen positivo)</transl
         <translation>ADVERTENCIA: un rango de tono demasiado amplio puede generar falsos positivos.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="998"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="994"/>
         <source>Hue range warning.
 Your total hue range exceeds 60°.
 Wide hue ranges may detect many different colors.
@@ -6668,7 +6655,7 @@ Considere reducir los márgenes para una detección más precisa.</translation>
         <translation>Canal de saturación (intensidad del color): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1011"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1008"/>
         <source>Center saturation value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=gray, 100%=vivid color)</source>
@@ -6677,7 +6664,7 @@ Se calcula automáticamente a partir de la selección.
 Rango: 0-100% (0%=gris, 100%=color vivo)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1024"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1018"/>
         <source>Saturation lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center saturation
@@ -6692,7 +6679,7 @@ WARNING: Lower bound &lt; 25% may include unwanted gray/desaturated colors</sour
 ADVERTENCIA: un límite inferior &lt; 25% puede incluir colores grises/desaturados no deseados</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1037"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1032"/>
         <source>Saturation upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center saturation
@@ -6705,7 +6692,7 @@ ADVERTENCIA: un límite inferior &lt; 25% puede incluir colores grises/desaturad
 • Aumentar la saturación superior suele ser seguro</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1046"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1043"/>
         <source>Final saturation detection range.
 Shows the complete min-max saturation range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6719,7 +6706,7 @@ Se calcula como: (centro - margen negativo) a (centro + margen positivo)</transl
         <translation>ADVERTENCIA: un nivel de saturación demasiado bajo puede generar falsos positivos.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1058"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1054"/>
         <source>Saturation range warning.
 Your lower saturation bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -6740,7 +6727,7 @@ Puede detectar objetos grises o desaturados no deseados.</translation>
         <translation>Canal de valor (brillo): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1071"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1068"/>
         <source>Center value/brightness (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=black, 100%=bright)</source>
@@ -6749,7 +6736,7 @@ Se calcula automáticamente a partir de la selección.
 Rango: 0-100% (0%=negro, 100%=brillante)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1084"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1078"/>
         <source>Value lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center brightness
@@ -6764,7 +6751,7 @@ WARNING: Lower bound &lt; 25% may include unwanted shadows or dark objects</sour
 ADVERTENCIA: un límite inferior &lt; 25% puede incluir sombras u objetos oscuros no deseados</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1097"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1092"/>
         <source>Value upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center brightness
@@ -6777,7 +6764,7 @@ ADVERTENCIA: un límite inferior &lt; 25% puede incluir sombras u objetos oscuro
 • Aumentar el brillo superior suele ser seguro</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1106"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1103"/>
         <source>Final value/brightness detection range.
 Shows the complete min-max brightness range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6791,7 +6778,7 @@ Se calcula como: (centro - margen negativo) a (centro + margen positivo)</transl
         <translation>ADVERTENCIA: un nivel de valor demasiado bajo puede generar falsos positivos.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1118"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1114"/>
         <source>Value range warning.
 Your lower value bound is below 25%.
 Low value includes very dark colors.
@@ -6807,7 +6794,7 @@ Puede detectar sombras u objetos oscuros no deseados.</translation>
         <translation>Estadísticas</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1128"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1126"/>
         <source>Statistics about your current selection.
 Shows how many pixels are selected and what percentage of the image they represent.</source>
         <translation>Estadísticas de la selección actual.
@@ -6820,7 +6807,7 @@ Muestra cuántos píxeles están seleccionados y qué porcentaje de la imagen re
         <translation>Píxeles seleccionados: 0</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1135"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1132"/>
         <source>Number of pixels currently selected.
 Shows the total count of white-highlighted pixels in the main viewer.
 Updates in real-time as you select colors.</source>
@@ -6835,7 +6822,7 @@ Se actualiza en tiempo real al seleccionar colores.</translation>
         <translation>Cobertura: 0%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1143"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1139"/>
         <source>Percentage of image covered by selection.
 Shows what portion of the total image is selected.
 • Low %: Precise selection, may miss some target pixels
@@ -6851,14 +6838,14 @@ Muestra qué parte de la imagen total está seleccionada.
         <translation>Vista previa de máscara</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1152"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1150"/>
         <source>Black and white preview of the detection mask.
 Shows what pixels will be detected with current HSV ranges and buffers.</source>
         <translation>Vista previa en blanco y negro de la máscara de detección.
 Muestra qué píxeles se detectarán con los rangos y márgenes HSV actuales.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1166"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1161"/>
         <source>Grayscale mask preview.
 • White pixels: Will be detected with current settings
 • Black pixels: Will NOT be detected
@@ -6876,7 +6863,7 @@ Use esta opción para verificar que el rango HSV capture el objetivo sin falsos 
         <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1180"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp)</source>
         <translation>Imágenes (*.png *.jpg *.jpeg *.bmp)</translation>
     </message>
@@ -6891,7 +6878,7 @@ Use esta opción para verificar que el rango HSV capture el objetivo sin falsos 
         <translation>Cobertura: {0:.1f}%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1503"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1476"/>
         <source>
 &lt;h2&gt;HSV Color Range Assistant - Help&lt;/h2&gt;
 
@@ -6959,8 +6946,8 @@ Haga clic en el botón EXAMINAR para abrir una imagen.&lt;/p&gt;
         <translation>Ningún color seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="121"/>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="126"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="125"/>
         <source>Add Color</source>
         <translation>Añadir color</translation>
     </message>
@@ -6970,7 +6957,7 @@ Haga clic en el botón EXAMINAR para abrir una imagen.&lt;/p&gt;
         <translation>Expansión de tono</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="178"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -6979,7 +6966,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 Se excluyen los píxeles con saturación inferior al {1}% o valor inferior al {2}%.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="469"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="468"/>
         <source>Please add at least one color to detect.</source>
         <translation>Añada al menos un color para detectar.</translation>
     </message>
@@ -7010,7 +6997,7 @@ Se excluyen los píxeles con saturación inferior al {1}% o valor inferior al {2
         <translation>Expansión de tono</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="104"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="101"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -7019,7 +7006,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 Se excluyen los píxeles con saturación inferior al {1}% o valor inferior al {2}%.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="409"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="408"/>
         <source>Please add at least one color to detect.</source>
         <translation>Añada al menos un color para detectar.</translation>
     </message>
@@ -7048,14 +7035,14 @@ de coincidencia:</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="95"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="93"/>
         <source>Hexadecimal color code input.
 Enter colors as hex codes (e.g., #FF0000 for red).</source>
         <translation>Entrada de código de color hexadecimal.
 Introduzca colores como códigos hexadecimales (por ejemplo, #FF0000 para rojo).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="107"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="102"/>
         <source>Enter a hexadecimal color code.
 • Format: #RRGGBB (e.g., #FF0000 for red, #00FF00 for green)
 • Also accepts short format: #RGB (e.g., #F00 for red)
@@ -7073,7 +7060,7 @@ El color se convertirá automáticamente a HSV.</translation>
         <translation>Restablecer valores predeterminados</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="114"/>
         <source>Reset to default color and ranges.
 • Color: Pure red (H:0°, S:100%, V:100%)
 • Hue range: ±20° (total 40° range)
@@ -7093,7 +7080,7 @@ Use esta opción para empezar de nuevo con ajustes estándar.</translation>
         <translation>Saturación / Valor</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="144"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="141"/>
         <source>Saturation and Value (brightness) selector.
 Saturation controls color intensity (left=gray, right=vivid).
 Value controls brightness (bottom=dark, top=bright).</source>
@@ -7102,7 +7089,7 @@ La saturación controla la intensidad del color (izquierda=gris, derecha=vivo).
 El valor controla el brillo (abajo=oscuro, arriba=brillante).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="157"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="149"/>
         <source>Interactive Saturation/Value selector.
 • Click anywhere to set the center color&apos;s saturation and brightness
 • White circle = current center color position
@@ -7126,14 +7113,14 @@ Los rangos mayores detectan más variaciones de color, pero pueden incluir color
         <translation>Tono</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="171"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="169"/>
         <source>Hue (color type) selector.
 Hue represents the actual color: red, orange, yellow, green, cyan, blue, purple, magenta.</source>
         <translation>Selector de tono (tipo de color).
 El tono representa el color propiamente dicho: rojo, naranja, amarillo, verde, cian, azul, morado, magenta.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="184"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="176"/>
         <source>Interactive Hue color ring selector.
 • Click on the ring to select a hue (color type)
 • White line = current center hue
@@ -7157,7 +7144,7 @@ Advertencia: los rangos de tono mayores de 60° pueden detectar demasiados color
         <translation>Usar imagen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="215"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="208"/>
         <source>Open HSV Color Range Assistant.
 Advanced tool for selecting colors from an image:
 • Load an image from your input folder
@@ -7179,7 +7166,7 @@ Recomendado para encontrar el mejor rango de color para el objetivo.</translatio
         <translation>Tomar color de pantalla</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="228"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="222"/>
         <source>Pick a color from anywhere on your screen.
 Opens a color picker that lets you:
 • Click anywhere on your screen to sample a color
@@ -7199,7 +7186,7 @@ Los rangos no cambian; ajústelos manualmente después de elegir el color.</tran
         <translation>Añadir a colores personalizados</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="241"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="235"/>
         <source>Save current color to Custom Colors palette.
 Adds the current center color to the first empty slot in Custom Colors.
 • Only saves the color, not the ranges
@@ -7219,7 +7206,7 @@ Añade el color central actual al primer espacio vacío de Colores personalizado
         <translation>Colores básicos:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="259"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="256"/>
         <source>Preset basic color palette.
 Quick access to common colors like red, orange, yellow, green, cyan, blue, purple, and grayscale.
 Click any color swatch to set it as the center color.</source>
@@ -7228,7 +7215,7 @@ Acceso rápido a colores comunes como rojo, naranja, amarillo, verde, cian, azul
 Haga clic en cualquier muestra para establecerla como color central.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="269"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="264"/>
         <source>Basic color swatches.
 Click any color to quickly set it as your center color.
 • Top row: Primary colors and tints
@@ -7246,7 +7233,7 @@ Haga clic en cualquier color para establecerlo rápidamente como color central.
         <translation>Colores personalizados:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="280"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="277"/>
         <source>Your saved custom color palette.
 Colors you&apos;ve saved using &apos;Add to Custom Colors&apos; button.
 Click any saved color to reuse it.</source>
@@ -7255,7 +7242,7 @@ Colores guardados con el botón &apos;Añadir a colores personalizados&apos;.
 Haga clic en cualquier color guardado para reutilizarlo.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="291"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="285"/>
         <source>Custom color swatches.
 Click any color to set it as your center color.
 • Empty slots shown as gray
@@ -7270,7 +7257,7 @@ Haga clic en cualquier color para establecerlo como color central.
 Cree su propia paleta de colores usados con frecuencia.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="464"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="461"/>
         <source>Current HSV color range summary.
 Shows the center color and detection ranges in real-time.
 Warning indicators appear when ranges may cause detection issues.</source>
@@ -7294,7 +7281,7 @@ Aparecen indicadores de advertencia cuando los rangos pueden causar problemas de
         <translation>Rango de sat.:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="471"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="470"/>
         <source>Val Range:</source>
         <translation>Rango de val.:</translation>
     </message>
@@ -7320,7 +7307,7 @@ Warning shown if lower bound &lt; 25%.</source>
 Se muestra una advertencia si el límite inferior &lt; 25%.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="477"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="475"/>
         <source>Value detection range (minus/plus from center).
 Warning shown if lower bound &lt; 25%.</source>
         <translation>Rango de detección de valor (menos/más desde el centro).
@@ -7332,7 +7319,7 @@ Se muestra una advertencia si el límite inferior &lt; 25%.</translation>
         <translation>⚠ Demasiado amplio</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="506"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="502"/>
         <source>Hue range warning.
 Your hue range is wider than 60° total.
 Wide hue ranges may detect too many different colors.
@@ -7349,7 +7336,7 @@ Considere reducir el rango para una detección más precisa.</translation>
         <translation>⚠ Demasiado bajo</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="519"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="515"/>
         <source>Saturation range warning.
 Your saturation lower bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -7360,7 +7347,7 @@ La saturación baja incluye colores grisáceos o apagados.
 Puede detectar colores grises o desaturados no deseados.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="532"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="528"/>
         <source>Value range warning.
 Your value lower bound is below 25%.
 Low value includes very dark colors.
@@ -7409,7 +7396,7 @@ Puede detectar sombras u objetos oscuros no deseados.</translation>
         <translation>Alta (400)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="117"/>
+        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="114"/>
         <source>Hot zones (colored) show high-density detection areas. Gray zones are below the threshold. Adjust the threshold to control what counts as a hot zone.</source>
         <translation>Las zonas calientes (en color) muestran áreas con alta densidad de detecciones. Las zonas grises están por debajo del umbral. Ajuste el umbral para controlar qué cuenta como zona caliente.</translation>
     </message>
@@ -7783,7 +7770,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>• Se requiere distancia focal (disponible en los datos EXIF de la imagen)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="486"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="485"/>
         <source>GSD calculation requires an actual image file to extract focal length.</source>
         <translation>El cálculo de GSD requiere un archivo de imagen real para extraer la distancia focal.</translation>
     </message>
@@ -7803,7 +7790,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Principal</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="529"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="527"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
@@ -7844,7 +7831,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Personalizada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="65"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="61"/>
         <source>Select a preset resolution for processing. Lower resolutions are faster but less detailed.
 &apos;Original&apos; uses the video&apos;s native resolution (no downsampling).
 720P (1280x720) provides excellent balance between speed and detection accuracy.
@@ -7860,7 +7847,7 @@ Seleccione &apos;Personalizada&apos; para definir manualmente el ancho y la altu
         <translation>Ancho:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="81"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="78"/>
         <source>Custom processing width in pixels (320-3840).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7874,7 +7861,7 @@ Valores menores = procesamiento más rápido y menos detalle.</translation>
         <translation>Altura:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="94"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="91"/>
         <source>Custom processing height in pixels (240-2160).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7898,7 +7885,7 @@ Valores menores = procesamiento más rápido y menos detalle.</translation>
         <translation>FPS de origen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="143"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="133"/>
         <source>Limit the frame rate for processing.
 
 • Source FPS - Follow the source cadence (live sources may apply a safety cap)
@@ -7930,7 +7917,7 @@ Las detecciones persisten entre fotogramas saltados para mantener la continuidad
         <translation>Renderizar a resolución de procesamiento (más rápido en alta resolución)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="155"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="151"/>
         <source>Renders detection overlays at processing resolution instead of original video resolution.
 Significantly faster for high-resolution videos (1080p+) with minimal visual impact.
 Example: Processing at 720p but video is 4K - renders at 720p then upscales.
@@ -8180,7 +8167,7 @@ Valores más bajos = detección más sensible.</translation>
         <translation>Expansión de umbral</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="53"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="50"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8194,7 +8181,7 @@ los píxeles fuera se añaden si están conectados a través de otros píxeles q
         <translation>Expansión de tono</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="62"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="59"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -8273,7 +8260,7 @@ agresivo</translation>
         <translation>Expansión de umbral</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="72"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="69"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8287,7 +8274,7 @@ los píxeles fuera se añaden si están conectados a través de otros píxeles q
         <translation>Expansión de tono</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="81"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="78"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -9306,12 +9293,12 @@ Haga preguntas, reporte problemas y sugiera nuevas funciones.</translation>
         <translation>Canal de YouTube</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="90"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="89"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Herramienta automatizada de análisis de imágenes de dron v{version} - Patrocinado por TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="326"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="288"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -9388,7 +9375,7 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
   • Limitación: Solo detecta personas, procesamiento más lento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="385"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="384"/>
         <source>Select AOI Highlight Color</source>
         <translation>Seleccionar color de resaltado del AOI</translation>
     </message>
@@ -9404,7 +9391,7 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>Seleccionar una imagen de referencia</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="435"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Imágenes (*.png *.jpg)</translation>
     </message>
@@ -9415,21 +9402,21 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>Valor ajustado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="500"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="498"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>El área máxima se ha ajustado a {value} píxeles para mantener un rango válido.
 (El área mínima debe ser menor que el área máxima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="532"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="530"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>El área mínima se ha ajustado a {value} píxeles para mantener un rango válido.
 (El área máxima debe ser mayor que el área mínima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="645"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="644"/>
         <source>Please set the input and output directories.</source>
         <translation>Establezca los directorios de entrada y salida.</translation>
     </message>
@@ -9439,12 +9426,12 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>--- Iniciando procesamiento de imágenes ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="886"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>No se pudo analizar el archivo XML. Compruebe las rutas de archivo en &quot;{file_name}&quot;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="909"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="908"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Se ha superado el límite de áreas de interés ({limit}). ¿Continuar?</translation>
     </message>
@@ -9507,7 +9494,7 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>Seleccionar archivo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1155"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>Archivos XML (*.xml);;Todos los archivos (*)</translation>
     </message>
@@ -9527,7 +9514,7 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>No se encontraron resultados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1232"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1231"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>No se encontraron archivos ADIAT_DATA.XML en la carpeta seleccionada.</translation>
     </message>
@@ -9611,12 +9598,12 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation> Abrir Coordinador de búsqueda</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1779"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1778"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Abra el Coordinador de búsqueda para revisar todos los lotes de esta ejecución.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1785"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1784"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Abra el Visor de resultados para revisar los resultados de las detecciones.</translation>
     </message>
@@ -9727,7 +9714,7 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>Mapa de calor de cobertura POD (considera el terreno)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
         <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). KML exports embed the heatmap in the KML/KMZ as an image overlay; the GeoTIFF products (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json) are also written — the GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
         <translation>Calcula un ráster de probabilidad de detección consciente del terreno y del dosel para toda la misión (todas las imágenes no ocultas, independiente de las selecciones anteriores). Las exportaciones KML incrustan el mapa de calor en el KML/KMZ como superposición de imagen; también se escriben los productos GeoTIFF (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json); el GeoTIFF puede importarse en CalTopo Map Sheets. Puede tardar varios minutos.</translation>
     </message>
@@ -9772,7 +9759,7 @@ DETECTOR DE PERSONAS CON IA: Modelo de aprendizaje profundo para detección prec
         <translation>Ambas</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="145"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="142"/>
         <source>Large Image uploads the same multi-zoom composite used in the PDF report
 (full image with 3x and 6x insets). AOI Thumbnail uploads a zoomed crop
 centered on the detection. Both uploads each.</source>
@@ -9841,7 +9828,7 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>Ningún color seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="300"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="299"/>
         <source>Please add at least one color to detect.</source>
         <translation>Añada al menos un color para detectar.</translation>
     </message>
@@ -9867,7 +9854,7 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>Ver rango</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="219"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="218"/>
         <source>Please add at least one target color to detect.</source>
         <translation>Añada al menos un color objetivo para detectar.</translation>
     </message>
@@ -9886,7 +9873,7 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>Medir sombra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="90"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="87"/>
         <source>When checked, the two clicks estimate the height of a vertical object from its shadow. Click the base of the object first, then the tip of its shadow.</source>
         <translation>Al marcarlo, los dos clics estiman la altura de un objeto vertical a partir de su sombra. Haga clic primero en la base del objeto y luego en la punta de su sombra.</translation>
     </message>
@@ -9937,17 +9924,17 @@ Use this to see what colors are going to be detected and optimize the thresholds
         <translation>Usar de todos modos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="140"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="137"/>
         <source>Force the estimate with the current base/tip clicks even though the drawn line doesn&apos;t match the expected shadow direction. Use only when you&apos;re confident the geometry is correct.</source>
         <translation>Fuerza la estimación con los clics actuales de base/punta aunque la línea dibujada no coincida con la dirección esperada de la sombra. Úselo solo si está seguro de que la geometría es correcta.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="181"/>
         <source>Click the BASE of the object first, then the TIP of its shadow.</source>
         <translation>Haga clic primero en la BASE del objeto y luego en la PUNTA de su sombra.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="187"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="185"/>
         <source>Click on the image to place the first point,
 then click again to place the second point.</source>
         <translation>Haga clic en la imagen para colocar el primer punto,
@@ -9975,7 +9962,7 @@ y luego vuelva a hacer clic para colocar el segundo punto.</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="467"/>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="553"/>
         <source>Rejected</source>
         <translation>Rechazado</translation>
     </message>
@@ -10107,7 +10094,7 @@ y luego vuelva a hacer clic para colocar el segundo punto.</translation>
         <translation type="unfinished">Desconocido</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="177"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="175"/>
         <source> (Current)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10129,7 +10116,7 @@ y luego vuelva a hacer clic para colocar el segundo punto.</translation>
         <translation>Sin imágenes para exportar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="156"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="153"/>
         <source>There are no images available to include in the PDF report.
 
 All images may be hidden or there are no images in the dataset.</source>
@@ -10138,7 +10125,7 @@ All images may be hidden or there are no images in the dataset.</source>
 Todas las imágenes pueden estar ocultas o no hay imágenes en el conjunto de datos.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="166"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="162"/>
         <source>There are no images with flagged AOIs to include in the PDF report.
 
 Please flag at least one AOI, or check &apos;Include images without flagged AOIs&apos; to include all images in the report.</source>
@@ -10152,7 +10139,7 @@ Marque al menos un AOI, o active &apos;Incluir imágenes sin AOI marcados&apos; 
         <translation>Guardar archivo PDF</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="175"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="174"/>
         <source>PDF files (*.pdf)</source>
         <translation>Archivos PDF (*.pdf)</translation>
     </message>
@@ -10177,7 +10164,7 @@ Marque al menos un AOI, o active &apos;Incluir imágenes sin AOI marcados&apos; 
         <translation>Éxito</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="278"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="277"/>
         <source>PDF report generated successfully!</source>
         <translation>¡Informe PDF generado correctamente!</translation>
     </message>
@@ -10235,7 +10222,7 @@ Marque al menos un AOI, o active &apos;Incluir imágenes sin AOI marcados&apos; 
         <translation>Incluir imágenes sin AOI marcados</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="62"/>
         <source>When checked, all images will be included in the PDF report, even if they don&apos;t have any flagged AOIs. When unchecked, only images with flagged AOIs will be included.</source>
         <translation>Cuando está activado, se incluirán todas las imágenes en el informe PDF, incluso si no tienen AOI marcados. Cuando está desactivado, solo se incluirán las imágenes con AOI marcados.</translation>
     </message>
@@ -10280,7 +10267,7 @@ Marque al menos un AOI, o active &apos;Incluir imágenes sin AOI marcados&apos; 
   ... y {count} más</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10308,7 +10295,7 @@ Seleccione la carpeta que contiene las imágenes de origen.</translation>
         <translation>Aún faltan algunas imágenes</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="168"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10326,7 +10313,7 @@ Seleccione la carpeta que contiene los archivos de máscara.</translation>
         <translation>Máscaras de detección no encontradas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="140"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10337,7 +10324,7 @@ Aún faltan:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10358,7 +10345,7 @@ Se esperaba encontrar archivos con estos nombres:
         <translation>Aún faltan algunas máscaras</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="174"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="172"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10369,7 +10356,7 @@ Aún faltan:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="179"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="176"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10390,7 +10377,7 @@ Se esperaba encontrar archivos con estos nombres:
         <translation>Continuar de todos modos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="414"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="410"/>
         <source>
 
 {count} of these appear more than once in that folder, so which capture they belong to cannot be determined:
@@ -10438,7 +10425,7 @@ Choose the specific flight/sortie folder rather than a folder containing several
         <translation>Usar elevación del terreno (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Gire la persona sobre el terreno para alinearla con un objeto</translation>
     </message>
@@ -10474,173 +10461,193 @@ Choose the specific flight/sortie folder rather than a folder containing several
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="402"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1247"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1254"/>
+        <source>Flight track log...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <source>Attach a ForeFlight track log CSV to stamp true aircraft attitude (bank/pitch) and GPS-accurate capture times onto these images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="411"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1371"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="419"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Arrastre el controlador blanco para colocar a la persona de referencia. Las siluetas se dibujan a escala real del terreno según la altitud y el ángulo de cámara de esta imagen.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="427"/>
         <source>Recenter</source>
         <translation>Centrar de nuevo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="420"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="429"/>
         <source>Bring the reference person to the center of the current view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="421"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="430"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="487"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="497"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation>No se encontró ningún fallo del reloj de la cámara ni ninguna corrección aplicada en esta carpeta.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="539"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="596"/>
+        <source>Select ForeFlight track log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <source>Track logs (*.csv);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Superposición de perspectiva no disponible: a esta imagen le faltan los metadatos de altitud o lente necesarios para proyectar una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="709"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation>Ampliado a la persona de referencia: a esta altitud una persona ocupa solo unos pocos píxeles.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="638"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>no image loaded</source>
         <translation>no hay imagen cargada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="643"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="758"/>
         <source>image metadata could not be read</source>
         <translation>no se pudieron leer los metadatos de la imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="762"/>
         <source>image has no GPS coordinates</source>
         <translation>la imagen no tiene coordenadas GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="659"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="774"/>
         <source>capture time / timezone not in metadata</source>
         <translation>la hora de captura / zona horaria no está en los metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="670"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="785"/>
         <source>sun position could not be computed</source>
         <translation>no se pudo calcular la posición del sol</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="684"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="799"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sol durante la captura: {elev:.0f}° sobre el horizonte, acimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="688"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="804"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Zona horaria de captura estimada a partir de la ubicación GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="691"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="807"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation>Se usa la hora de captura corregida (fallo del reloj de la cámara).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="694"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="810"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="699"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="815"/>
         <source>the sun was below the horizon at capture</source>
         <translation>el sol estaba por debajo del horizonte durante la captura</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="701"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="817"/>
         <source>sun position unavailable</source>
         <translation>posición del sol no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="702"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="818"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Sombra no disponible: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="801"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Colocar la persona y la sombra sobre la superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="805"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="921"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Los datos de terreno (DEM) no están disponibles para esta imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1065"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1181"/>
         <source>Choose Overlay Color</source>
         <translation>Elegir color de superposición</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1339"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1341"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1265"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1382"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1467"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1357"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1473"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1373"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1488"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1493"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1380"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1495"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1502"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1391"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1506"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11049,7 +11056,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Idioma:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="105"/>
+        <location filename="../app/core/controllers/Preferences.py" line="104"/>
         <source>AWS Terrain Tiles (online, ~30 m) is always available as the baseline; local USGS 3DEP adds 1 m detail where downloaded.</source>
         <translation>AWS Terrain Tiles (en línea, ~30 m) siempre está disponible como base; el USGS 3DEP local añade detalle de 1 m donde se haya descargado.</translation>
     </message>
@@ -11090,8 +11097,8 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Carpeta que contiene las teselas GeoTIFF</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="146"/>
-        <location filename="../app/core/controllers/Preferences.py" line="400"/>
+        <location filename="../app/core/controllers/Preferences.py" line="145"/>
+        <location filename="../app/core/controllers/Preferences.py" line="399"/>
         <source>3DEP is inactive until both paths are set — the AWS Terrain Tiles baseline is used. Use Download tiles… or Browse.</source>
         <translation>3DEP está inactivo hasta que se establezcan ambas rutas; se usa la base de AWS Terrain Tiles. Use Descargar teselas… o Examinar.</translation>
     </message>
@@ -11116,8 +11123,8 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Ruta al CSV de manifiesto del dosel</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="230"/>
-        <location filename="../app/core/controllers/Preferences.py" line="480"/>
+        <location filename="../app/core/controllers/Preferences.py" line="229"/>
+        <location filename="../app/core/controllers/Preferences.py" line="479"/>
         <source>Canopy is disabled until both paths are set — use Download tiles… or Browse.</source>
         <translation>El dosel está deshabilitado hasta que ambas rutas estén configuradas — use Descargar teselas… o Examinar.</translation>
     </message>
@@ -11127,7 +11134,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Descargar teselas...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="242"/>
+        <location filename="../app/core/controllers/Preferences.py" line="241"/>
         <source>Download DEM and/or canopy tiles for an area of interest and register them here. Note: the canopy download uses Meta/WRI data and registers it as the canopy source.</source>
         <translation>Descargar teselas de MDE y/o dosel para un área de interés y registrarlas aquí. Nota: la descarga de dosel usa datos de Meta/WRI y los registra como fuente de dosel.</translation>
     </message>
@@ -11138,7 +11145,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="406"/>
+        <location filename="../app/core/controllers/Preferences.py" line="405"/>
         <source>The registered 3DEP files no longer exist on disk — the AWS Terrain Tiles baseline is used. Re-download or fix the paths.</source>
         <translation>Los archivos 3DEP registrados ya no existen en el disco; se usa la base de AWS Terrain Tiles. Vuelva a descargar o corrija las rutas.</translation>
     </message>
@@ -11159,7 +11166,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Seleccionar directorio de teselas 3DEP</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="486"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>The registered canopy files no longer exist on disk — canopy is disabled. Re-download or fix the paths.</source>
         <translation>Los archivos de dosel registrados ya no existen en el disco; el dosel está desactivado. Vuelva a descargar o corrija las rutas.</translation>
     </message>
@@ -11208,7 +11215,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="625"/>
+        <location filename="../app/core/controllers/Preferences.py" line="624"/>
         <source>Terrain service not available.</source>
         <translation>Servicio de terreno no disponible.</translation>
     </message>
@@ -11218,7 +11225,7 @@ Todos los cambios se guardan automáticamente al modificarse.</translation>
         <translation>Borrar caché de terreno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="634"/>
+        <location filename="../app/core/controllers/Preferences.py" line="632"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -11247,7 +11254,7 @@ Esto requerirá volver a descargar los mosaicos cuando se use la elevación del 
         <translation>Seleccionar un archivo de sensor de dron</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="662"/>
+        <location filename="../app/core/controllers/Preferences.py" line="661"/>
         <source>CSV Files (*.csv)</source>
         <translation>Archivos CSV (*.csv)</translation>
     </message>
@@ -11257,7 +11264,7 @@ Esto requerirá volver a descargar los mosaicos cuando se use la elevación del 
         <translation>Reinicio necesario</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="689"/>
+        <location filename="../app/core/controllers/Preferences.py" line="688"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Reinicie la aplicación para que los cambios de idioma surtan efecto.</translation>
     </message>
@@ -11632,7 +11639,7 @@ agresivo</translation>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="64"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="55"/>
         <source>Shape to draw around detections:
 
 • Box: Rectangle around detection bounding box.
@@ -11671,7 +11678,7 @@ agresivo</translation>
         <translation>Mostrar etiquetas de texto (más lento)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="79"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="75"/>
         <source>Displays text labels near detections showing detection information.
 Adds ~5-15ms processing overhead depending on detection count.
 Labels show: detection type, confidence, area.
@@ -11687,7 +11694,7 @@ Recomendado: desactivado para mayor velocidad; activado para depuración/anális
         <translation>Mostrar contornos (lo más lento)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="84"/>
         <source>Draws exact detection contours (pixel-precise boundaries).
 Adds ~10-20ms processing overhead (very expensive).
 Shows exact shape detected by algorithm.
@@ -11703,7 +11710,7 @@ Recomendado: desactivado para velocidad; activado solo para análisis detallado.
         <translation>Usar color de la detección (tono al 100% de sat./valor para anomalías de color)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="100"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="95"/>
         <source>Color the detection overlay based on detected color.
 For color anomalies: Uses the detected hue at 100% saturation/value.
 For motion detections: Uses default color (green/blue).
@@ -11726,7 +11733,7 @@ Recomendado: activado para detección de color; desactivado si solo se usa movim
         <translation>Detecciones máx.:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="120"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="115"/>
         <source>Maximum number of detections to render on screen (0-1000).
 Prevents rendering slowdown when hundreds of detections occur.
 Shows highest confidence detections first.
@@ -11749,7 +11756,7 @@ Recomendado: 10 para uso general, 50 para renderizado complejo (texto + contorno
         <translation>Activar votación temporal (reducir parpadeo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="136"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="132"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -11765,7 +11772,7 @@ Recomendado: activado para todos los casos de uso (predeterminado).</translation
         <translation>Fotogramas de ventana (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="152"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="147"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -11783,7 +11790,7 @@ Recomendado: 5 para video de 30 fps (ventana de ~167 ms), 7 para 60 fps.</transl
         <translation>Umbral (N de M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="165"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="160"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -11806,7 +11813,7 @@ Recomendado: 3 de 5 (detección en el 60% de los fotogramas).</translation>
         <translation>Activar filtro de relación de aspecto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="183"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="180"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -11820,7 +11827,7 @@ La mayoría de los usuarios puede dejarlo desactivado salvo que vea muchos falso
         <translation>Relación mín.:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="199"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="195"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -11836,7 +11843,7 @@ Ejemplo: 0,2 ≈ rechazar si la altura es más de 5 veces el ancho.</translation
         <translation>Relación máx.:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="211"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="208"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -11855,7 +11862,7 @@ Valores mayores = permiten objetos más anchos, como vehículos o equipos largos
         <translation>Activar agrupación de detecciones</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="226"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="223"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -11869,7 +11876,7 @@ La mayoría de los usuarios puede dejarlo desactivado salvo que los objetos se v
         <translation>Distancia de agrupación (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="240"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="237"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -11896,7 +11903,7 @@ Valores mayores = fusionan detecciones más alejadas (puede agrupar de más).</t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="363"/>
         <source>Export finished with problems - see the log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11994,7 +12001,7 @@ Valores mayores = fusionan detecciones más alejadas (puede agrupar de más).</t
         <translation>Mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="134"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="133"/>
         <source>View</source>
         <translation>Ver</translation>
     </message>
@@ -12055,7 +12062,7 @@ Valores mayores = fusionan detecciones más alejadas (puede agrupar de más).</t
         <translation>Seleccionar archivo de resultados ADIAT</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="117"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="116"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>Archivos XML (*.xml);;Todos los archivos (*)</translation>
     </message>
@@ -12065,7 +12072,7 @@ Valores mayores = fusionan detecciones más alejadas (puede agrupar de más).</t
         <translation>Advertencia de nombre de archivo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="131"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="128"/>
         <source>The selected file does not appear to be an ADIAT_Data.xml result or an ADIAT_Search project file.
 
 Do you want to continue with this file?</source>
@@ -12087,7 +12094,7 @@ Do you want to continue with this file?</source>
         <translation>Seguimiento de revisión</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="51"/>
         <source>Enter your name to track your review activity.
 This helps coordinate reviews across multiple reviewers.</source>
         <translation>Introduzca su nombre para realizar el seguimiento de su actividad de revisión.
@@ -12114,7 +12121,7 @@ Esto ayuda a coordinar las revisiones entre varios revisores.</translation>
         <translation>Recordar mi nombre</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="76"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="74"/>
         <source>Save your name for future review sessions.
 You can change it later in Preferences or by clicking the reviewer name in the viewer.</source>
         <translation>Guarde su nombre para futuras sesiones de revisión.
@@ -12136,7 +12143,7 @@ Puede cambiarlo más tarde en Preferencias o haciendo clic en el nombre del revi
         <translation>Nombre requerido</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="124"/>
         <source>Please enter your name to continue.</source>
         <translation>Introduzca su nombre para continuar.</translation>
     </message>
@@ -12152,12 +12159,12 @@ Puede cambiarlo más tarde en Preferencias o haciendo clic en el nombre del revi
 <context>
     <name>SimilarityGalleryView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="173"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
         <source>Reference</source>
         <translation>Referencia</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
@@ -12233,12 +12240,12 @@ Puede cambiarlo más tarde en Preferencias o haciendo clic en el nombre del revi
 <context>
     <name>StreamAlgorithmPage</name>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="91"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="90"/>
         <source>Are you primarily looking for a person?</source>
         <translation>¿Está buscando principalmente a una persona?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="157"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="156"/>
         <source>Do you know a distinctive target color?</source>
         <translation>¿Conoce un color distintivo del objetivo?</translation>
     </message>
@@ -12263,7 +12270,7 @@ Puede cambiarlo más tarde en Preferencias o haciendo clic en el nombre del revi
         <translation>Algoritmo seleccionado: {algorithm}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="192"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="191"/>
         <source>{result}
 Secondary Recommendation: {secondary}</source>
         <translation>{result}
@@ -12326,7 +12333,7 @@ Recomendación secundaria: {secondary}</translation>
         <translation>4K</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="332"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="327"/>
         <source>Choose the video file you want to analyze. Use Browse to pick a file from disk.
 
 Location data is optional and usually detected automatically — ADIAT reads an .SRT sitting next to the video, or telemetry embedded in the video, on its own. Set it only to override that, or to supply location data the video does not have: a DJI .SRT or a .CSV flight log.</source>
@@ -12343,7 +12350,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>Haga clic en Examinar para seleccionar un archivo de vídeo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="341"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="340"/>
         <source>Click Scan to detect available capture devices, then select one from the dropdown.</source>
         <translation>Haga clic en Escanear para detectar los dispositivos de captura disponibles y luego seleccione uno del menú desplegable.</translation>
     </message>
@@ -12359,7 +12366,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="350"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="349"/>
         <source>Enter the RTMP URL provided by your streaming server (rtmp://server:port/app/key).</source>
         <translation>Introduzca la URL RTMP proporcionada por su servidor de transmisión (rtmp://servidor:puerto/app/clave).</translation>
     </message>
@@ -12374,7 +12381,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>rtmp://servidor:puerto/app/claveTransmisión</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="358"/>
         <source>You&apos;ll be prompted for the pairing code when you connect — pairing codes expire about 30 seconds after ADIAT Flight shows them, so don&apos;t generate one until you&apos;re ready.
 
 Finish this setup first, then start sharing in ADIAT Flight and enter the code. Detections reported by ADIAT Flight are ignored — this desktop runs its own analysis on the video.</source>
@@ -12417,7 +12424,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Seleccionar archivo de vídeo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="494"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="493"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;All Files (*)</source>
         <translation>Archivos de vídeo (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;Todos los archivos (*)</translation>
     </message>
@@ -12427,7 +12434,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation type="unfinished">Seleccionar un archivo de metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="517"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="515"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12437,7 +12444,6 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
     <message>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="862"/>
         <source>Stream Connection</source>
-        <extracomment>Gap between the HUD and the bottom of the video pane. Flush against the edge reads as an artifact of the window rather than an overlay.</extracomment>
         <translation>Conexión de transmisión</translation>
     </message>
     <message>
@@ -12461,7 +12467,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Transmisión RTMP</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="887"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="879"/>
         <source>Select the type of video source:
 • File: Pre-recorded video file with timeline controls
 • HDMI Capture: Live capture from HDMI capture device
@@ -12483,7 +12489,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Haga clic para buscar un archivo de vídeo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="868"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="865"/>
         <source>Configure and connect to video source (file, HDMI capture, RTMP stream, or ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12493,12 +12499,12 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="891"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="890"/>
         <source>• ADIAT Flight: Live feed paired with the ADIAT Flight app</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="912"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="907"/>
         <source>Enter or browse for the video source:
 • File: Click to browse for video file (MP4, AVI, MOV, etc.)
 • RTMP Stream: Enter RTMP URL (rtmp://server:port/app/stream)
@@ -12523,7 +12529,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Examinar...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="930"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="927"/>
         <source>Open file browser to select a video file for analysis.
 Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</source>
         <translation>Abrir el explorador de archivos para seleccionar un archivo de vídeo para analizar.
@@ -12540,7 +12546,7 @@ Formatos compatibles: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <translation>Escanear en busca de dispositivos de captura HDMI disponibles</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="966"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="957"/>
         <source>Optional. ADIAT already finds location data on its own, from:
 • an .SRT file sitting next to the video
 • telemetry embedded in the video (newer DJI aircraft)
@@ -12554,12 +12560,12 @@ Choose a file here only to override that, or to supply location data the video d
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="974"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="973"/>
         <source>Optional - usually detected automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="982"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="980"/>
         <source>Browse for an SRT or CSV file with the flight&apos;s location data.
 Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
@@ -12570,7 +12576,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Conectar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="993"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="992"/>
         <source>Connect to the specified video source and begin processing.</source>
         <translation>Conectar a la fuente de vídeo especificada e iniciar el procesamiento.</translation>
     </message>
@@ -12580,7 +12586,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Desconectar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="999"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="998"/>
         <source>Disconnect from the current video source and stop processing.</source>
         <translation>Desconectar de la fuente de vídeo actual y detener el procesamiento.</translation>
     </message>
@@ -12620,7 +12626,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Procesando: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1020"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1019"/>
         <source>Resolution used for detection processing</source>
         <translation>Resolución usada para el procesamiento de detección</translation>
     </message>
@@ -12640,7 +12646,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>FPS de proc.: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1028"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1027"/>
         <source>Actual frames per second being processed</source>
         <translation>Fotogramas por segundo reales que se están procesando</translation>
     </message>
@@ -12650,7 +12656,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Tiempo: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1034"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1033"/>
         <source>Time in milliseconds to process each frame</source>
         <translation>Tiempo en milisegundos para procesar cada fotograma</translation>
     </message>
@@ -12660,7 +12666,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Latencia: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1038"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1037"/>
         <source>End-to-end latency from frame capture to display</source>
         <translation>Latencia de extremo a extremo desde la captura del fotograma hasta la visualización</translation>
     </message>
@@ -12695,7 +12701,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Iniciar grabación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1067"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1066"/>
         <source>Start recording the video stream with detection overlays.</source>
         <translation>Iniciar la grabación de la transmisión de vídeo con superposiciones de detección.</translation>
     </message>
@@ -12705,7 +12711,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Detener grabación</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1072"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1071"/>
         <source>Stop the current recording and save to file.</source>
         <translation>Detener la grabación actual y guardarla en un archivo.</translation>
     </message>
@@ -12716,7 +12722,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Estado: No se está grabando</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1082"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1081"/>
         <source>Current recording status and output file path</source>
         <translation>Estado de grabación actual y ruta del archivo de salida</translation>
     </message>
@@ -12727,7 +12733,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Duración: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1088"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1087"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Estadísticas de grabación: Duración, FPS, fotogramas</translation>
     </message>
@@ -12737,12 +12743,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Guardar en:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1100"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1099"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Directorio donde se guardarán las grabaciones de vídeo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1104"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1103"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Elija una carpeta para almacenar las grabaciones.</translation>
     </message>
@@ -12752,7 +12758,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>rtmp://servidor:puerto/app/transmisión</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1174"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1173"/>
         <source>Click Connect to enter your pairing code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12762,7 +12768,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Dispositivo no válido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1196"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1195"/>
         <source>Please select a valid HDMI capture device.</source>
         <translation>Seleccione un dispositivo de captura HDMI válido.</translation>
     </message>
@@ -12772,7 +12778,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>URL no válida</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1217"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1216"/>
         <source>Please enter a valid stream URL.</source>
         <translation>Introduzca una URL de transmisión válida.</translation>
     </message>
@@ -12874,7 +12880,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Seleccionar archivo de vídeo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1484"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1482"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Archivos de vídeo (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Todos los archivos (*)</translation>
     </message>
@@ -12884,7 +12890,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished">Seleccionar un archivo de metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1506"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1503"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12927,7 +12933,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>-- (faltan datos de cámara)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="547"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="546"/>
         <source>Unable to calculate GSD. Sensor dimensions are required.</source>
         <translation>No se puede calcular el GSD. Se requieren las dimensiones del sensor.</translation>
     </message>
@@ -12947,7 +12953,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Principal</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="588"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="587"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
@@ -12995,12 +13001,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Más ejemplos:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>pies²</translation>
     </message>
@@ -13008,7 +13014,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamTelemetryCoordinator</name>
     <message>
-        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="101"/>
+        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="100"/>
         <source>Waiting for telemetry from ADIAT Flight...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +13062,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamViewerWindow</name>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="130"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="129"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Herramienta automatizada de análisis de imágenes de dron v{version} - Patrocinado por TEXSAR</translation>
     </message>
@@ -13132,7 +13138,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Estado: No se está grabando</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="392"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="391"/>
         <source>Current recording status and output file path</source>
         <translation>Estado de grabación actual y ruta del archivo de salida</translation>
     </message>
@@ -13143,7 +13149,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Duración: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="398"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="397"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Estadísticas de grabación: Duración, FPS, fotogramas</translation>
     </message>
@@ -13153,7 +13159,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Guardar en:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="407"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="406"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Directorio donde se guardarán las grabaciones de vídeo.</translation>
     </message>
@@ -13163,7 +13169,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Examinar...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="411"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="410"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Elija una carpeta para almacenar las grabaciones.</translation>
     </message>
@@ -13173,7 +13179,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="426"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="423"/>
         <source>Save each confirmed detection with the recording: a thumbnail, its position, and a results file that opens in the Image Analysis window.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13183,7 +13189,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="433"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="430"/>
         <source>Save the flight path and detection locations as a map and a KML file. Requires location data from the video or a live ADIAT Flight feed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13193,7 +13199,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="442"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="441"/>
         <source>Watch this recording: video, detections, telemetry and map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13203,7 +13209,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="447"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="446"/>
         <source>Open the folder holding the last recording and its detections.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13223,12 +13229,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Algoritmo:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="610"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="609"/>
         <source>Select which streaming detection algorithm to use</source>
         <translation>Seleccione qué algoritmo de detección de transmisión usar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="619"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="615"/>
         <source>Choose which streaming detection algorithm to run.
 • Color Anomaly &amp; Motion Detection: fused anomaly detectors
 • Color Detection: color-based highlighting</source>
@@ -13242,7 +13248,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Umbral de galería:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="655"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="653"/>
         <source>Number of frames a detection must be seen before appearing in the Gallery tab</source>
         <translation>Número de fotogramas que debe verse una detección antes de aparecer en la pestaña Galería</translation>
     </message>
@@ -13252,7 +13258,7 @@ Not needed for most videos, which already carry it.</source>
         <translation> fotogramas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="667"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="663"/>
         <source>Detections must be seen for this many consecutive frames
 before appearing in the Gallery. Higher values reduce
 false positives but delay detection appearance.</source>
@@ -13363,27 +13369,27 @@ los falsos positivos, pero retrasan la aparición de la detección.</translation
         <translation>{state} - {message}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1913"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1912"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="537"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="534"/>
         <source>Save the flight path and detection locations as a map and a KML file. Location data is available for this source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="544"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="541"/>
         <source>Save the flight path and detection locations as a map and a KML file. Nothing is saved unless location data arrives while recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1915"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1914"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1917"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1916"/>
         <source>Connecting</source>
         <translation type="unfinished">Conectando</translation>
     </message>
@@ -13413,7 +13419,7 @@ los falsos positivos, pero retrasan la aparición de la detección.</translation
         <translation>Resultados de detección ({count} encontrados):</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2239"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2238"/>
         <source>#{index}: Type({cls}) Pos({x},{y}) Size({w}x{h})</source>
         <translation>n.º{index}: Tipo({cls}) Pos({x},{y}) Tamaño({w}x{h})</translation>
     </message>
@@ -13478,7 +13484,7 @@ los falsos positivos, pero retrasan la aparición de la detección.</translation
         <translation>Transmisión en vivo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2514"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2512"/>
         <source>Cannot seek in live stream.
 
 Detection was first seen at frame {frame}.</source>
@@ -13823,12 +13829,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Más ejemplos:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>pies²</translation>
     </message>
@@ -13841,7 +13847,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Ningún AOI marcado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="52"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="49"/>
         <source>There are no flagged AOIs to assign.
 
 Flag at least one AOI in the viewer before using Plan Verification.</source>
@@ -13865,7 +13871,7 @@ Marque al menos un AOI en el visor antes de usar la Verificación del plan.</tra
         <translation>Ningún AOI seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="223"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="221"/>
         <source>Select one or more AOIs on the map first.
 Click on markers, or use Rectangle Select for area selection.</source>
         <translation>Primero seleccione uno o más AOI en el mapa.
@@ -13990,7 +13996,7 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation>Selección rectangular</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="97"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="96"/>
         <source>Draw a rectangle on the map to select multiple AOIs</source>
         <translation>Dibuje un rectángulo en el mapa para seleccionar varios AOI</translation>
     </message>
@@ -14031,7 +14037,7 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation>Asignar selección ▶</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="146"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="145"/>
         <source>Assign the selected AOIs on the map to the chosen team</source>
         <translation>Asignar los AOI seleccionados en el mapa al equipo elegido</translation>
     </message>
@@ -14046,7 +14052,7 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation>Exportar PDF del equipo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="174"/>
         <source>Generate a PDF report for the selected team only</source>
         <translation>Generar un informe PDF solo para el equipo seleccionado</translation>
     </message>
@@ -14056,17 +14062,17 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation>Exportar todos los PDF</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="181"/>
         <source>Generate one PDF per team plus a master summary PDF</source>
         <translation>Generar un PDF por equipo más un PDF resumen maestro</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="198"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="195"/>
         <source>Click to select AOI • Ctrl+Click to multi-select • Use Rectangle Select for area selection • Scroll to zoom</source>
         <translation>Haga clic para seleccionar AOI • Ctrl+Clic para selección múltiple • Use Selección rectangular para selección por área • Rueda para acercar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="223"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="222"/>
         <source>Team</source>
         <translation>Equipo</translation>
     </message>
@@ -14145,18 +14151,18 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation>sin actualizar {age}s</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="265"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="264"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="57"/>
         <source>ALT —</source>
         <translation>ALT —</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="299"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="297"/>
         <source>no AGL yet - ADIAT Flight found no terrain source here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="301"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="300"/>
         <source>no terrain-referenced AGL available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14176,47 +14182,47 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="307"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="306"/>
         <source>AGL — above the terrain beneath the aircraft; what clearance and image scale depend on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="309"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="308"/>
         <source>ATO — above the takeoff point (the drone&apos;s own reading); equal to AGL only over flat ground</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="325"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="324"/>
         <source>ADIAT Flight (fused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="327"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="326"/>
         <source>laser rangefinder (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="329"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="328"/>
         <source>downward sensor (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="331"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="330"/>
         <source>terrain DEM (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="333"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="332"/>
         <source>desktop DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="335"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="334"/>
         <source>no terrain source — this is the takeoff-relative reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="341"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="339"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="91"/>
         <source>HDG —</source>
         <translation>RUM —</translation>
@@ -14227,7 +14233,7 @@ Haga clic en los marcadores o use Selección rectangular para selección por ár
         <translation>RUM {bearing:03d}° {cardinal}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="354"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="349"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="98"/>
         <source>SPD —</source>
         <translation>VEL —</translation>
@@ -14547,18 +14553,18 @@ agresivo</translation>
 <context>
     <name>ThermalHistogramChart</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="98"/>
         <source>No histogram data available</source>
         <translation>No hay datos de histograma disponibles</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="435"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="434"/>
         <source>All Pixels</source>
         <translation>Todos los píxeles</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="446"/>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="457"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="445"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="456"/>
         <source>AOI Pixels</source>
         <translation>Píxeles del AOI</translation>
     </message>
@@ -14571,7 +14577,7 @@ agresivo</translation>
         <translation>Histograma térmico no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="34"/>
+        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="33"/>
         <source>No thermal temperature data is available for the current image.</source>
         <translation>No hay datos de temperatura térmica disponibles para la imagen actual.</translation>
     </message>
@@ -14628,7 +14634,7 @@ agresivo</translation>
         <translation>Pase el cursor sobre el histograma para inspeccionar una banda de temperatura.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="30"/>
         <source>No thermal histogram data available</source>
         <translation>No hay datos de histograma térmico disponibles</translation>
     </message>
@@ -14974,7 +14980,7 @@ agresivo</translation>
         <translation>¿Reemplazar la fuente de dosel?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="361"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="359"/>
         <source>A LANDFIRE canopy source is currently configured.
 
 Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay on disk; only the selected source changes.)</source>
@@ -14988,7 +14994,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Elevación (MDE)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="370"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="368"/>
         <source>Canopy height</source>
         <translation>Altura del dosel</translation>
     </message>
@@ -15119,7 +15125,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Margen de huella (m):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="110"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
         <translation>Relleno añadido alrededor de las posiciones de la cámara para que las teselas descargadas cubran las huellas de las imágenes. Se dimensiona automáticamente a partir de la misión; edítelo y vuelva a rellenar para cambiarlo.</translation>
     </message>
@@ -15134,7 +15140,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>USGS 3DEP DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="123"/>
         <source>USGS 3DEP provides 1 m local elevation. Optional when you already have a terrain source configured (AWS Terrain Tiles online, or downloaded 3DEP) — enable it to download higher-resolution data.</source>
         <translation>USGS 3DEP proporciona elevación local de 1 m. Opcional cuando ya tiene configurada una fuente de terreno (AWS Terrain Tiles en línea, o 3DEP descargado): actívelo para descargar datos de mayor resolución.</translation>
     </message>
@@ -15164,7 +15170,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Carpeta personalizada...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="152"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="149"/>
         <source>The central library collects tiles from all missions in one place (they merge, nothing gets replaced) and registers automatically. Choose the results folder or a custom folder to keep tiles beside a specific mission instead.</source>
         <translation>La biblioteca central reúne las teselas de todas las misiones en un solo lugar (se combinan, nada se reemplaza) y se registra automáticamente. Elija la carpeta de resultados o una carpeta personalizada para guardar las teselas junto a una misión concreta.</translation>
     </message>
@@ -15194,32 +15200,32 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="207"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="206"/>
         <source>This area is already covered by your registered tiles.</source>
         <translation>Esta área ya está cubierta por sus teselas registradas.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="210"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="208"/>
         <source>Partially covered by your registered tiles — downloading fills the gaps.</source>
         <translation>Parcialmente cubierto por sus teselas registradas; la descarga rellena los huecos.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="214"/>
         <source>Your downloaded 1 m tiles don&apos;t include this area — without this download, online AWS Terrain Tiles (~30 m) are used here instead.</source>
         <translation>Sus teselas de 1 m descargadas no incluyen esta área; sin esta descarga, aquí se usan los AWS Terrain Tiles en línea (~30 m).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="220"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
         <source>Your downloaded canopy tiles don&apos;t include this area — without this download, POD runs with no canopy attenuation here.</source>
         <translation>Sus teselas de dosel descargadas no incluyen esta área; sin esta descarga, el POD se ejecuta aquí sin atenuación del dosel.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="222"/>
         <source>No local elevation tiles registered — online AWS Terrain Tiles (~30 m) serve as the baseline.</source>
         <translation>No hay teselas de elevación locales registradas; los AWS Terrain Tiles en línea (~30 m) sirven como base.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
         <source>No canopy source is configured yet.</source>
         <translation>Aún no se ha configurado una fuente de dosel.</translation>
     </message>
@@ -15260,7 +15266,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Ningún dato seleccionado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="441"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="440"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Seleccione al menos un tipo de datos para exportar.</translation>
     </message>
@@ -15291,7 +15297,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Guardar exportación de mapa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="500"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="499"/>
         <source>KML files (*.kml);;KMZ files (*.kmz)</source>
         <translation>Archivos KML (*.kml);;Archivos KMZ (*.kmz)</translation>
     </message>
@@ -15317,12 +15323,12 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="704"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="716"/>
         <source>POD coverage complete</source>
         <translation>Cobertura POD completada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
         <source>POD coverage complete — {count} frame(s) used online elevation (outside local DEM)</source>
         <translation>Cobertura POD completada: {count} fotograma(s) usaron elevación en línea (fuera del DEM local)</translation>
     </message>
@@ -15342,7 +15348,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>(los datos de dosel cubrieron el {pct}% del área buscada)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="808"/>
         <source>Terrain and canopy aware probability-of-detection heatmap.</source>
         <translation>Mapa de calor de probabilidad de detección consciente del terreno y del dosel.</translation>
     </message>
@@ -15362,7 +15368,7 @@ Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay
         <translation>Superposición POD</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="826"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="824"/>
         <source>The POD coverage was computed, but embedding it into the exported file failed:
 {error}
 
@@ -15415,7 +15421,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
         <source>(no takeoff elevation — POD is approximate over changing terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15433,12 +15439,12 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
 <context>
     <name>UpdateController</name>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="53"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="52"/>
         <source>Disabled while Offline Only mode is enabled.</source>
         <translation>Desactivado mientras el modo Solo sin conexión está habilitado.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="57"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="56"/>
         <source>Check the update feed for a newer ADIAT installer.</source>
         <translation>Consulte la fuente de actualizaciones para un instalador de ADIAT más reciente.</translation>
     </message>
@@ -15448,7 +15454,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>Actualizaciones deshabilitadas</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="88"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="87"/>
         <source>Update checks are disabled while Offline Only mode is enabled.</source>
         <translation>La búsqueda de actualizaciones está deshabilitada mientras el modo Solo sin conexión está habilitado.</translation>
     </message>
@@ -15470,7 +15476,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>No hay actualizaciones disponibles</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="113"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="112"/>
         <source>You are already running the latest available version of ADIAT.</source>
         <translation>Ya está ejecutando la última versión disponible de ADIAT.</translation>
     </message>
@@ -15492,7 +15498,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>Instalador iniciado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="140"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="139"/>
         <source>The installer has been launched. Close ADIAT when you are ready to continue the update.</source>
         <translation>El instalador se ha iniciado. Cierre ADIAT cuando esté listo para continuar la actualización.</translation>
     </message>
@@ -15507,7 +15513,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>ADIAT {new_version} está disponible. Usted está ejecutando {current_version}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="157"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="156"/>
         <source>Do you want to download and launch the installer now?</source>
         <translation>¿Quiere descargar e iniciar el instalador ahora?</translation>
     </message>
@@ -15538,7 +15544,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>{value} MB</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="194"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="193"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -15551,7 +15557,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
     </message>
     <message>
         <location filename="../app/core/controllers/UpdateController.py" line="204"/>
-        <location filename="../app/core/controllers/UpdateController.py" line="211"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="210"/>
         <source>Update download canceled.</source>
         <translation>Descarga de actualización cancelada.</translation>
     </message>
@@ -15617,7 +15623,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>Cerrar esta ventana de escalado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="306"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="302"/>
         <source>Resolution: {width} × {height} pixels | Original: {orig_w} × {orig_h} pixels | Upscale: {level}x | Use mouse wheel to zoom, right-click to pan</source>
         <translation>Resolución: {width} × {height} píxeles | Original: {orig_w} × {orig_h} píxeles | Ampliación: {level}x | Use la rueda del mouse para hacer zoom y el clic derecho para desplazar</translation>
     </message>
@@ -15636,7 +15642,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>Error durante el escalado inicial: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="388"/>
         <source>Unable to extract visible image portion.</source>
         <translation>No se puede extraer la porción visible de la imagen.</translation>
     </message>
@@ -15646,7 +15652,7 @@ Los productos GeoTIFF de POD se escribieron igualmente junto a la exportación.<
         <translation>Escalado máximo alcanzado</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="401"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="399"/>
         <source>Maximum upscale level of {level}x has been reached.
 Further upscaling is not allowed to prevent memory issues.</source>
         <translation>Se ha alcanzado el nivel máximo de escalado de {level}x.
@@ -15658,7 +15664,7 @@ No se permite más escalado para evitar problemas de memoria.</translation>
         <translation>Imagen demasiado grande</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="415"/>
         <source>Upscaling would result in an image of {width}×{height} pixels.
 Maximum allowed dimension is {max_dim} pixels.
 
@@ -15674,7 +15680,7 @@ Intente ampliar a un área más pequeña antes de escalar.</translation>
         <translation>Imagen demasiado pequeña</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="430"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="428"/>
         <source>Visible portion is too small ({width}×{height} pixels).
 Please zoom in to a larger area before upscaling.</source>
         <translation>La porción visible es demasiado pequeña ({width}×{height} píxeles).
@@ -15689,7 +15695,7 @@ Amplíe a un área más grande antes de escalar.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="487"/>
         <source>Upscaling image with AI enhancement...
 From {width}×{height} to {new_width}×{new_height} pixels
 This may take a few seconds.</source>
@@ -15721,7 +15727,7 @@ Esto puede tardar unos segundos.</translation>
         <translation>Método no disponible</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="605"/>
         <source>Real-ESRGAN is not yet implemented.
 Falling back to Lanczos interpolation.</source>
         <translation>Real-ESRGAN aún no está implementado.
@@ -15931,7 +15937,7 @@ Muestra información en tiempo real durante la extracción de fotogramas:
 Muestra el total de fotogramas extraídos al completarse.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="58"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="57"/>
         <source>Select a Video File</source>
         <translation>Seleccionar un archivo de vídeo</translation>
     </message>
@@ -15941,7 +15947,7 @@ Muestra el total de fotogramas extraídos al completarse.</translation>
         <translation>Seleccionar un archivo de metadatos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="74"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="73"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)</source>
         <translation>Archivos de metadatos (*.srt *.csv);;Archivos SRT (*.srt);;Registros de vuelo CSV (*.csv)</translation>
     </message>
@@ -15951,7 +15957,7 @@ Muestra el total de fotogramas extraídos al completarse.</translation>
         <translation>Seleccionar directorio</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="111"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="110"/>
         <source>Please set the video file and output directory.</source>
         <translation>Establezca el archivo de vídeo y el directorio de salida.</translation>
     </message>
@@ -16024,7 +16030,7 @@ Cuando está deshabilitada, muestra la imagen original sin procesar.
         <translation>Mostrar superposición</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1346"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1343"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -16042,7 +16048,7 @@ Muestra todos los AOI de todas las imágenes en una vista de cuadrícula</transl
         <translation>Mostrar AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1364"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1363"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="328"/>
         <source>Open Histogram</source>
         <translation>Abrir histograma</translation>
@@ -16090,7 +16096,7 @@ Muestra todos los AOI de todas las imágenes en una vista de cuadrícula</transl
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2158"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2157"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="427"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation>Referencia de tamaño de persona (Ctrl+P)</translation>
@@ -16294,7 +16300,7 @@ La ordenación ayuda a priorizar la revisión de objetos más grandes o más cer
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="139"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="138"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Herramienta automatizada de análisis de imágenes de dron v{version} - Patrocinado por TEXSAR</translation>
     </message>
@@ -16319,7 +16325,7 @@ La ordenación ayuda a priorizar la revisión de objetos más grandes o más cer
         <translation>Error al cargar los resultados</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="189"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -16349,7 +16355,7 @@ El visor se cerrará ahora.</translation>
         <translation>Cargando resultados de detección de {n} imágenes...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="307"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="304"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Metadatos e información de la imagen.
@@ -16371,7 +16377,7 @@ Haga clic en las coordenadas GPS para copiar, compartir o abrir en aplicaciones 
         <translation>Sin conjunto de datos</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="721"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>No dataset is currently loaded.</source>
         <translation>Actualmente no hay ningún conjunto de datos cargado.</translation>
     </message>
@@ -16381,7 +16387,7 @@ Haga clic en las coordenadas GPS para copiar, compartir o abrir en aplicaciones 
         <translation>Generar caché</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="732"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="729"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -16426,7 +16432,7 @@ Esto puede tardar varios minutos según el tamaño del conjunto de datos.
         <translation>Caché generada</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="806"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -16444,7 +16450,7 @@ El visor cargará ahora miniaturas y colores mucho más rápido.</translation>
         <translation>Error de generación de caché</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="840"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="839"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -16458,7 +16464,7 @@ El visor cargará ahora miniaturas y colores mucho más rápido.</translation>
         <translation>AOI no visible</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1028"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -16472,7 +16478,7 @@ Para seleccionar este AOI, borre o ajuste sus filtros.</translation>
         <translation>Actualizar dimensiones de imagen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1228"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1224"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -16486,7 +16492,7 @@ Would you like to read dimensions from the image files and update the results fi
         <translation>Leyendo dimensiones de imagen ({done}/{total})...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1355"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1354"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Mostrar píxeles de interés (H o Ctrl+I)</translation>
     </message>
@@ -16506,7 +16512,7 @@ Would you like to read dimensions from the image files and update the results fi
         <translation>Dependencia faltante</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1797"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1794"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>El módulo qimage2ndarray es necesario para la función de escalado.
@@ -16518,19 +16524,19 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Error de escalado</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1806"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1805"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Se produjo un error al abrir el diálogo de escalado:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2161"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation>La referencia de tamaño de persona no está disponible: esta imagen no tiene GSD</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2261"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2258"/>
         <source>Unknown Reviewer</source>
         <translation>Revisor desconocido</translation>
     </message>
@@ -16553,7 +16559,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>El reloj de la cámara de estas imágenes parece estar mal configurado:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
         <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
         <translation>ADIAT puede grabar una hora de captura corregida en los metadatos de la imagen. Es un proceso no destructivo: los campos EXIF originales no se modifican y los cálculos de sol y sombra usarán la hora corregida. Compare la vista previa con la hora real del vuelo; si difiere en 12 horas, ajuste el error de la esfera del reloj.</translation>
     </message>
@@ -16568,7 +16574,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Error de la esfera del reloj a corregir:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="129"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
         <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
         <translation>Nombre de zona horaria IANA (p. ej. America/Los_Angeles) o un desfase UTC fijo en horas (p. ej. -7)</translation>
     </message>
@@ -16649,6 +16655,124 @@ Instálelo usando: pip install qimage2ndarray</translation>
     </message>
 </context>
 <context>
+    <name>WaldoFlightLogDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="126"/>
+        <source>WALDO Flight Track Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="150"/>
+        <source>An aircraft track log can supply the true per-image camera attitude (bank and pitch) and a GPS-accurate capture time, making image footprints and AOI positions substantially more accurate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="162"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished">Recordar mi elección para esta carpeta</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="171"/>
+        <source>Reading image metadata...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="182"/>
+        <source>Apply Flight Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="186"/>
+        <source>Not Now</source>
+        <translation type="unfinished">Ahora no</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="190"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="193"/>
+        <source>OK</source>
+        <translation type="unfinished">Aceptar</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="246"/>
+        <source>The track log does not match these images: {reason}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="258"/>
+        <source>Camera clock is {n:.1f} s {direction} of GPS time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>behind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="261"/>
+        <source>Track log: {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="263"/>
+        <source>Images sit {d:.0f} m from the flight track on average ({p:.0%} matched)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="269"/>
+        <source>Attitude channel verified against turn physics (correlation {c:.2f}, recorded {lag:+.0f} s late)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="273"/>
+        <source>Bank during capture: {lo:+.1f}° to {hi:+.1f}°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="277"/>
+        <source>Attitude channel is NOT reliable (correlation {c:.2f}) - only the capture-time refinement will be stamped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="305"/>
+        <source>Stamping flight-log attitude...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="324"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished">Cancelando...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="347"/>
+        <source>Stamped:          {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="348"/>
+        <source>Already current:  {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="349"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Errores:          {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="355"/>
+        <source>Cancelled - remaining images are unstamped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WaldoPrePassDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="58"/>
@@ -16681,7 +16805,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Prepasada WALDO completada</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="148"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="147"/>
         <source>WALDO Pre-Pass Cancelled</source>
         <translation>Prepasada WALDO cancelada</translation>
     </message>
@@ -16739,7 +16863,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Resumen de importación</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="61"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="58"/>
         <source>&lt;b&gt;Matched images:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;CSV entries without match:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Result images without CSV data:&lt;/b&gt; {unmatched_images}</source>
         <translation>&lt;b&gt;Imágenes coincidentes:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;Entradas CSV sin coincidencia:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Imágenes de resultado sin datos CSV:&lt;/b&gt; {unmatched_images}</translation>
     </message>
@@ -16749,12 +16873,12 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Altitud y GSD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="78"/>
         <source>&lt;b&gt;AGL computed from terrain:&lt;/b&gt; {agl_count} of {matched_count} images&lt;br&gt;&lt;br&gt;Per-image AGL is derived from the CSV altitude (ASL) minus terrain elevation at each GPS location. GSD will be calculated automatically using the camera sensor data and focal length.</source>
         <translation>&lt;b&gt;AGL calculado a partir del terreno:&lt;/b&gt; {agl_count} de {matched_count} imágenes&lt;br&gt;&lt;br&gt;El AGL de cada imagen se deriva de la altitud CSV (ASL) menos la elevación del terreno en cada ubicación GPS. El GSD se calculará automáticamente usando los datos del sensor de la cámara y la distancia focal.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="89"/>
         <source>&lt;b&gt;Terrain data unavailable&lt;/b&gt; - AGL could not be computed.&lt;br&gt;&lt;br&gt;Orientation (yaw/pitch/roll) will still be applied from the CSV. GSD and altitude displays require terrain data or a manual altitude override (Shift+O) after import.</source>
         <translation>&lt;b&gt;Datos de terreno no disponibles&lt;/b&gt;: no se pudo calcular el AGL.&lt;br&gt;&lt;br&gt;La orientación (yaw/pitch/roll) se aplicará igualmente desde el CSV. Las visualizaciones de GSD y altitud requieren datos de terreno o una sustitución manual de altitud (Mayús+O) después de importar.</translation>
     </message>
@@ -16777,7 +16901,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Guardar archivo Zip</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="132"/>
         <source>Zip files (*.zip)</source>
         <translation>Archivos Zip (*.zip)</translation>
     </message>
@@ -16810,7 +16934,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Opciones de exportación ZIP</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="30"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="26"/>
         <source>Choose what to export:
 
 - Native: Original images, TIFF masks, and XML (paths made portable).
@@ -16836,7 +16960,7 @@ Instálelo usando: pip install qimage2ndarray</translation>
         <translation>Incluir imágenes sin AOI marcados</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="53"/>
         <source>When unchecked, only images with at least one flagged AOI will be exported.
 When checked, all images will be exported regardless of flagged AOI status.</source>
         <translation>Cuando está desactivado, solo se exportarán las imágenes con al menos un AOI marcado.
@@ -16851,6 +16975,24 @@ Cuando está activado, se exportarán todas las imágenes independientemente del
         <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="60"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>_CalibrateWorker</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="66"/>
+        <source>No images with resolvable GPS + capture time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="68"/>
+        <source>No ForeFlight track log found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="73"/>
+        <source>Calibrating {name}...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_it.ts
+++ b/translations/app_it.ts
@@ -125,12 +125,12 @@ L&apos;accelerazione GPU migliora significativamente la velocità di elaborazion
 <context>
     <name>AIPersonDetectorController</name>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="82"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="81"/>
         <source>GPU Not Available</source>
         <translation>GPU non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="88"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="87"/>
         <source>GPU Available</source>
         <translation>GPU disponibile</translation>
     </message>
@@ -203,7 +203,7 @@ Permissivo</translation>
         <translation>Commento AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="38"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="37"/>
         <source>Add a comment for this flagged AOI (max 256 characters):</source>
         <translation>Aggiungi un commento per questa AOI contrassegnata (max 256 caratteri):</translation>
     </message>
@@ -287,7 +287,7 @@ Permissivo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1092"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1091"/>
         <source>Terrain-corrected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -297,12 +297,12 @@ Permissivo</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1105"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1102"/>
         <source>Flat terrain assumed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1538"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Ordinamento per temperatura non disponibile (nessun dato termico)</translation>
     </message>
@@ -312,7 +312,7 @@ Permissivo</translation>
         <translation>Impossibile eliminare l&apos;AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1895"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1892"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Solo le AOI create manualmente possono essere eliminate. Le AOI rilevate dagli algoritmi non possono essere eliminate.</translation>
     </message>
@@ -322,7 +322,7 @@ Permissivo</translation>
         <translation>Elimina AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1904"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1903"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>Sei sicuro di voler eliminare questa AOI? Questa azione non può essere annullata.</translation>
     </message>
@@ -596,7 +596,7 @@ Permissivo</translation>
         <translation>Seleziona Maschera Immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="610"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="609"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)</source>
         <translation>Immagini (*.png *.jpg *.jpeg *.bmp *.tiff);;Tutti i file (*)</translation>
     </message>
@@ -606,7 +606,7 @@ Permissivo</translation>
         <translation>Immagine Non Valida</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="620"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="619"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>Impossibile caricare l&apos;immagine selezionata. Scegli un file immagine valido.</translation>
     </message>
@@ -659,12 +659,12 @@ Permissivo</translation>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="380"/>
         <source>Showing the {count} nearest images containing this AOI; there are more. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="385"/>
         <source>Found AOI in {count} image(s). Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,7 +677,7 @@ Permissivo</translation>
         <translation>Nessuna AOI selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="194"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="193"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Seleziona prima un&apos;AOI cliccandoci sopra nel pannello delle miniature.</translation>
     </message>
@@ -687,7 +687,7 @@ Permissivo</translation>
         <translation>Impossibile calcolare il GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="406"/>
         <source>Unable to calculate GPS coordinates for this AOI.
 
 This may be due to missing image metadata (GPS, altitude, or camera info).</source>
@@ -728,7 +728,7 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
         <translation>Nessuna immagine vicina trovata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="437"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>L&apos;AOI non è stata trovata in nessuna delle immagini vicine.</translation>
     </message>
@@ -745,7 +745,7 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="587"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="584"/>
         <source> (no detections)</source>
         <translation> (nessun rilevamento)</translation>
     </message>
@@ -770,7 +770,7 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
         <translation>Nessuna AOI selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="142"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Seleziona prima un&apos;AOI cliccandoci sopra nel pannello delle miniature.</translation>
     </message>
@@ -813,7 +813,7 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
         <translation>Nessuna AOI simile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="280"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="279"/>
         <source>No other AOIs could be analyzed for similarity.</source>
         <translation>Non è stato possibile analizzare altre AOI per la similarità.</translation>
     </message>
@@ -865,7 +865,7 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
         <translation>AOI simili</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="479"/>
         <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
         <translation>Le prime {shown} di {total} AOI ordinate per similarità con {reference}. Usa la rotellina del mouse per lo zoom, trascina con il tasto destro per la panoramica. Fai clic su una miniatura per passare a quell&apos;AOI.</translation>
     </message>
@@ -936,7 +936,7 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
         <translation>AOI #{number}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="584"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="582"/>
         <source>the selected AOI</source>
         <translation>l&apos;AOI selezionata</translation>
     </message>
@@ -944,15 +944,15 @@ Ciò potrebbe essere dovuto alla mancanza di metadati dell&apos;immagine (GPS, a
 <context>
     <name>AOIUIComponent</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="251"/>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="347"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="250"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="346"/>
         <source>AOI Information
 Right-click to copy data to clipboard</source>
         <translation>Informazioni AOI
 Fai clic destro per copiare i dati negli appunti</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="257"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="256"/>
         <source>
 
 Score Type: {type}
@@ -973,7 +973,7 @@ Punteggio Grezzo: {score} ({method})</translation>
         <translation>Rimuovi contrassegno AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="387"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="386"/>
         <source>Flag AOI</source>
         <translation>Contrassegna AOI</translation>
     </message>
@@ -989,7 +989,7 @@ Click to edit comment</source>
 Clicca per modificare il commento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="415"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="411"/>
         <source>No comment yet.
 Click to add a comment for this AOI.
 
@@ -1002,7 +1002,7 @@ Usa i commenti per annotare dettagli importanti, osservazioni,
 o azioni necessarie per questo rilevamento.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="429"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="428"/>
         <source>Calculate and show GPS location for this AOI</source>
         <translation>Calcola e mostra la posizione GPS per questa AOI</translation>
     </message>
@@ -1017,7 +1017,7 @@ o azioni necessarie per questo rilevamento.</translation>
         <translation>Area</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="485"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="484"/>
         <source>Areas</source>
         <translation>Aree</translation>
     </message>
@@ -1027,12 +1027,12 @@ o azioni necessarie per questo rilevamento.</translation>
         <translation>{filtered} di {total} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="496"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="495"/>
         <source>Area of Interest</source>
         <translation>Area di Interesse</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="498"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="497"/>
         <source>Areas of Interest</source>
         <translation>Aree di Interesse</translation>
     </message>
@@ -1055,7 +1055,7 @@ o azioni necessarie per questo rilevamento.</translation>
 <context>
     <name>AlertManager</name>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="295"/>
+        <location filename="../app/core/services/AlertService.py" line="294"/>
         <source>ADIAT - Color Detection Alerts</source>
         <translation>ADIAT - Avvisi Rilevamento Colore</translation>
     </message>
@@ -1065,7 +1065,7 @@ o azioni necessarie per questo rilevamento.</translation>
         <translation>ADIAT - Avviso Rilevamento Colore</translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="613"/>
+        <location filename="../app/core/services/AlertService.py" line="610"/>
         <source>Detected {count} object(s)
 Average confidence: {avg_confidence:.2f}
 Total area: {area:.0f} pixels
@@ -1076,7 +1076,7 @@ Area totale: {area:.0f} pixel
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="621"/>
+        <location filename="../app/core/services/AlertService.py" line="620"/>
         <source>
 Details:
 </source>
@@ -1085,7 +1085,7 @@ Dettagli:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="625"/>
+        <location filename="../app/core/services/AlertService.py" line="624"/>
         <source>  #{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
 </source>
         <translation>  #{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
@@ -1113,7 +1113,7 @@ Dettagli:
         <translation>Stai usando immagini termiche?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="157"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="156"/>
         <source>Are you looking for anomalies within a specific temperature range?</source>
         <translation>Stai cercando anomalie entro un intervallo di temperatura specifico?</translation>
     </message>
@@ -1123,7 +1123,7 @@ Dettagli:
         <translation>Vuoi rilevare specificamente persone?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="169"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="168"/>
         <source>Do you want to detect anomalies relative to local surroundings?</source>
         <translation>Vuoi rilevare anomalie rispetto alle aree circostanti locali?</translation>
     </message>
@@ -1138,12 +1138,12 @@ Dettagli:
         <translation>Vuoi regolare manualmente l&apos;intervallo di colore?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="194"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="193"/>
         <source>Do your images contain complex backgrounds or structures?</source>
         <translation>Le tue immagini contengono sfondi o strutture complesse?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="201"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="200"/>
         <source>Do your images include shadows or areas with uneven lighting?</source>
         <translation>Le tue immagini includono ombre o aree con illuminazione non uniforme?</translation>
     </message>
@@ -1179,7 +1179,7 @@ Dettagli:
 <context>
     <name>AlignImageDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="53"/>
         <source>This saved alignment looks mirrored - re-place each corner handle on its matching photo corner (coloured squares).</source>
         <translation>Questo allineamento salvato sembra speculare: riposiziona ogni maniglia d&apos;angolo sull&apos;angolo corrispondente della foto (quadrati colorati).</translation>
     </message>
@@ -1189,7 +1189,7 @@ Dettagli:
         <translation>Allinea immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="136"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="130"/>
         <source>Rotate the drone image to line it up with the map. The small coloured squares mark the photo&apos;s corners - drag each corner handle onto the map where its matching-coloured photo corner belongs. For extra accuracy, add tie points: put the IMAGE end on a feature in the drone photo and the MAP end on the same feature on the map.</source>
         <translation>Ruota l&apos;immagine del drone per allinearla alla mappa. I piccoli quadrati colorati segnano gli angoli della foto: trascina ogni maniglia d&apos;angolo sulla mappa nel punto in cui deve trovarsi l&apos;angolo della foto dello stesso colore. Per maggiore precisione, aggiungi punti di collegamento: metti l&apos;estremità IMMAGINE su un elemento nella foto del drone e l&apos;estremità MAPPA sullo stesso elemento sulla mappa.</translation>
     </message>
@@ -1235,7 +1235,7 @@ Dettagli:
         <translation>Gli angoli sembrano speculari</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="220"/>
         <source>The four corners appear mirrored - the drone image would map to the ground flipped.
 
 Each corner handle is colour-matched to a corner of the drone photo (the small coloured squares). Make sure every handle sits where its matching photo corner belongs.</source>
@@ -1275,7 +1275,7 @@ Ogni maniglia d&apos;angolo è abbinata per colore a un angolo della foto del dr
         <translation>metri</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="100"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="98"/>
         <source>feet</source>
         <translation>piedi</translation>
     </message>
@@ -1285,7 +1285,7 @@ Ogni maniglia d&apos;angolo è abbinata per colore a un angolo della foto del dr
         <translation>Rilevata altitudine negativa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="113"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="111"/>
         <source>WARNING! Relative Altitude is negative. Enter an AGL altitude to be used for GSD calculations (in {unit}):</source>
         <translation>ATTENZIONE! L&apos;altitudine relativa è negativa. Inserisci un&apos;altitudine AGL da utilizzare per i calcoli GSD (in {unit}):</translation>
     </message>
@@ -1295,7 +1295,7 @@ Ogni maniglia d&apos;angolo è abbinata per colore a un angolo della foto del dr
         <translation>Forza Altitudine</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="132"/>
         <source>Enter a custom AGL altitude to be used for GSD calculations for all images (in {unit}):</source>
         <translation>Inserisci un&apos;altitudine AGL personalizzata da utilizzare per i calcoli GSD per tutte le immagini (in {unit}):</translation>
     </message>
@@ -1367,7 +1367,7 @@ Ogni maniglia d&apos;angolo è abbinata per colore a un angolo della foto del dr
         <translation>Rilevati Orientamenti Mancanti</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="135"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="132"/>
         <source>Some images are missing bearing/heading information. We can estimate bearings from a flight track file (KML/GPX/CSV) or calculate them automatically from image GPS coordinates.</source>
         <translation>Alcune immagini mancano di informazioni sull&apos;orientamento/prua. Possiamo stimare gli orientamenti da un file di traccia di volo (KML/GPX/CSV) o calcolarli automaticamente dalle coordinate GPS dell&apos;immagine.</translation>
     </message>
@@ -1402,7 +1402,7 @@ Ogni maniglia d&apos;angolo è abbinata per colore a un angolo della foto del dr
         <translation>Seleziona File Traccia</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="262"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="261"/>
         <source>Track Files (*.kml *.gpx *.csv);;KML Files (*.kml);;GPX Files (*.gpx);;CSV Files (*.csv);;All Files (*.*)</source>
         <translation>File Traccia (*.kml *.gpx *.csv);;File KML (*.kml);;File GPX (*.gpx);;File CSV (*.csv);;Tutti i File (*.*)</translation>
     </message>
@@ -1442,7 +1442,7 @@ Ogni maniglia d&apos;angolo è abbinata per colore a un angolo della foto del dr
         <translation>Calcolo Orientamento Fallito</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="393"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="391"/>
         <source>An error occurred during bearing calculation:
 
 {error}
@@ -1470,7 +1470,7 @@ Controlla i file di input e riprova.</translation>
         <translation>Recupero Orientamento Non Necessario</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="440"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="437"/>
         <source>Bearing recovery requires multiple images to calculate direction of travel.
 
 With only one image, bearing recovery cannot be performed.</source>
@@ -1479,7 +1479,7 @@ With only one image, bearing recovery cannot be performed.</source>
 Con una sola immagine, il recupero dell&apos;orientamento non può essere eseguito.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="452"/>
         <source>
 &lt;h3&gt;What is Bearing Recovery?&lt;/h3&gt;
 
@@ -1558,14 +1558,14 @@ Procedi senza il recupero dell&apos;orientamento. Alcune funzioni potrebbero non
         <translation>Dati memorizzati nella cache non trovati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="57"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="56"/>
         <source>The following cached items were not found:
 </source>
         <translation>I seguenti elementi memorizzati nella cache non sono stati trovati:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="71"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="66"/>
         <source>Without cached data, thumbnails and colors will be generated on-demand, which may cause delays when viewing results.
 
 If you have previously processed this dataset and have an ADIAT_Results folder with cached data, you can locate it now to improve performance.</source>
@@ -1594,7 +1594,7 @@ Se hai precedentemente elaborato questo set di dati e hai una cartella ADIAT_Res
         <translation>Cartella Cache Non Valida</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="143"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="138"/>
         <source>The selected folder does not contain thumbnail cache directory.
 
 Expected to find:
@@ -1658,7 +1658,7 @@ Seleziona una cartella ADIAT_Results valida.</translation>
         <translation>Credenziali Aggiornate</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="517"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="516"/>
         <source>Credentials have been updated and the map list has been refreshed.</source>
         <translation>Le credenziali sono state aggiornate e l&apos;elenco delle mappe è stato aggiornato.</translation>
     </message>
@@ -1668,7 +1668,7 @@ Seleziona una cartella ADIAT_Results valida.</translation>
         <translation>Aggiornamento Fallito</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="526"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="523"/>
         <source>Failed to refresh account data with new credentials.
 
 Please check your credentials and try again.</source>
@@ -1691,7 +1691,7 @@ Controlla le tue credenziali e riprova.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="544"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="542"/>
         <source>Credentials have been updated. Please close and reopen this dialog to refresh the map list.</source>
         <translation>Le credenziali sono state aggiornate. Chiudi e riapri questa finestra per aggiornare l&apos;elenco delle mappe.</translation>
     </message>
@@ -1701,7 +1701,7 @@ Controlla le tue credenziali e riprova.</translation>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="560"/>
         <source>Please select a map from the list.</source>
         <translation>Seleziona una mappa dall&apos;elenco.</translation>
     </message>
@@ -1757,7 +1757,7 @@ Controlla le tue credenziali e riprova.</translation>
         <translation>Caricamento Fallito</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Impossibile caricare CalTopo. Controlla la tua connessione internet e riprova.</translation>
     </message>
@@ -1772,7 +1772,7 @@ Controlla le tue credenziali e riprova.</translation>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="480"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1786,7 +1786,7 @@ L&apos;URL della mappa deve contenere un ID mappa (es., /m/ABC123 o #id=ABC123).
         <translation>Browser non pronto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="488"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>Il browser CalTopo è ancora in fase di caricamento. Attendi un momento e riprova.</translation>
     </message>
@@ -1802,12 +1802,12 @@ L&apos;URL della mappa deve contenere un ID mappa (es., /m/ABC123 o #id=ABC123).
         <translation>Autenticazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser non inizializzato. Riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="768"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1834,7 +1834,7 @@ Assicurati di aver effettuato l&apos;accesso a CalTopo in questa finestra e di a
         <translation>Credenziali API Team CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="87"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="85"/>
         <source>Enter your CalTopo Team API credentials.
 These can be found in the Team Admin page under Service Accounts.</source>
         <translation>Inserisci le tue credenziali API Team CalTopo.
@@ -1945,7 +1945,7 @@ Queste possono essere trovate nella pagina Team Admin sotto Service Accounts.</t
         <translation>Segreto credenziale non valido</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="268"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="263"/>
         <source>The Credential Secret cannot be used to sign a CalTopo request.
 
 Copy it exactly as shown on the CalTopo Team Admin page under Service Accounts - it is a long base64 string, not the Credential ID or the Team ID.
@@ -1968,7 +1968,7 @@ Dettagli: {error}</translation>
         <translation>Credenziali Valide</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="319"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="318"/>
         <source>The credentials are valid and successfully authenticated with CalTopo API.</source>
         <translation>Le credenziali sono valide e l&apos;autenticazione con l&apos;API CalTopo è riuscita.</translation>
     </message>
@@ -1978,7 +1978,7 @@ Dettagli: {error}</translation>
         <translation>Credenziali Non Valide</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="332"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="325"/>
         <source>The credentials failed to authenticate with CalTopo API.
 
 Please check:
@@ -2013,13 +2013,13 @@ Controlla:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="488"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1297"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1298"/>
         <source>Offline Mode Enabled</source>
         <translation>Modalità Offline Abilitata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="495"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1304"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1300"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2035,13 +2035,13 @@ Disattiva Solo Offline per esportare su CalTopo.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="501"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1310"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1311"/>
         <source>Nothing Selected</source>
         <translation>Nessuna Selezione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="505"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="503"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1313"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Seleziona almeno un tipo di dati (AOI contrassegnate, posizioni drone/immagini o area di copertura) da esportare.</translation>
     </message>
@@ -2066,7 +2066,7 @@ Disattiva Solo Offline per esportare su CalTopo.</translation>
         <translation>Errore di Preparazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="563"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="562"/>
         <source>An error occurred while preparing export data:
 
 {error}</source>
@@ -2090,14 +2090,14 @@ Disattiva Solo Offline per esportare su CalTopo.</translation>
         <translation>area di copertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="582"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="579"/>
         <source>No flagged AOIs, geotagged image locations, or coverage areas are available.
 Flag some AOIs with the &apos;F&apos; key or ensure your images have GPS metadata.</source>
         <translation>Non sono disponibili AOI contrassegnate, posizioni di immagini georeferenziate o aree di copertura.
 Contrassegna alcune AOI con il tasto &apos;F&apos; o assicurati che le tue immagini abbiano metadati GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="590"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="585"/>
         <source>Found {count} flagged AOI(s), but could not extract GPS coordinates.
 
 This usually means:
@@ -2114,30 +2114,11 @@ Questo di solito significa:
 Assicurati che le tue immagini abbiano le coordinate GPS incorporate.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="593"/>
         <source>No geotagged drone/image locations were found.
 Ensure your images contain GPS metadata and try again.</source>
         <translation>Non sono state trovate posizioni di droni/immagini georeferenziate.
 Assicurati che le tue immagini contengano metadati GPS e riprova.</translation>
-    </message>
-    <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="605"/>
-        <source>No coverage area polygons could be calculated.
-
-This usually means:
-• The images don&apos;t have GPS data in their EXIF metadata
-• The images are not nadir (gimbal pitch must be between -85° and -95°)
-• GSD (ground sample distance) could not be calculated
-
-Please ensure your images have GPS coordinates and are nadir shots.</source>
-        <translation>Non è stato possibile calcolare alcun poligono dell&apos;area di copertura.
-
-Questo di solito significa:
-• Le immagini non hanno dati GPS nei loro metadati EXIF
-• Le immagini non sono nadirali (l&apos;inclinazione del gimbal deve essere compresa tra -85° e -95°)
-• Non è stato possibile calcolare la GSD (ground sample distance)
-
-Assicurati che le tue immagini abbiano le coordinate GPS e siano scatti nadirali.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="608"/>
@@ -2145,18 +2126,18 @@ Assicurati che le tue immagini abbiano le coordinate GPS e siano scatti nadirali
         <translation>Nessun {types} disponibile per l&apos;esportazione.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="613"/>
         <source>Nothing to Export</source>
         <translation>Nulla da Esportare</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="637"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="680"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="638"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No Map Selected</source>
         <translation>Nessuna Mappa Selezionata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="643"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="640"/>
         <source>Please navigate to a CalTopo map before clicking &apos;I&apos;m Logged In&apos;.
 
 The map URL should look like:
@@ -2167,7 +2148,7 @@ L&apos;URL della mappa dovrebbe essere simile a:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="686"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2176,7 +2157,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Apri la mappa nella finestra CalTopo prima di fare clic su &apos;Sono connesso - Esporta Dati&apos;.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1615"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1613"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2190,7 +2171,7 @@ Il motivo è stato scritto nel registro (adiat_logs.txt) e nella console.</trans
         <translation>Foto caricate: {uploaded} di {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1630"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2199,7 +2180,7 @@ The items should now be visible on your map.</source>
 Gli elementi dovrebbero ora essere visibili sulla mappa.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1641"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1639"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2208,24 +2189,24 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 I dettagli di eventuali errori sono stati scritti nel registro (adiat_logs.txt) e nella console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1628"/>
         <source>Export Successful</source>
         <translation>Esportazione Riuscita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1636"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1637"/>
         <source>Partial Success</source>
         <translation>Successo Parziale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1610"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1611"/>
         <source>Export Failed</source>
         <translation>Esportazione Fallita</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="718"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1377"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1572"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1378"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1573"/>
         <source>Export Error</source>
         <translation>Errore di Esportazione</translation>
     </message>
@@ -2240,7 +2221,7 @@ I dettagli di eventuali errori sono stati scritti nel registro (adiat_logs.txt) 
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1057"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1055"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2249,14 +2230,27 @@ Area in metri quadrati: {sqm:.0f} m²
 Numero di angoli: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1534"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1535"/>
         <source>Exporting to CalTopo</source>
         <translation>Esportazione su CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1265"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1266"/>
         <source>Logged Out</source>
         <translation>Disconnesso</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="598"/>
+        <source>No coverage area polygons could be calculated.
+
+This usually means:
+• The images don&apos;t have GPS data in their EXIF metadata
+• The images are not nadir (gimbal pitch must be between -85° and -95°;
+  WALDO images: boresight within 40° of nadir)
+• GSD (ground sample distance) could not be calculated
+
+Please ensure your images have GPS coordinates and are near-nadir shots.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1267"/>
@@ -2264,17 +2258,17 @@ Numero di angoli: {count}</translation>
         <translation>Disconnessione da CalTopo riuscita.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1425"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1426"/>
         <source>Loading CalTopo Maps</source>
         <translation>Caricamento Mappe CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
         <source>Connecting to CalTopo...</source>
         <translation>Connessione a CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1430"/>
         <source>Fetching account data and maps...</source>
         <translation>Recupero dati account e mappe...</translation>
     </message>
@@ -2293,7 +2287,7 @@ Numero di angoli: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="696"/>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
         <source>Authentication Failed</source>
         <translation>Autenticazione Fallita</translation>
@@ -2313,7 +2307,7 @@ Numero di angoli: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1497"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1492"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2326,12 +2320,12 @@ Il motivo è stato scritto nel registro (adiat_logs.txt) e nella console.
 Vuoi reinserire ID team, ID credenziale e segreto credenziale?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1537"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
         <source>Exporting to CalTopo...</source>
         <translation>Esportazione su CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1539"/>
         <source>Preparing data and exporting...</source>
         <translation>Preparazione dati ed esportazione...</translation>
     </message>
@@ -2349,7 +2343,7 @@ Vuoi reinserire ID team, ID credenziale e segreto credenziale?</translation>
         <translation>Seleziona Metodo di Esportazione CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="62"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="61"/>
         <source>Choose how you want to authenticate with CalTopo:</source>
         <translation>Scegli come vuoi autenticarti con CalTopo:</translation>
     </message>
@@ -2364,7 +2358,7 @@ Vuoi reinserire ID team, ID credenziale e segreto credenziale?</translation>
         <translation>API (Consigliato per Account Team CalTopo)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="77"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="75"/>
         <source>Use CalTopo Team API with service account credentials.
 Best for Teams accounts with service accounts configured.</source>
         <translation>Usa l&apos;API Team CalTopo con le credenziali dell&apos;account di servizio.
@@ -2376,14 +2370,14 @@ Ideale per gli account Team con account di servizio configurati.</translation>
         <translation>Accesso tramite Browser</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="81"/>
         <source>Use browser-based authentication.
 Log in through an embedded browser window.</source>
         <translation>Usa l&apos;autenticazione basata su browser.
 Accedi tramite una finestra del browser integrata.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="98"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="96"/>
         <source>API method requires Team ID and Credential Secret from your
 CalTopo Team Admin page. Browser method uses your regular login.</source>
         <translation>Il metodo API richiede l&apos;ID Team e il Segreto Credenziale dalla tua
@@ -2413,7 +2407,7 @@ pagina Admin Team CalTopo. Il metodo Browser utilizza il tuo normale accesso.</t
         <translation>Abilita Voto Temporale (riduce lo sfarfallio)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="42"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="38"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -2429,7 +2423,7 @@ Consigliato: ON in tutti i casi d&apos;uso (predefinito).</translation>
         <translation>Frame Finestra (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="53"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -2447,7 +2441,7 @@ Consigliato: 5 per 30 fps (finestra ~167 ms), 7 per 60 fps.</translation>
         <translation>Soglia (N su M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="71"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="66"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -2470,7 +2464,7 @@ Consigliato: 3 su 5 (rilevamento nel 60% dei frame).</translation>
         <translation>Abilita Filtro Rapporto d&apos;Aspetto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="85"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -2484,7 +2478,7 @@ La maggior parte degli utenti può lasciarlo OFF, a meno di rilevare molti falsi
         <translation>Rapporto Min:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="104"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="100"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -2500,7 +2494,7 @@ Esempio: 0,2 = rifiuta se l&apos;altezza è più di 5x la larghezza.</translatio
         <translation>Rapporto Max:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="116"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="113"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -2519,7 +2513,7 @@ Valori più alti = consente oggetti più larghi come veicoli o attrezzature lung
         <translation>Abilita Clustering Rilevamenti</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="131"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="128"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -2533,7 +2527,7 @@ La maggior parte degli utenti può lasciarlo OFF, a meno che gli oggetti non app
         <translation>Distanza Clustering (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="142"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -2562,7 +2556,7 @@ Click to change color</source>
 Clicca per cambiare colore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="79"/>
+        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="78"/>
         <source>HSV: ({h}°, {s}%, {v}%)
 RGB: ({r}, {g}, {b})
 Click to change color</source>
@@ -2609,7 +2603,7 @@ Clicca per cambiare colore</translation>
         <translation>Abilita Rilevamento Movimento</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="153"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="149"/>
         <source>Turn ON to highlight moving objects in the scene.
 Most users can leave all other settings at their defaults.
 Works best for stationary or slow-moving cameras and can be combined
@@ -2645,7 +2639,7 @@ con il Rilevamento Anomalie Basato sul Colore per risultati più affidabili.</tr
         <translation>KNN</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="179"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="174"/>
         <source>Motion detection algorithm (advanced setting):
 
 • FRAME_DIFF – Fast and simple; very sensitive to any motion.
@@ -2672,7 +2666,7 @@ In caso di dubbi, lascia impostato MOG2.</translation>
         <translation>Soglia Movimento:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="200"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="196"/>
         <source>Minimum pixel intensity change to consider as motion (1-255).
 Lower values = more sensitive, detects subtle motion, more false positives.
 Higher values = less sensitive, only strong motion, fewer false positives.
@@ -2688,7 +2682,7 @@ Consigliato: 10 per uso generale, 5 per movimenti sottili, 15-20 per scene ad al
         <translation>Kernel Sfocatura (dispari):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="215"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="210"/>
         <source>Gaussian blur kernel size (must be odd: 1, 3, 5, 7, etc.).
 Smooths the frame before motion detection to reduce noise.
 Larger values = more smoothing, less noise, less detail.
@@ -2706,7 +2700,7 @@ Consigliato: 5 per uso generale, 1 per nessuna sfocatura, 7-9 per video rumorosi
         <translation>Kernel Morfologia:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="230"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="225"/>
         <source>Morphological operation kernel size (odd numbers: 1, 3, 5, etc.).
 Removes small noise and fills holes in detections.
 Larger values = remove more noise, merge nearby detections.
@@ -2729,7 +2723,7 @@ Consigliato: 3 per uso generale, 1 per bordi precisi, 5-7 per video rumorosi.</t
         <translation>Frame Finestra (M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="251"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="246"/>
         <source>Size of temporal window for persistence filtering (2-30 frames).
 Motion must appear in N out of M consecutive frames to be confirmed.
 Larger values = longer memory, more stable, slower response.
@@ -2747,7 +2741,7 @@ Consigliato: 3 per video a 30 fps (finestra di 100 ms), 5 per 60 fps.</translati
         <translation>Soglia (N su M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="264"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="259"/>
         <source>Number of frames within window where motion must appear (N of M).
 Higher values = more stringent, filters flickering false positives.
 Lower values = more lenient, detects brief/intermittent motion.
@@ -2770,7 +2764,7 @@ Consigliato: 2 (movimento in 2 degli ultimi 3 frame).</translation>
         <translation>Frame Cronologia:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="285"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="280"/>
         <source>Number of frames to learn background model (10-500).
 Only applies to MOG2 and KNN algorithms.
 Longer history = adapts slower to lighting changes, more stable.
@@ -2788,7 +2782,7 @@ Consigliato: 50 (~1,7 sec a 30 fps) per uso generale.</translation>
         <translation>Soglia Varianza:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="298"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="293"/>
         <source>Variance threshold for background/foreground classification (1.0-100.0).
 Only applies to MOG2 and KNN algorithms.
 Lower values = more sensitive, detects subtle changes, more false positives.
@@ -2806,7 +2800,7 @@ Consigliato: 10,0 per interni, 15-20 per esterni con illuminazione variabile.</t
         <translation>Rileva Ombre (più lento)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="307"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="303"/>
         <source>Enables shadow detection in MOG2 background subtractor.
 Helps distinguish shadows from actual objects (reduces false positives).
 Adds ~10-20% processing overhead.
@@ -2828,7 +2822,7 @@ Consigliato: ON per scene esterne con ombre marcate, OFF per la velocità.</tran
         <translation>Area Min Oggetto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="328"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="323"/>
         <source>Minimum detection area in pixels (1-100000).
 Filters out very small detections such as noise, insects, or raindrops.
 Lower values = detect smaller objects (more noise).
@@ -2847,7 +2841,7 @@ Consigliato: 5-10 per soggetti delle dimensioni di una persona, 50-100 per i vei
         <translation>Area Max Oggetto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="341"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="336"/>
         <source>Maximum detection area in pixels (10-1000000).
 Filters out very large regions such as full-frame lighting changes or giant shadows.
 Lower values = only small/medium objects.
@@ -2870,7 +2864,7 @@ Consigliato: 1000 per le persone, 10000 per i veicoli, valori più alti per ogge
         <translation>Metti in Pausa Durante il Movimento della Telecamera</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="357"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="353"/>
         <source>Automatically pauses motion detection when camera is moving/panning.
 Prevents false positives caused by camera movement (entire scene appears to move).
 Detects camera movement by measuring percentage of frame with motion.
@@ -2886,7 +2880,7 @@ Consigliato: ON per riprese a mano libera o da drone, OFF per telecamere su trep
         <translation>Soglia:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="371"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="366"/>
         <source>Percentage of frame with motion to consider as camera movement (1-100%).
 If more than this % of pixels show motion, pause detection.
 Lower values = detect camera movement sooner (more pauses).
@@ -2904,7 +2898,7 @@ Consigliato: 15% per drone/mano libera, 30% per treppiedi instabili.</translatio
         <translation>Mostra Impostazioni Avanzate Movimento</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="386"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="383"/>
         <source>Advanced users can expand this to adjust the motion algorithm
 and detailed thresholds (sensitivity, filters, background model).
 If you are unsure, leave this unchecked and use the defaults.</source>
@@ -2918,7 +2912,7 @@ In caso di dubbi, lascia disattivata questa opzione e usa le impostazioni predef
         <translation>Abilita Rilevamento Anomalie Basato sul Colore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="409"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="405"/>
         <source>Detects pixels whose colors are statistically rare in the frame.
 Conceptually similar to MRMap&apos;s rarity-based detection for images.
 Works well for: bright colored clothing, vehicles, equipment in natural scenes.
@@ -2939,7 +2933,7 @@ Può essere combinato con il Rilevamento Movimento per un rilevamento più robus
         <translation>Risoluzione Colore (bin):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="430"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="424"/>
         <source>Controls how finely colors are grouped into histogram bins (3-8 bits).
 Analogous to MRMap&apos;s color binning.
 Lower values (3-4) = fewer bins → faster, more grouping, fewer but stronger detections.
@@ -2964,7 +2958,7 @@ e più alti solo quando devi cogliere differenze di colore molto sottili.</trans
         <translation>Soglia Rarità (% dei colori):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="448"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="442"/>
         <source>Sensitivity threshold for how rare a color must be to be flagged (0-100%).
 Computed from the distribution of color-bin counts in the frame, similar in role
 to MRMap&apos;s detection threshold.
@@ -2979,7 +2973,7 @@ Valori medi (25-40%) = bilanciato (consigliato per uso generale).
 Valori più alti (40-60%) = più sensibile: include colori più comuni (più rilevamenti).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="464"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="459"/>
         <source>Minimum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s minimum AOI area.
 Lower values = detect smaller colored objects (more noise).
@@ -2992,7 +2986,7 @@ Valori più alti = solo regioni colorate più grandi (meno rumore).
 Consigliato: 15 per soggetti delle dimensioni di una persona, 50+ per veicoli o oggetti grandi.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="477"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="472"/>
         <source>Maximum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s maximum AOI area.
 Lower values = only detect smaller colored objects.
@@ -3020,7 +3014,7 @@ Consigliato: 50000 per uso generale, 10000 per ricerche di soli oggetti piccoli.
         <translation>Componenti Connesse</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="491"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="486"/>
         <source>Method for extracting blob regions from the detection mask:
 
 Find Contours: Traditional OpenCV contour detection (default).
@@ -3062,7 +3056,7 @@ Componenti Connesse: usa cv2.connectedComponentsWithStats.
         <translation>LAB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="518"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="509"/>
         <source>Color space for histogram-based anomaly detection:
 
 RGB: Uses all 3 color channels. Fast, but sensitive to lighting.
@@ -3094,7 +3088,7 @@ LAB (cromaticità a,b): usa i canali a,b, invariante alla luce, percettivamente 
         <translation>Saturazione Min HSV:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="535"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="529"/>
         <source>Minimum saturation for HSV mode (0-255).
 Pixels below this saturation are ignored (grays, whites, blacks).
 These have undefined/noisy hue values.
@@ -3114,7 +3108,7 @@ Consigliato: 30-50 per uso generale.</translation>
         <translation>Croma Min LAB:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="555"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="549"/>
         <source>Minimum chroma (color intensity) for LAB mode (0-128).
 Chroma = distance from neutral gray in a,b plane.
 Pixels below this are ignored (near-neutral grays).
@@ -3139,7 +3133,7 @@ Consigliato: 10-20 per uso generale.</translation>
         <translation>Consenti Colori Simili (Espansione Tonalità)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="577"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="573"/>
         <source>Lets the detector treat similar colors as the same object.
 For example, a red jacket that looks slightly orange in some frames will still be grouped together.
 Turn this OFF if you only care about one very specific color shade.
@@ -3155,7 +3149,7 @@ Attivalo se vuoi un&apos;intera famiglia di colori (es. tutti i rossi/aranci cal
         <translation>Intervallo Corrispondenza Colore:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="590"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="586"/>
         <source>How wide to stretch the color match around each detected color.
 Smaller values = stay very close to the original color (more specific).
 Larger values = include a wider range of similar colors (more forgiving).
@@ -3181,7 +3175,7 @@ Consigliato: valori bassi per colori precisi, valori più alti quando la luce o 
         <translation>Abilita Esclusione Colori</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="609"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="605"/>
         <source>Exclude specific background colors from color anomaly detection.
 Useful for ignoring dominant scene colors such as grass, sky, or buildings.
 Click on the color wheel below to choose colors to ignore.
@@ -3197,7 +3191,7 @@ I colori selezionati sono evidenziati con un bordo scuro.</translation>
         <translation>Clicca sulla ruota dei colori per escludere colori (passi di 20°, 0-360°):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="621"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="618"/>
         <source>Click on any color segment to toggle exclusion on/off.
 Segments represent broad color ranges (e.g., blues, greens, reds).
 Use this to teach the system which background colors to ignore.</source>
@@ -3216,7 +3210,7 @@ Usa questa funzione per indicare al sistema quali colori di sfondo ignorare.</tr
         <translation>Abilita Fusione (quando movimento e colore sono entrambi attivi)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="645"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="641"/>
         <source>Combines motion and color detections when both are enabled.
 Only active when both Motion and Color detection are ON.
 Different modes control how detections are merged.
@@ -3252,7 +3246,7 @@ Consigliato: ON per un rilevamento multi-modale affidabile.</translation>
         <translation>PRIORITÀ_MOVIMENTO</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="666"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="657"/>
         <source>How to combine motion and color detections:
 
 • UNION: Show all detections from both (most detections).
@@ -3407,7 +3401,7 @@ Aggressivo</translation>
         <translation>Aggiungi Colore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="115"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="111"/>
         <source>Add a new color range to detect.
 Choose from HSV Color Picker, Image, List, or Recent Colors.
 You can add multiple color ranges to detect different colors simultaneously.</source>
@@ -3421,7 +3415,7 @@ Puoi aggiungere più intervalli di colori per rilevare diversi colori contempora
         <translation>Visualizza Intervallo</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="139"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="134"/>
         <source>View HSV color ranges for all configured colors.
 Opens a viewer dialog for each color range showing
 the hue, saturation, and value ranges that will be detected.
@@ -3442,7 +3436,7 @@ Utile per comprendere e perfezionare il rilevamento multicolore.</translation>
         <translation>Area Min Oggetto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="190"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="184"/>
         <source>Minimum detection area in pixels (10-50000).
 Filters out very small detections (noise, small objects, fragments).
 Lower values = detect smaller objects, more detections, more noise.
@@ -3460,7 +3454,7 @@ Consigliato: 100 per uso generale, 50 per piccoli oggetti, 200-500 per grandi og
         <translation>Area Max Oggetto (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="205"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="199"/>
         <source>Maximum detection area in pixels (100-500000).
 Filters out very large detections (shadows, lighting changes, entire scene).
 Lower values = only small/medium objects.
@@ -3478,7 +3472,7 @@ Consigliato: 100000 per uso generale, 50000 per piccoli oggetti, 200000+ per gra
         <translation>Soglia di Confidenza:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="224"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="215"/>
         <source>Minimum confidence score to accept a detection (0-100%).
 Confidence is calculated from:
 • Size score: area relative to max area
@@ -3551,7 +3545,7 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>Intervalli Colore: {count} colori</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="330"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="329"/>
         <source>Please add at least one color to detect.</source>
         <translation>Aggiungi almeno un colore da rilevare.</translation>
     </message>
@@ -3564,7 +3558,7 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>Istogramma della tonalita non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="59"/>
         <source>No color image data is available for the current image.</source>
         <translation>Nessun dato dell&apos;immagine a colori e disponibile per l&apos;immagine corrente.</translation>
     </message>
@@ -3602,8 +3596,8 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>Intervallo di tonalita visibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="65"/>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="174"/>
         <location filename="../resources/views/images/viewer/ColorHistogramDialog.ui" line="127"/>
         <source>Hover over the histogram to inspect a hue band.</source>
         <translation>Passa sull&apos;istogramma per ispezionare una banda di tonalita.</translation>
@@ -3626,7 +3620,7 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>Reimposta intervallo</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="30"/>
         <source>No hue histogram data available</source>
         <translation>Nessun dato disponibile per l&apos;istogramma della tonalita</translation>
     </message>
@@ -3681,8 +3675,8 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="57"/>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="62"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Utilizzi</translation>
     </message>
@@ -3751,7 +3745,7 @@ Consigliato: 50% per un filtraggio bilanciato, 30% per più rilevamenti, 70% per
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="446"/>
+        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (passaggio mouse)</translation>
     </message>
@@ -3811,7 +3805,7 @@ Usa questo per vedere quali colori verranno rilevati e ottimizzare gli intervall
         <translation>Nessun Colore Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="325"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="324"/>
         <source>Please add at least one color to detect.</source>
         <translation>Aggiungi almeno un colore da rilevare.</translation>
     </message>
@@ -3839,7 +3833,7 @@ Usa questo per vedere quali colori verranno rilevati e ottimizzare gli intervall
         <translation>Immagine Originale</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="219"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="216"/>
         <source>Original image preview.
 Shows the unmodified input image for reference.
 Use this to compare with the filtered result below.</source>
@@ -3853,7 +3847,7 @@ Usala per confrontarla con il risultato filtrato qui sotto.</translation>
         <translation>Risultato Filtrato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="232"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="228"/>
         <source>Filtered result preview.
 Shows pixels that match your current HSV color range settings.
 Updates in real-time as you adjust the color and range values.
@@ -3869,7 +3863,7 @@ I pixel corrispondenti vengono mostrati, gli altri appaiono in nero.</translatio
         <translation>Mostra solo la maschera</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="241"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="237"/>
         <source>Toggle between masked color result and grayscale mask.
 • Unchecked (default): Shows the original image with matching colors visible
 • Checked: Shows a black and white mask where white = matching pixels
@@ -3900,7 +3894,7 @@ Usa la vista a maschera per vedere chiaramente quali pixel vengono rilevati.</tr
         <translation>Prova sull&apos;Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="273"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="270"/>
         <source>Test current HSV range settings on the loaded image.
 Manually triggers a preview update to see detection results.
 Preview updates automatically as you adjust settings.</source>
@@ -3914,7 +3908,7 @@ L&apos;anteprima si aggiorna automaticamente mentre modifichi le impostazioni.</
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="284"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="282"/>
         <source>Cancel color selection.
 Discards all changes and closes the dialog without applying the color range.</source>
         <translation>Annulla la selezione del colore.
@@ -3926,7 +3920,7 @@ Scarta tutte le modifiche e chiude la finestra senza applicare l&apos;intervallo
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="292"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="289"/>
         <source>Apply color selection.
 Saves the current HSV color range settings and closes the dialog.
 The selected color range will be used for image analysis.</source>
@@ -4012,7 +4006,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Visualizza Intervallo</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="259"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="258"/>
         <source>Please add at least one color to detect.</source>
         <translation>Aggiungi almeno un colore da rilevare.</translation>
     </message>
@@ -4096,7 +4090,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Vista orientata a Nord (Ruotata di {angle:.1f}°)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="445"/>
+        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="444"/>
         <source>Original bearing: {bearing:.1f}° | Rotation applied: {rotation:.1f}°</source>
         <translation>Orientamento originale: {bearing:.1f}° | Rotazione applicata: {rotation:.1f}°</translation>
     </message>
@@ -4144,7 +4138,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Aggiungi Batch alla Ricerca</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="79"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="78"/>
         <source>Add more batch XML files to the current search project</source>
         <translation>Aggiungi altri file XML batch al progetto di ricerca corrente</translation>
     </message>
@@ -4169,7 +4163,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Esamina batch selezionato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="118"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="116"/>
         <source>Open the selected batch&apos;s results in the Viewer to review (same as double-clicking the batch).</source>
         <translation>Apri i risultati del batch selezionato nel Visualizzatore per esaminarli (equivale a fare doppio clic sul batch).</translation>
     </message>
@@ -4288,7 +4282,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Ancora nessun revisore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="315"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="312"/>
         <source>Batch review status and assignments. Load reviewer XMLs to update progress. Double-click a batch to open its results in the Viewer.</source>
         <translation>Stato e assegnazioni della revisione batch. Carica gli XML dei revisori per aggiornare l&apos;avanzamento. Fai doppio clic su un batch per aprire i risultati nel Visualizzatore.</translation>
     </message>
@@ -4313,12 +4307,12 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Revisioni</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="329"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="328"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="350"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="349"/>
         <source>Consolidated AOI data from all reviews. Shows flag counts and reviewer comments.</source>
         <translation>Dati AOI consolidati da tutte le revisioni. Mostra il numero di contrassegni e i commenti dei revisori.</translation>
     </message>
@@ -4338,7 +4332,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Conteggio Contrassegni</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="363"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="362"/>
         <source>Comments</source>
         <translation>Commenti</translation>
     </message>
@@ -4348,7 +4342,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Nuovo Progetto di Ricerca</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="381"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="380"/>
         <source>Enter project name:</source>
         <translation>Inserisci il nome del progetto:</translation>
     </message>
@@ -4358,7 +4352,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Informazioni Coordinatore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="391"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="390"/>
         <source>Enter your name:</source>
         <translation>Inserisci il tuo nome:</translation>
     </message>
@@ -4373,7 +4367,7 @@ Fai clic sulle immagini per spostarle nella sezione Selezionate in alto.</transl
         <translation>Seleziona i File XML Batch Iniziali</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="409"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="403"/>
         <source>You can select multiple ADIAT_Data.xml files from different folders.
 
 Tips:
@@ -4393,11 +4387,11 @@ Suggerimenti:
         <translation>Seleziona i File ADIAT_Data.xml Batch (Tieni premuto Ctrl per selezionarne più di uno)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="420"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="435"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="559"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="606"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="661"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="419"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="434"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="558"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="605"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="660"/>
         <source>XML Files (*.xml)</source>
         <translation>File XML (*.xml)</translation>
     </message>
@@ -4433,7 +4427,7 @@ Suggerimenti:
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="454"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="453"/>
         <source>Failed to save project file.</source>
         <translation>Impossibile salvare il file di progetto.</translation>
     </message>
@@ -4448,12 +4442,12 @@ Suggerimenti:
         <translation>Apri Progetto di Ricerca</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="465"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="464"/>
         <source>Search Project Files (ADIAT_Search_*.xml);;All XML Files (*.xml)</source>
         <translation>File Progetto di Ricerca (ADIAT_Search_*.xml);;Tutti i File XML (*.xml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="475"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="474"/>
         <source>Project loaded successfully!</source>
         <translation>Progetto caricato con successo!</translation>
     </message>
@@ -4465,12 +4459,12 @@ Suggerimenti:
 {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="508"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="507"/>
         <source>Failed to load project file.</source>
         <translation>Impossibile caricare il file di progetto.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="519"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="518"/>
         <source>Project saved successfully!</source>
         <translation>Progetto salvato con successo!</translation>
     </message>
@@ -4485,7 +4479,7 @@ Suggerimenti:
         <translation>Nessun Progetto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="530"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="529"/>
         <source>Please create or open a project first.</source>
         <translation>Crea o apri prima un progetto.</translation>
     </message>
@@ -4500,7 +4494,7 @@ Suggerimenti:
         <translation>Aggiungi Altri File XML Batch</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="547"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="540"/>
         <source>Select additional ADIAT_Data.xml batch files to add to this search.
 
 Tips:
@@ -4522,7 +4516,7 @@ Suggerimenti:
         <translation>Seleziona i File ADIAT_Data.xml Batch da Aggiungere (Tieni premuto Ctrl per selezionarne più di uno)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="581"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="579"/>
         <source>Successfully added {count} batch(es) to the project!
 Total batches: {total}</source>
         <translation>Aggiunti con successo {count} batch al progetto!
@@ -4534,7 +4528,7 @@ Batch totali: {total}</translation>
         <translation>Nessun Batch Aggiunto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="593"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="591"/>
         <source>No batches were added. Check that the XML files are valid ADIAT_Data.xml files.</source>
         <translation>Nessun batch aggiunto. Controlla che i file XML siano file ADIAT_Data.xml validi.</translation>
     </message>
@@ -4549,7 +4543,7 @@ Batch totali: {total}</translation>
         <translation>Nessun Batch</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="618"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="617"/>
         <source>No batches found in project.</source>
         <translation>Nessun batch trovato nel progetto.</translation>
     </message>
@@ -4564,12 +4558,12 @@ Batch totali: {total}</translation>
         <translation>A quale batch appartiene questa revisione?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="643"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="642"/>
         <source>Review data loaded and merged successfully!</source>
         <translation>Dati di revisione caricati e uniti con successo!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="649"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="648"/>
         <source>Failed to load review data.</source>
         <translation>Impossibile caricare i dati di revisione.</translation>
     </message>
@@ -4596,7 +4590,7 @@ Batch totali: {total}</translation>
         <translation>Nessun batch selezionato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="760"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="759"/>
         <source>Select a batch in the table, then click Review Selected Batch.</source>
         <translation>Seleziona un batch nella tabella, quindi fai clic su Esamina batch selezionato.</translation>
     </message>
@@ -4609,7 +4603,7 @@ Batch totali: {total}</translation>
         <translation>Genera KML Estensione Copertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="131"/>
         <source>Generate a KML file showing the geographic coverage extent of all images?
 
 This will create polygon(s) representing the area covered by all images. Overlapping image areas will be merged into a single polygon.</source>
@@ -4623,7 +4617,7 @@ Questo creerà dei poligoni che rappresentano l&apos;area coperta da tutte le im
         <translation>Salva KML Estensione Copertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="148"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="147"/>
         <source>KML files (*.kml)</source>
         <translation>File KML (*.kml)</translation>
     </message>
@@ -4677,7 +4671,7 @@ Questo creerà dei poligoni che rappresentano l&apos;area coperta da tutte le im
         <translation>Estensione della Copertura</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="285"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="278"/>
         <source>Could not calculate coverage extent.
 
 Images processed: {processed}
@@ -4686,36 +4680,29 @@ Images skipped: {skipped}
 Images may be skipped for the following reasons:
   • Missing GPS data in EXIF
   • No valid GSD (missing altitude/focal length)
-  • Gimbal not nadir (must be -85° to -95°)</source>
-        <translation>Impossibile calcolare l&apos;estensione della copertura.
-
-Immagini elaborate: {processed}
-Immagini saltate: {skipped}
-
-Le immagini possono essere saltate per i seguenti motivi:
-  • Dati GPS mancanti negli EXIF
-  • Nessun GSD valido (altitudine/lunghezza focale mancante)
-  • Gimbal non nadirale (deve essere tra -85° e -95°)</translation>
+  • Gimbal not nadir (must be -85° to -95°;
+    WALDO: boresight within 40° of nadir)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="300"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="302"/>
         <source>{value:.2f} acres</source>
         <translation>{value:.2f} acri</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="305"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="306"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="307"/>
         <source>{value:.3f} km²</source>
         <translation>{value:.3f} km²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="309"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="310"/>
         <source>Coverage extent KML saved: {area}</source>
         <translation>KML dell&apos;estensione della copertura salvato: {area}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="324"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="319"/>
         <source>
 
 Images may be skipped for:
@@ -4730,12 +4717,12 @@ Le immagini possono essere saltate per:
   • Gimbal non nadirale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="327"/>
         <source>Coverage Extent KML Generated</source>
         <translation>KML dell&apos;Estensione della Copertura Generato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="334"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="329"/>
         <source>Coverage extent KML file created successfully!
 
 File: {file}
@@ -4883,7 +4870,7 @@ non valida</translation>
 <context>
     <name>FlightMapView</name>
     <message>
-        <location filename="../app/core/views/components/FlightMapView.py" line="553"/>
+        <location filename="../app/core/views/components/FlightMapView.py" line="550"/>
         <source>QtWebEngine not available — install PySide6-Addons for the interactive map. Showing list view instead.</source>
         <translation type="unfinished">QtWebEngine non disponibile — installa PySide6-Addons per la mappa interattiva. Verrà mostrata la vista elenco.</translation>
     </message>
@@ -4942,7 +4929,7 @@ non valida</translation>
         <translation>il drone ha {current}/{limit} visualizzatori</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="99"/>
+        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="98"/>
         <source>known device — same fingerprint as last pair</source>
         <translation>dispositivo noto — stessa impronta dell&apos;ultimo abbinamento</translation>
     </message>
@@ -4991,7 +4978,7 @@ non valida</translation>
         <translation>Rinomina flusso</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightTile.py" line="526"/>
+        <location filename="../app/core/views/flight/FlightTile.py" line="524"/>
         <source>Nickname for this drone (persists across new pairing codes via the aircraft serial number). Leave blank to clear.</source>
         <translation>Soprannome per questo drone (rimane valido tra nuovi codici di abbinamento tramite il numero di serie del drone). Lascia vuoto per cancellarlo.</translation>
     </message>
@@ -5123,7 +5110,7 @@ non valida</translation>
 <context>
     <name>FlightTileController</name>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="219"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="218"/>
         <source>Looking up code {code} and connecting to the drone.</source>
         <translation>Ricerca del codice {code} e connessione al drone.</translation>
     </message>
@@ -5133,12 +5120,12 @@ non valida</translation>
         <translation>Assegna un nome a questo dispositivo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="297"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="295"/>
         <source>Give this publisher a name so you can recognise it next time (e.g. &apos;Operator A&apos;s M4E&apos;).</source>
         <translation>Dai un nome a questo emittente per riconoscerlo la prossima volta (ad es. &apos;M4E operatore A&apos;).</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="318"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="313"/>
         <source>Device &apos;{label}&apos; presented a different DTLS fingerprint than the last time you paired with it. This could mean the controller was reset, a different controller is using the label, or somebody is impersonating it.
 
 Reject if you weren&apos;t expecting this.</source>
@@ -5147,12 +5134,12 @@ Reject if you weren&apos;t expecting this.</source>
 Rifiuta se non te lo aspettavi.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="483"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="480"/>
         <source>Pairing ended before video could start. Ask the operator to generate a new code and try again.</source>
         <translation>L&apos;abbinamento è terminato prima dell&apos;avvio del video. Chiedi all&apos;operatore di generare un nuovo codice e riprova.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1007"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1006"/>
         <source>Waiting for video before recording can start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5172,7 +5159,7 @@ Rifiuta se non te lo aspettavi.</translation>
         <translation type="unfinished">Registrazione salvata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1157"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1156"/>
         <source>No finished recording to replay yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5192,12 +5179,12 @@ Rifiuta se non te lo aspettavi.</translation>
         <translation>Impronta non corrispondente — &apos;{label}&apos;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="332"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="330"/>
         <source>Fingerprint changed on {ts}; previous identity was overwritten after operator review.</source>
         <translation>Impronta modificata il {ts}; l&apos;identità precedente è stata sovrascritta dopo la verifica dell&apos;operatore.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="425"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="422"/>
         <source>This drone already has {current} viewers connected (maximum {limit}). Ask one to disconnect, or try again later.</source>
         <translation>Questo drone ha già {current} visualizzatori connessi (massimo {limit}). Chiedi a uno di disconnettersi oppure riprova più tardi.</translation>
     </message>
@@ -5210,7 +5197,7 @@ Rifiuta se non te lo aspettavi.</translation>
         <translation>Nuova sessione di volo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="558"/>
+        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="555"/>
         <source>Mobile started a new flight under code {code}. The previous session&apos;s detections are still saved on this computer. Discard them, or keep them archived?</source>
         <translation>Mobile ha avviato un nuovo volo con il codice {code}. I rilevamenti della sessione precedente sono ancora salvati su questo computer. Vuoi eliminarli o conservarli in archivio?</translation>
     </message>
@@ -5378,7 +5365,7 @@ Rifiuta se non te lo aspettavi.</translation>
         <translation>Abilita Maschera Regione di Elaborazione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="55"/>
         <source>Enable to restrict detection processing to a specific region of the video.
 Useful for excluding edges, UI overlays, or focusing on specific areas.
 Improves performance by not processing masked regions.</source>
@@ -5392,7 +5379,7 @@ Migliora le prestazioni evitando di elaborare le aree mascherate.</translation>
         <translation>Abilita Frame Buffer</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="72"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="69"/>
         <source>Exclude a uniform border from all edges of the video.
 Enter the number of pixels to exclude from each edge.
 The inner area will be processed for detections.</source>
@@ -5411,7 +5398,7 @@ L&apos;area interna verrà elaborata per il rilevamento.</translation>
         <translation>Buffer (pixel):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="91"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="87"/>
         <source>Number of pixels to exclude from all edges (0-1000).
 A value of 50 excludes 50 pixels from top, bottom, left, and right.
 Useful for removing UI overlays or camera lens distortion at edges.
@@ -5427,7 +5414,7 @@ Il valore è riferito alla risoluzione originale del video.</translation>
         <translation>Abilita Maschera Immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="102"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="99"/>
         <source>Load a black/white image as a custom mask.
 White areas will be processed, black areas excluded.
 The mask will be scaled to match the video resolution.</source>
@@ -5483,7 +5470,7 @@ La maschera verrà ridimensionata in base alla risoluzione del video.</translati
         <translation>Mostra overlay della maschera sul video</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="142"/>
         <source>Display the processing region on the rendered video.
 Frame mode: Shows a cyan rectangle outline of the processed area.
 Image mask: Shows a semi-transparent overlay of excluded regions.</source>
@@ -5502,7 +5489,7 @@ Maschera immagine: mostra un overlay semitrasparente delle aree escluse.</transl
         <translation>{error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="231"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="229"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>Impossibile caricare l&apos;immagine selezionata. Scegli un file immagine valido.</translation>
     </message>
@@ -5512,7 +5499,7 @@ Maschera immagine: mostra un overlay semitrasparente delle aree escluse.</transl
         <translation>Mancata Corrispondenza Proporzioni</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="243"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="240"/>
         <source>{error}
 
 The mask will be scaled to fit, which may cause distortion.
@@ -5533,7 +5520,7 @@ Vuoi continuare?</translation>
         <translation>Nessun dato GPS trovato nelle immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="192"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="191"/>
         <source>POD overlay cleared — the elevation/canopy source changed. Recalculate to refresh it.</source>
         <translation>Sovrapposizione POD cancellata: la sorgente di elevazione/chioma è cambiata. Ricalcola per aggiornarla.</translation>
     </message>
@@ -5548,17 +5535,17 @@ Vuoi continuare?</translation>
         <translation>Calcolare la copertura POD?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="235"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="234"/>
         <source>Coverage data is ready. Calculate the probability-of-detection heatmap for this mission now? (May take several minutes.)</source>
         <translation>I dati di copertura sono pronti. Calcolare ora la heatmap della probabilità di rilevamento per questa missione? (Può richiedere diversi minuti.)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="293"/>
         <source>Your local USGS 3DEP tiles only partially cover this mission.</source>
         <translation>I tile locali USGS 3DEP coprono solo parzialmente questa missione.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
         <source>Your local USGS 3DEP tiles do not cover this mission.</source>
         <translation>I tile locali USGS 3DEP non coprono questa missione.</translation>
     </message>
@@ -5568,7 +5555,7 @@ Vuoi continuare?</translation>
         <translation>Copertura dell&apos;elevazione locale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="302"/>
         <source>Frames outside the local tiles will use online AWS Terrain Tiles (~30 m) elevation instead. You can download 1 m tiles for this area first, or continue with the fallback.</source>
         <translation>I fotogrammi fuori dai tile locali useranno l&apos;elevazione online di AWS Terrain Tiles (~30 m). Puoi prima scaricare i tile a 1 m per quest&apos;area oppure continuare con il fallback.</translation>
     </message>
@@ -5598,7 +5585,7 @@ Vuoi continuare?</translation>
         <translation>Scaricare i dati della chioma?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="391"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="386"/>
         <source>No canopy-height data is configured for this mission.
 
 Download elevation and canopy tiles for this area now so the canopy overlay and terrain-aware detection coverage can use them?
@@ -5641,7 +5628,7 @@ Questo scarica l&apos;altezza chioma Meta/WRI (1 m) e la imposta come origine da
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="603"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="602"/>
         <source>Altitude basis: reported ATO (approximate over terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5683,7 +5670,7 @@ Questo scarica l&apos;altezza chioma Meta/WRI (1 m) e la imposta come origine da
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1297"/>
         <source>Move this AOI to {lat:.6f}, {lon:.6f}?
 
 That is {dist:.1f} m from its previous position. The corrected location is saved with the results and used for exports.</source>
@@ -5804,17 +5791,17 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Calcola POD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Compute the terrain-aware probability-of-detection heatmap for this mission (may take several minutes)</source>
         <translation>Calcola la heatmap della probabilità di rilevamento con analisi del terreno per questa missione (può richiedere diversi minuti)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="189"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="188"/>
         <source>Click point to select • Drag to pan • Scroll to zoom • Drag AOI marker to correct its location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="274"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="273"/>
         <source>Downloading tiles is disabled in Offline Only mode</source>
         <translation>Il download delle tile è disabilitato nella modalità solo offline</translation>
     </message>
@@ -5839,7 +5826,7 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Problema di Caricamento Tasselli Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="394"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5861,12 +5848,12 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1422"/>
         <source>Position corrected by user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1424"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
         <source>Drag to correct the location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5890,7 +5877,7 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
         <translation>AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="411"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="410"/>
         <source>AOIs</source>
         <translation>AOI</translation>
     </message>
@@ -5901,12 +5888,12 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
         <translation>{count} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="431"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="430"/>
         <source>Area of Interest</source>
         <translation>Area di Interesse</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="433"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="432"/>
         <source>Areas of Interest</source>
         <translation>Aree di Interesse</translation>
     </message>
@@ -5914,7 +5901,7 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
 <context>
     <name>GeneralSettingsPage</name>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="122"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="121"/>
         <source>Select AOI Highlight Color</source>
         <translation>Seleziona Colore Evidenziazione AOI</translation>
     </message>
@@ -5924,7 +5911,7 @@ La mappa continuerà a funzionare con i tasselli memorizzati nella cache, ove di
         <translation>Benchmark Completato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="164"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="161"/>
         <source>Detected {count} CPU core(s).
 
 Recommended number of processes: {recommended}
@@ -5955,7 +5942,7 @@ Il cursore è stato impostato su {recommended} processi.</translation>
         <translation>Applica griglia a tutte le immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="322"/>
         <source>{n} image(s) already have review progress recorded at a different grid size.
 
 Reset their progress and apply {rows}×{cols} to them too?
@@ -5973,7 +5960,7 @@ Sì le reimposta; No le mantiene alla dimensione attuale.</translation>
         <translation>Immagine completamente revisionata; avanzamento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="629"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="628"/>
         <source>cell {cell}/{cells} — image {image}/{images} — run {percent}% reviewed</source>
         <translation>cella {cell}/{cells} — immagine {image}/{images} — sessione {percent}% revisionata</translation>
     </message>
@@ -5981,7 +5968,7 @@ Sì le reimposta; No le mantiene alla dimensione attuale.</translation>
 <context>
     <name>GridReviewDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="52"/>
         <source>Suggested: {rows}×{cols} (person ≈ {px} px on screen at cell zoom)</source>
         <translation>Suggerito: {rows}×{cols} (persona ≈ {px} px sullo schermo con zoom sulla cella)</translation>
     </message>
@@ -6265,7 +6252,7 @@ Usa questo per vedere quali colori verranno rilevati e ottimizzare gli intervall
         <translation>Assistente Intervallo Colore HSV - Selezione con Clic</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="709"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="694"/>
         <source>Interactive image viewer with color selection.
 
 NAVIGATION:
@@ -6309,7 +6296,7 @@ VISUALIZZAZIONE:
         <translation>Sfoglia...</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="748"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="743"/>
         <source>Browse for an image file to load.
 Opens a file dialog to select an image from your computer.
 • Supported formats: PNG, JPG, JPEG, BMP
@@ -6327,7 +6314,7 @@ L&apos;immagine verrà mostrata nel visualizzatore principale a sinistra.</trans
         <translation>Reimposta</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="761"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="755"/>
         <source>Reset all selections and start over.
 • Clears all selected pixels (white overlay)
 • Resets HSV ranges to defaults
@@ -6347,14 +6334,14 @@ Utile per ripartire da zero senza ricaricare l&apos;immagine.</translation>
         <translation>Raggio di Selezione:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="770"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="768"/>
         <source>Size of the circular selection cursor.
 Determines how many pixels are sampled when you CTRL+Click.</source>
         <translation>Dimensione del cursore circolare di selezione.
 Determina quanti pixel vengono campionati con CTRL+Clic.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="788"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="777"/>
         <source>Set the selection cursor radius in pixels.
 • Range: 1-50 pixels
 • Default: 1 pixel (single pixel selection)
@@ -6384,14 +6371,14 @@ Scorciatoie da tastiera: [ diminuisce, ] aumenta di 2 pixel.</translation>
         <translation>Tolleranza Colore:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="797"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="795"/>
         <source>HSV color matching tolerance.
 Controls how similar colors must be to get selected.</source>
         <translation>Tolleranza di corrispondenza dei colori HSV.
 Controlla quanto i colori devono essere simili per essere selezionati.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="817"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="803"/>
         <source>Set color tolerance for similar pixel detection.
 • Range: 0-50
 • Default: 2
@@ -6422,7 +6409,7 @@ Tolleranza più bassa:
 • Può non rilevare alcuni pixel del colore target.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="826"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="825"/>
         <source>CTRL+Click: Select similar colors | CTRL+SHIFT+Click: Remove | [ ] : Radius</source>
         <translation>CTRL+Clic: seleziona colori simili | CTRL+MAIUSC+Clic: rimuovi | [ ] : raggio</translation>
     </message>
@@ -6432,7 +6419,7 @@ Tolleranza più bassa:
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="840"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="833"/>
         <source>Show detailed help and instructions.
 Opens a dialog with:
 • Step-by-step usage instructions
@@ -6454,7 +6441,7 @@ Clicca qui se non sei sicuro di come usare questo strumento.</translation>
         <translation>Colore Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="863"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="861"/>
         <source>Average color of all selected pixels.
 Shows the center/mean color that will be used for HSV range detection.</source>
         <translation>Colore medio di tutti i pixel selezionati.
@@ -6466,14 +6453,14 @@ Mostra il colore centrale/medio che verrà usato per il rilevamento dell&apos;in
         <translation>Colore:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="870"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="868"/>
         <source>Visual preview of the average selected color.
 This is the center color calculated from all selected pixels.</source>
         <translation>Anteprima visiva del colore medio selezionato.
 È il colore centrale calcolato da tutti i pixel selezionati.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="878"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="876"/>
         <source>Color swatch showing the average of all selected pixels.
 This becomes the center color for HSV range detection.</source>
         <translation>Campione che mostra la media di tutti i pixel selezionati.
@@ -6485,14 +6472,14 @@ Diventa il colore centrale per il rilevamento dell&apos;intervallo HSV.</transla
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="885"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="883"/>
         <source>Hexadecimal representation of the selected color.
 Format: #RRGGBB</source>
         <translation>Rappresentazione esadecimale del colore selezionato.
 Formato: #RRGGBB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="891"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="889"/>
         <source>Hex color code of the average selected color.
 Can be used to identify the exact RGB color value.</source>
         <translation>Codice esadecimale del colore medio selezionato.
@@ -6504,14 +6491,14 @@ Può essere usato per identificare l&apos;esatto valore RGB.</translation>
         <translation>HSV:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="898"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="896"/>
         <source>HSV values of the selected color.
 H = Hue (0-360°), S = Saturation (0-100%), V = Value (0-100%)</source>
         <translation>Valori HSV del colore selezionato.
 H = Tonalità (0-360°), S = Saturazione (0-100%), V = Valore (0-100%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="904"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="902"/>
         <source>HSV color values of the average selected color.
 This is the center point of your color range.</source>
         <translation>Valori di colore HSV del colore medio selezionato.
@@ -6523,7 +6510,7 @@ This is the center point of your color range.</source>
         <translation>Intervalli HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="916"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="912"/>
         <source>HSV color range configuration.
 Defines the detection range for each HSV channel.
 Center values are calculated from selected pixels.
@@ -6594,7 +6581,7 @@ I valori di buffer aggiungono tolleranza per catturare le variazioni cromatiche.
         <translation>Canale Tonalità (tipo di colore): 0-360 gradi sulla ruota dei colori</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="950"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="947"/>
         <source>Center hue value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-360° (red=0°, green=120°, blue=240°)</source>
@@ -6603,7 +6590,7 @@ Calcolato automaticamente dalla tua selezione.
 Intervallo: 0-360° (rosso=0°, verde=120°, blu=240°)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="963"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="957"/>
         <source>Hue lower bound buffer (subtract from center).
 • Range: 0-360°
 • Adds tolerance below the center hue
@@ -6618,7 +6605,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 AVVISO: un intervallo totale di tonalità (meno + più) &gt; 60° può causare falsi positivi</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="977"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="971"/>
         <source>Hue upper bound buffer (add to center).
 • Range: 0-360°
 • Adds tolerance above the center hue
@@ -6633,7 +6620,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 AVVISO: un intervallo totale di tonalità (meno + più) &gt; 60° può causare falsi positivi</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="986"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="983"/>
         <source>Final hue detection range.
 Shows the complete min-max hue range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6647,7 +6634,7 @@ Calcolato come: (centro - buffer meno) fino a (centro + buffer più).</translati
         <translation>AVVISO: un intervallo di Tonalità troppo ampio può causare falsi positivi!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="998"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="994"/>
         <source>Hue range warning.
 Your total hue range exceeds 60°.
 Wide hue ranges may detect many different colors.
@@ -6668,7 +6655,7 @@ Considera di restringere i buffer per un rilevamento più accurato.</translation
         <translation>Canale Saturazione (intensità del colore): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1011"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1008"/>
         <source>Center saturation value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=gray, 100%=vivid color)</source>
@@ -6677,7 +6664,7 @@ Calcolato automaticamente dalla tua selezione.
 Intervallo: 0-100% (0%=grigio, 100%=colore vivido)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1024"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1018"/>
         <source>Saturation lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center saturation
@@ -6692,7 +6679,7 @@ WARNING: Lower bound &lt; 25% may include unwanted gray/desaturated colors</sour
 AVVISO: un limite inferiore &lt; 25% può includere colori grigi/desaturati indesiderati</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1037"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1032"/>
         <source>Saturation upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center saturation
@@ -6705,7 +6692,7 @@ AVVISO: un limite inferiore &lt; 25% può includere colori grigi/desaturati inde
 • Aumentare la saturazione superiore è in genere sicuro.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1046"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1043"/>
         <source>Final saturation detection range.
 Shows the complete min-max saturation range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6719,7 +6706,7 @@ Calcolato come: (centro - buffer meno) fino a (centro + buffer più).</translati
         <translation>AVVISO: un livello di Saturazione troppo basso può causare falsi positivi!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1058"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1054"/>
         <source>Saturation range warning.
 Your lower saturation bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -6740,7 +6727,7 @@ Potrebbe rilevare oggetti grigi o desaturati indesiderati.</translation>
         <translation>Canale Valore (luminosità): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1071"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1068"/>
         <source>Center value/brightness (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=black, 100%=bright)</source>
@@ -6749,7 +6736,7 @@ Calcolato automaticamente dalla tua selezione.
 Intervallo: 0-100% (0%=nero, 100%=luminoso)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1084"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1078"/>
         <source>Value lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center brightness
@@ -6764,7 +6751,7 @@ WARNING: Lower bound &lt; 25% may include unwanted shadows or dark objects</sour
 AVVISO: un limite inferiore &lt; 25% può includere ombre o oggetti scuri indesiderati</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1097"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1092"/>
         <source>Value upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center brightness
@@ -6777,7 +6764,7 @@ AVVISO: un limite inferiore &lt; 25% può includere ombre o oggetti scuri indesi
 • Aumentare la luminosità è in genere sicuro.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1106"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1103"/>
         <source>Final value/brightness detection range.
 Shows the complete min-max brightness range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6791,7 +6778,7 @@ Calcolato come: (centro - buffer meno) fino a (centro + buffer più).</translati
         <translation>AVVISO: un livello di Valore troppo basso può causare falsi positivi!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1118"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1114"/>
         <source>Value range warning.
 Your lower value bound is below 25%.
 Low value includes very dark colors.
@@ -6807,7 +6794,7 @@ Potrebbe rilevare ombre o oggetti scuri indesiderati.</translation>
         <translation>Statistiche</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1128"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1126"/>
         <source>Statistics about your current selection.
 Shows how many pixels are selected and what percentage of the image they represent.</source>
         <translation>Statistiche sulla selezione corrente.
@@ -6820,7 +6807,7 @@ Mostra quanti pixel sono selezionati e quale percentuale dell&apos;immagine rapp
         <translation>Pixel Selezionati: 0</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1135"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1132"/>
         <source>Number of pixels currently selected.
 Shows the total count of white-highlighted pixels in the main viewer.
 Updates in real-time as you select colors.</source>
@@ -6835,7 +6822,7 @@ Si aggiorna in tempo reale mentre selezioni i colori.</translation>
         <translation>Copertura: 0%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1143"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1139"/>
         <source>Percentage of image covered by selection.
 Shows what portion of the total image is selected.
 • Low %: Precise selection, may miss some target pixels
@@ -6851,14 +6838,14 @@ Mostra quale porzione dell&apos;immagine totale è selezionata.
         <translation>Anteprima Maschera</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1152"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1150"/>
         <source>Black and white preview of the detection mask.
 Shows what pixels will be detected with current HSV ranges and buffers.</source>
         <translation>Anteprima in bianco e nero della maschera di rilevamento.
 Mostra quali pixel verranno rilevati con gli attuali intervalli HSV e buffer.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1166"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1161"/>
         <source>Grayscale mask preview.
 • White pixels: Will be detected with current settings
 • Black pixels: Will NOT be detected
@@ -6876,7 +6863,7 @@ Usala per verificare che il tuo intervallo HSV catturi il target senza falsi pos
         <translation>Seleziona Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1180"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp)</source>
         <translation>Immagini (*.png *.jpg *.jpeg *.bmp)</translation>
     </message>
@@ -6891,7 +6878,7 @@ Usala per verificare che il tuo intervallo HSV catturi il target senza falsi pos
         <translation>Copertura: {0:.1f}%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1503"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1476"/>
         <source>
 &lt;h2&gt;HSV Color Range Assistant - Help&lt;/h2&gt;
 
@@ -6959,8 +6946,8 @@ Clicca sul pulsante SFOGLIA per aprire un&apos;immagine.&lt;/p&gt;
         <translation>Nessun Colore Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="121"/>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="126"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="125"/>
         <source>Add Color</source>
         <translation>Aggiungi Colore</translation>
     </message>
@@ -6970,7 +6957,7 @@ Clicca sul pulsante SFOGLIA per aprire un&apos;immagine.&lt;/p&gt;
         <translation>Espansione per Tonalità</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="178"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -6979,7 +6966,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 I pixel con saturazione inferiore al {1}% o valore inferiore al {2}% vengono esclusi.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="469"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="468"/>
         <source>Please add at least one color to detect.</source>
         <translation>Aggiungi almeno un colore da rilevare.</translation>
     </message>
@@ -7010,7 +6997,7 @@ I pixel con saturazione inferiore al {1}% o valore inferiore al {2}% vengono esc
         <translation>Espansione per Tonalità</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="104"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="101"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -7019,7 +7006,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 I pixel con saturazione inferiore al {1}% o valore inferiore al {2}% vengono esclusi.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="409"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="408"/>
         <source>Please add at least one color to detect.</source>
         <translation>Aggiungi almeno un colore da rilevare.</translation>
     </message>
@@ -7048,14 +7035,14 @@ Corrispondenza:</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="95"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="93"/>
         <source>Hexadecimal color code input.
 Enter colors as hex codes (e.g., #FF0000 for red).</source>
         <translation>Inserimento codice colore esadecimale.
 Inserisci i colori come codici esadecimali (es. #FF0000 per il rosso).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="107"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="102"/>
         <source>Enter a hexadecimal color code.
 • Format: #RRGGBB (e.g., #FF0000 for red, #00FF00 for green)
 • Also accepts short format: #RGB (e.g., #F00 for red)
@@ -7073,7 +7060,7 @@ Il colore verrà convertito automaticamente in HSV.</translation>
         <translation>Ripristina Predefiniti</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="114"/>
         <source>Reset to default color and ranges.
 • Color: Pure red (H:0°, S:100%, V:100%)
 • Hue range: ±20° (total 40° range)
@@ -7093,7 +7080,7 @@ Usalo per ripartire dalle impostazioni standard.</translation>
         <translation>Saturazione / Valore</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="144"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="141"/>
         <source>Saturation and Value (brightness) selector.
 Saturation controls color intensity (left=gray, right=vivid).
 Value controls brightness (bottom=dark, top=bright).</source>
@@ -7102,7 +7089,7 @@ La Saturazione controlla l&apos;intensità del colore (sinistra=grigio, destra=v
 Il Valore controlla la luminosità (basso=scuro, alto=luminoso).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="157"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="149"/>
         <source>Interactive Saturation/Value selector.
 • Click anywhere to set the center color&apos;s saturation and brightness
 • White circle = current center color position
@@ -7126,14 +7113,14 @@ Intervalli più ampi rilevano più variazioni di colore ma possono includere col
         <translation>Tonalità</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="171"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="169"/>
         <source>Hue (color type) selector.
 Hue represents the actual color: red, orange, yellow, green, cyan, blue, purple, magenta.</source>
         <translation>Selettore di Tonalità (tipo di colore).
 La Tonalità rappresenta il colore effettivo: rosso, arancione, giallo, verde, ciano, blu, viola, magenta.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="184"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="176"/>
         <source>Interactive Hue color ring selector.
 • Click on the ring to select a hue (color type)
 • White line = current center hue
@@ -7157,7 +7144,7 @@ Avviso: intervalli di tonalità superiori a 60° possono rilevare troppi colori.
         <translation>Usa Immagine</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="215"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="208"/>
         <source>Open HSV Color Range Assistant.
 Advanced tool for selecting colors from an image:
 • Load an image from your input folder
@@ -7179,7 +7166,7 @@ Consigliato per trovare l&apos;intervallo cromatico migliore per il tuo target.<
         <translation>Preleva Colore dallo Schermo</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="228"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="222"/>
         <source>Pick a color from anywhere on your screen.
 Opens a color picker that lets you:
 • Click anywhere on your screen to sample a color
@@ -7199,7 +7186,7 @@ Gli intervalli restano invariati: regolali manualmente dopo il prelievo.</transl
         <translation>Aggiungi ai Colori Personalizzati</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="241"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="235"/>
         <source>Save current color to Custom Colors palette.
 Adds the current center color to the first empty slot in Custom Colors.
 • Only saves the color, not the ranges
@@ -7219,7 +7206,7 @@ Utile per costruire una tavolozza dei colori usati di frequente.</translation>
         <translation>Colori di Base:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="259"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="256"/>
         <source>Preset basic color palette.
 Quick access to common colors like red, orange, yellow, green, cyan, blue, purple, and grayscale.
 Click any color swatch to set it as the center color.</source>
@@ -7228,7 +7215,7 @@ Accesso rapido ai colori comuni come rosso, arancione, giallo, verde, ciano, blu
 Clicca su un campione di colore per impostarlo come colore centrale.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="269"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="264"/>
         <source>Basic color swatches.
 Click any color to quickly set it as your center color.
 • Top row: Primary colors and tints
@@ -7246,7 +7233,7 @@ Utile per selezionare velocemente i colori standard.</translation>
         <translation>Colori Personalizzati:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="280"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="277"/>
         <source>Your saved custom color palette.
 Colors you&apos;ve saved using &apos;Add to Custom Colors&apos; button.
 Click any saved color to reuse it.</source>
@@ -7255,7 +7242,7 @@ Colori che hai salvato con il pulsante &quot;Aggiungi ai Colori Personalizzati&q
 Clicca su un colore salvato per riutilizzarlo.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="291"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="285"/>
         <source>Custom color swatches.
 Click any color to set it as your center color.
 • Empty slots shown as gray
@@ -7270,7 +7257,7 @@ Clicca su un colore per impostarlo come colore centrale.
 Costruisci la tua tavolozza di colori usati di frequente.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="464"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="461"/>
         <source>Current HSV color range summary.
 Shows the center color and detection ranges in real-time.
 Warning indicators appear when ranges may cause detection issues.</source>
@@ -7294,7 +7281,7 @@ Gli indicatori di avviso compaiono quando gli intervalli possono causare problem
         <translation>Intervallo Sat:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="471"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="470"/>
         <source>Val Range:</source>
         <translation>Intervallo Val:</translation>
     </message>
@@ -7320,7 +7307,7 @@ Warning shown if lower bound &lt; 25%.</source>
 L&apos;avviso appare se il limite inferiore &lt; 25%.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="477"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="475"/>
         <source>Value detection range (minus/plus from center).
 Warning shown if lower bound &lt; 25%.</source>
         <translation>Intervallo di rilevamento valore (meno/più dal centro).
@@ -7332,7 +7319,7 @@ L&apos;avviso appare se il limite inferiore &lt; 25%.</translation>
         <translation>⚠ Troppo ampio!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="506"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="502"/>
         <source>Hue range warning.
 Your hue range is wider than 60° total.
 Wide hue ranges may detect too many different colors.
@@ -7349,7 +7336,7 @@ Considera di restringere l&apos;intervallo per un rilevamento più accurato.</tr
         <translation>⚠ Troppo basso!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="519"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="515"/>
         <source>Saturation range warning.
 Your saturation lower bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -7360,7 +7347,7 @@ Una saturazione bassa include colori grigiastri/sbiaditi.
 Potrebbe rilevare colori grigi o desaturati indesiderati.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="532"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="528"/>
         <source>Value range warning.
 Your value lower bound is below 25%.
 Low value includes very dark colors.
@@ -7409,7 +7396,7 @@ Potrebbe rilevare ombre o oggetti scuri indesiderati.</translation>
         <translation>Alta (400)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="117"/>
+        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="114"/>
         <source>Hot zones (colored) show high-density detection areas. Gray zones are below the threshold. Adjust the threshold to control what counts as a hot zone.</source>
         <translation>Le zone calde (colorate) mostrano aree con alta densità di rilevamenti. Le zone grigie sono sotto la soglia. Regola la soglia per controllare cosa viene considerato una zona calda.</translation>
     </message>
@@ -7783,7 +7770,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>• È richiesta la lunghezza focale (disponibile nei metadati EXIF delle immagini)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="486"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="485"/>
         <source>GSD calculation requires an actual image file to extract focal length.</source>
         <translation>Il calcolo del GSD richiede un file immagine reale da cui estrarre la lunghezza focale.</translation>
     </message>
@@ -7803,7 +7790,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Principale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="529"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="527"/>
         <source>Sensor</source>
         <translation>Sensore</translation>
     </message>
@@ -7844,7 +7831,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Personalizzata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="65"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="61"/>
         <source>Select a preset resolution for processing. Lower resolutions are faster but less detailed.
 &apos;Original&apos; uses the video&apos;s native resolution (no downsampling).
 720P (1280x720) provides excellent balance between speed and detection accuracy.
@@ -7860,7 +7847,7 @@ Seleziona &quot;Personalizzata&quot; per impostare manualmente larghezza e altez
         <translation>Larghezza:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="81"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="78"/>
         <source>Custom processing width in pixels (320-3840).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7874,7 +7861,7 @@ Valori più bassi = elaborazione più rapida, meno dettaglio.</translation>
         <translation>Altezza:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="94"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="91"/>
         <source>Custom processing height in pixels (240-2160).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7898,7 +7885,7 @@ Valori più bassi = elaborazione più rapida, meno dettaglio.</translation>
         <translation>FPS della Sorgente</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="143"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="133"/>
         <source>Limit the frame rate for processing.
 
 • Source FPS - Follow the source cadence (live sources may apply a safety cap)
@@ -7930,7 +7917,7 @@ I rilevamenti persistono tra i frame saltati per garantire continuità visiva.</
         <translation>Renderizza alla Risoluzione di Elaborazione (più veloce per alte risoluzioni)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="155"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="151"/>
         <source>Renders detection overlays at processing resolution instead of original video resolution.
 Significantly faster for high-resolution videos (1080p+) with minimal visual impact.
 Example: Processing at 720p but video is 4K - renders at 720p then upscales.
@@ -8180,7 +8167,7 @@ Valori più bassi = rilevamento più sensibile.</translation>
         <translation>Espansione per Soglia</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="53"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="50"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8194,7 +8181,7 @@ quelli esterni vengono aggiunti se collegati tramite altri pixel idonei.</transl
         <translation>Espansione per Tonalità</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="62"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="59"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -8273,7 +8260,7 @@ Aggressivo</translation>
         <translation>Espansione per Soglia</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="72"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="69"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8287,7 +8274,7 @@ quelli esterni vengono aggiunti se collegati tramite altri pixel idonei.</transl
         <translation>Espansione per Tonalità</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="81"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="78"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -8541,12 +8528,12 @@ Risoluzioni più basse = elaborazione più veloce ma possono perdere oggetti pic
         <translation>Risoluzione Elaborazione:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="90"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="89"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Strumento Automatico di Analisi Immagini Drone v{version} - Sponsorizzato da TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="645"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="644"/>
         <source>Please set the input and output directories.</source>
         <translation>Imposta le cartelle di input e output.</translation>
     </message>
@@ -8663,12 +8650,12 @@ Risoluzioni più basse = elaborazione più veloce ma possono perdere oggetti pic
         <translation> Apri Coordinatore di Ricerca</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1779"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1778"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Apri il Coordinatore di Ricerca per esaminare tutti i batch di questa esecuzione.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1785"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1784"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Apri il Visualizzatore Risultati per esaminare i risultati dei rilevamenti.</translation>
     </message>
@@ -8678,12 +8665,12 @@ Risoluzioni più basse = elaborazione più veloce ma possono perdere oggetti pic
         <translation>Valore Non Valido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="385"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="384"/>
         <source>Select AOI Highlight Color</source>
         <translation>Seleziona Colore Evidenziazione AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="326"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="288"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -8771,7 +8758,7 @@ AI PERSON DETECTOR: modello di deep learning per il rilevamento accurato di pers
         <translation>Seleziona un&apos;Immagine di Riferimento</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="435"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Immagini (*.png *.jpg)</translation>
     </message>
@@ -8782,21 +8769,21 @@ AI PERSON DETECTOR: modello di deep learning per il rilevamento accurato di pers
         <translation>Valore Regolato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="500"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="498"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>L&apos;area massima è stata regolata a {value} pixel per mantenere un intervallo valido.
 (L&apos;area minima deve essere inferiore all&apos;area massima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="532"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="530"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>L&apos;area minima è stata regolata a {value} pixel per mantenere un intervallo valido.
 (L&apos;area massima deve essere maggiore dell&apos;area minima)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="909"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="908"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Limite Area di Interesse ({limit}) superato. Continuare?</translation>
     </message>
@@ -8816,7 +8803,7 @@ AI PERSON DETECTOR: modello di deep learning per il rilevamento accurato di pers
         <translation>Seleziona File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1155"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>File XML (*.xml);;Tutti i File (*)</translation>
     </message>
@@ -8836,7 +8823,7 @@ AI PERSON DETECTOR: modello di deep learning per il rilevamento accurato di pers
         <translation>Nessun Risultato Trovato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1232"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1231"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>Nessun file ADIAT_DATA.XML trovato nella cartella selezionata.</translation>
     </message>
@@ -9621,7 +9608,7 @@ Fai domande, segnala problemi e suggerisci nuove funzionalità.</translation>
         <translation>Canale YouTube</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="886"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>Impossibile analizzare il file XML. Controlla i percorsi dei file in &quot;{file_name}&quot;</translation>
     </message>
@@ -9727,7 +9714,7 @@ Fai domande, segnala problemi e suggerisci nuove funzionalità.</translation>
         <translation>Heatmap di copertura POD (con analisi del terreno)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
         <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). KML exports embed the heatmap in the KML/KMZ as an image overlay; the GeoTIFF products (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json) are also written — the GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
         <translation>Calcola un raster di probabilità di rilevamento consapevole di terreno e chioma per l&apos;intera missione (tutte le immagini non nascoste, indipendente dalle selezioni sopra). Le esportazioni KML incorporano la mappa di calore nel KML/KMZ come sovrapposizione immagine; vengono scritti anche i prodotti GeoTIFF (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json); il GeoTIFF può essere importato in CalTopo Map Sheets. Può richiedere diversi minuti.</translation>
     </message>
@@ -9772,7 +9759,7 @@ Fai domande, segnala problemi e suggerisci nuove funzionalità.</translation>
         <translation>Entrambe</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="145"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="142"/>
         <source>Large Image uploads the same multi-zoom composite used in the PDF report
 (full image with 3x and 6x insets). AOI Thumbnail uploads a zoomed crop
 centered on the detection. Both uploads each.</source>
@@ -9841,7 +9828,7 @@ Usalo per vedere quali colori verranno rilevati e ottimizzare le soglie prima de
         <translation>Nessun Colore Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="300"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="299"/>
         <source>Please add at least one color to detect.</source>
         <translation>Aggiungi almeno un colore da rilevare.</translation>
     </message>
@@ -9867,7 +9854,7 @@ Usalo per vedere quali colori verranno rilevati e ottimizzare le soglie prima de
         <translation>Visualizza Intervallo</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="219"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="218"/>
         <source>Please add at least one target color to detect.</source>
         <translation>Aggiungi almeno un colore obiettivo da rilevare.</translation>
     </message>
@@ -9886,7 +9873,7 @@ Usalo per vedere quali colori verranno rilevati e ottimizzare le soglie prima de
         <translation>Misura ombra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="90"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="87"/>
         <source>When checked, the two clicks estimate the height of a vertical object from its shadow. Click the base of the object first, then the tip of its shadow.</source>
         <translation>Se selezionata, i due clic stimano l&apos;altezza di un oggetto verticale dalla sua ombra. Fai prima clic sulla base dell&apos;oggetto, poi sulla punta della sua ombra.</translation>
     </message>
@@ -9937,17 +9924,17 @@ Usalo per vedere quali colori verranno rilevati e ottimizzare le soglie prima de
         <translation>Usa comunque</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="140"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="137"/>
         <source>Force the estimate with the current base/tip clicks even though the drawn line doesn&apos;t match the expected shadow direction. Use only when you&apos;re confident the geometry is correct.</source>
         <translation>Forza la stima con i clic base/punta correnti anche se la linea disegnata non corrisponde alla direzione prevista dell&apos;ombra. Usalo solo se sei sicuro che la geometria sia corretta.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="181"/>
         <source>Click the BASE of the object first, then the TIP of its shadow.</source>
         <translation>Fai clic prima sulla BASE dell&apos;oggetto, poi sulla PUNTA della sua ombra.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="187"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="185"/>
         <source>Click on the image to place the first point,
 then click again to place the second point.</source>
         <translation>Clicca sull&apos;immagine per posizionare il primo punto,
@@ -9975,7 +9962,7 @@ poi clicca di nuovo per posizionare il secondo punto.</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="467"/>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="553"/>
         <source>Rejected</source>
         <translation>Rifiutata</translation>
     </message>
@@ -10107,7 +10094,7 @@ poi clicca di nuovo per posizionare il secondo punto.</translation>
         <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="177"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="175"/>
         <source> (Current)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10129,7 +10116,7 @@ poi clicca di nuovo per posizionare il secondo punto.</translation>
         <translation>Nessuna Immagine da Esportare</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="156"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="153"/>
         <source>There are no images available to include in the PDF report.
 
 All images may be hidden or there are no images in the dataset.</source>
@@ -10138,7 +10125,7 @@ All images may be hidden or there are no images in the dataset.</source>
 Tutte le immagini potrebbero essere nascoste oppure non ci sono immagini nel dataset.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="166"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="162"/>
         <source>There are no images with flagged AOIs to include in the PDF report.
 
 Please flag at least one AOI, or check &apos;Include images without flagged AOIs&apos; to include all images in the report.</source>
@@ -10152,7 +10139,7 @@ Contrassegna almeno una AOI oppure seleziona &apos;Includi immagini senza AOI co
         <translation>Salva File PDF</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="175"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="174"/>
         <source>PDF files (*.pdf)</source>
         <translation>File PDF (*.pdf)</translation>
     </message>
@@ -10177,7 +10164,7 @@ Contrassegna almeno una AOI oppure seleziona &apos;Includi immagini senza AOI co
         <translation>Successo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="278"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="277"/>
         <source>PDF report generated successfully!</source>
         <translation>Report PDF generato con successo!</translation>
     </message>
@@ -10235,7 +10222,7 @@ Contrassegna almeno una AOI oppure seleziona &apos;Includi immagini senza AOI co
         <translation>Includi immagini senza AOI contrassegnate</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="62"/>
         <source>When checked, all images will be included in the PDF report, even if they don&apos;t have any flagged AOIs. When unchecked, only images with flagged AOIs will be included.</source>
         <translation>Quando selezionato, tutte le immagini saranno incluse nel report PDF, anche se non hanno AOI contrassegnate. Quando deselezionato, verranno incluse solo le immagini con AOI contrassegnate.</translation>
     </message>
@@ -10280,7 +10267,7 @@ Contrassegna almeno una AOI oppure seleziona &apos;Includi immagini senza AOI co
   ... e altri {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10308,7 +10295,7 @@ Seleziona la cartella contenente le immagini sorgente.</translation>
         <translation>Alcune Immagini Mancano Ancora</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="168"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10326,7 +10313,7 @@ Seleziona la cartella contenente i file delle maschere.</translation>
         <translation>Maschere di Rilevamento Non Trovate</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="140"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10337,7 +10324,7 @@ Ancora mancanti:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10358,7 +10345,7 @@ Nomi dei file cercati:
         <translation>Alcune Maschere Mancano Ancora</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="174"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="172"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10369,7 +10356,7 @@ Ancora mancanti:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="179"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="176"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10390,7 +10377,7 @@ Nomi dei file cercati:
         <translation>Continua Comunque</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="414"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="410"/>
         <source>
 
 {count} of these appear more than once in that folder, so which capture they belong to cannot be determined:
@@ -10438,7 +10425,7 @@ Choose the specific flight/sortie folder rather than a folder containing several
         <translation>Usa quota del terreno (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Ruota la persona sul terreno per allinearla a un oggetto</translation>
     </message>
@@ -10474,173 +10461,193 @@ Choose the specific flight/sortie folder rather than a folder containing several
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="402"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1247"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1254"/>
+        <source>Flight track log...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <source>Attach a ForeFlight track log CSV to stamp true aircraft attitude (bank/pitch) and GPS-accurate capture times onto these images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="411"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1371"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="419"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Trascina la maniglia bianca per posizionare la persona di riferimento. Le sagome sono disegnate in scala reale al suolo per l&apos;altitudine e l&apos;angolo della fotocamera di questa immagine.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="427"/>
         <source>Recenter</source>
         <translation>Ricentra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="420"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="429"/>
         <source>Bring the reference person to the center of the current view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="421"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="430"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="487"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="497"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation>Non è stato trovato alcun errore dell&apos;orologio della fotocamera né alcuna correzione applicata per questa cartella.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="539"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="596"/>
+        <source>Select ForeFlight track log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <source>Track logs (*.csv);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Sovrapposizione prospettica non disponibile: a questa immagine mancano i metadati di quota o obiettivo necessari per proiettare una persona.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="709"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation>Ingrandito sulla persona di riferimento: a questa altitudine una persona occupa solo pochi pixel.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="638"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>no image loaded</source>
         <translation>nessuna immagine caricata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="643"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="758"/>
         <source>image metadata could not be read</source>
         <translation>impossibile leggere i metadati dell&apos;immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="762"/>
         <source>image has no GPS coordinates</source>
         <translation>l&apos;immagine non ha coordinate GPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="659"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="774"/>
         <source>capture time / timezone not in metadata</source>
         <translation>ora di scatto / fuso orario non presenti nei metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="670"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="785"/>
         <source>sun position could not be computed</source>
         <translation>impossibile calcolare la posizione del sole</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="684"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="799"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Sole allo scatto: {elev:.0f}° sopra l&apos;orizzonte, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="688"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="804"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Fuso orario dello scatto stimato dalla posizione GPS.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="691"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="807"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation>Si usa l&apos;ora di scatto corretta (errore dell&apos;orologio della fotocamera).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="694"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="810"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="699"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="815"/>
         <source>the sun was below the horizon at capture</source>
         <translation>il sole era sotto l&apos;orizzonte al momento dello scatto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="701"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="817"/>
         <source>sun position unavailable</source>
         <translation>posizione del sole non disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="702"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="818"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Ombra non disponibile: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="801"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Posiziona la persona e l&apos;ombra sulla superficie del terreno DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="805"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="921"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>I dati del terreno (DEM) non sono disponibili per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1065"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1181"/>
         <source>Choose Overlay Color</source>
         <translation>Scegli colore sovrapposizione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1339"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1341"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1265"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1382"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1467"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1357"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1473"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1373"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1488"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1493"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1380"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1495"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1502"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1391"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1506"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10704,8 +10711,8 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation>Origine elevazione:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="146"/>
-        <location filename="../app/core/controllers/Preferences.py" line="400"/>
+        <location filename="../app/core/controllers/Preferences.py" line="145"/>
+        <location filename="../app/core/controllers/Preferences.py" line="399"/>
         <source>3DEP is inactive until both paths are set — the AWS Terrain Tiles baseline is used. Use Download tiles… or Browse.</source>
         <translation>3DEP è inattivo finché non vengono impostati entrambi i percorsi: viene usata la base AWS Terrain Tiles. Usa Scarica tile… o Sfoglia.</translation>
     </message>
@@ -10741,7 +10748,7 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="406"/>
+        <location filename="../app/core/controllers/Preferences.py" line="405"/>
         <source>The registered 3DEP files no longer exist on disk — the AWS Terrain Tiles baseline is used. Re-download or fix the paths.</source>
         <translation>I file 3DEP registrati non esistono più sul disco: viene usata la base AWS Terrain Tiles. Scarica di nuovo o correggi i percorsi.</translation>
     </message>
@@ -10762,7 +10769,7 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation>Seleziona cartella tile 3DEP</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="486"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>The registered canopy files no longer exist on disk — canopy is disabled. Re-download or fix the paths.</source>
         <translation>I file della chioma registrati non esistono più sul disco: la chioma è disattivata. Scarica di nuovo o correggi i percorsi.</translation>
     </message>
@@ -10806,7 +10813,7 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="625"/>
+        <location filename="../app/core/controllers/Preferences.py" line="624"/>
         <source>Terrain service not available.</source>
         <translation>Servizio terreno non disponibile.</translation>
     </message>
@@ -10816,7 +10823,7 @@ Le modifiche si applicano immediatamente a tutte le finestre.</translation>
         <translation>Cancella Cache Terreno</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="634"/>
+        <location filename="../app/core/controllers/Preferences.py" line="632"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -10850,7 +10857,7 @@ Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;
         <translation>Lingua:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="105"/>
+        <location filename="../app/core/controllers/Preferences.py" line="104"/>
         <source>AWS Terrain Tiles (online, ~30 m) is always available as the baseline; local USGS 3DEP adds 1 m detail where downloaded.</source>
         <translation>AWS Terrain Tiles (online, ~30 m) è sempre disponibile come base; l&apos;USGS 3DEP locale aggiunge dettaglio a 1 m dove scaricato.</translation>
     </message>
@@ -10886,13 +10893,13 @@ Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;
         <translation>Cartella contenente i tile GeoTIFF</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="230"/>
-        <location filename="../app/core/controllers/Preferences.py" line="480"/>
+        <location filename="../app/core/controllers/Preferences.py" line="229"/>
+        <location filename="../app/core/controllers/Preferences.py" line="479"/>
         <source>Canopy is disabled until both paths are set — use Download tiles… or Browse.</source>
         <translation>La chioma è disabilitata finché entrambi i percorsi non sono impostati — usa Scarica tile… o Sfoglia.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="242"/>
+        <location filename="../app/core/controllers/Preferences.py" line="241"/>
         <source>Download DEM and/or canopy tiles for an area of interest and register them here. Note: the canopy download uses Meta/WRI data and registers it as the canopy source.</source>
         <translation>Scarica le tile DEM e/o chioma per un&apos;area di interesse e registrale qui. Nota: il download della chioma usa dati Meta/WRI e li registra come origine dati chioma.</translation>
     </message>
@@ -10902,7 +10909,7 @@ Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;
         <translation>N/D (tile locali)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="662"/>
+        <location filename="../app/core/controllers/Preferences.py" line="661"/>
         <source>CSV Files (*.csv)</source>
         <translation>File CSV (*.csv)</translation>
     </message>
@@ -10912,7 +10919,7 @@ Ciò richiederà il nuovo download dei tasselli quando verrà utilizzata l&apos;
         <translation>Riavvio Richiesto</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="689"/>
+        <location filename="../app/core/controllers/Preferences.py" line="688"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Riavvia l&apos;applicazione affinché le modifiche alla lingua abbiano effetto.</translation>
     </message>
@@ -11632,7 +11639,7 @@ Aggressivo</translation>
         <translation>Off</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="64"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="55"/>
         <source>Shape to draw around detections:
 
 • Box: Rectangle around detection bounding box.
@@ -11671,7 +11678,7 @@ Aggressivo</translation>
         <translation>Mostra Etichette di Testo (più lento)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="79"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="75"/>
         <source>Displays text labels near detections showing detection information.
 Adds ~5-15ms processing overhead depending on detection count.
 Labels show: detection type, confidence, area.
@@ -11687,7 +11694,7 @@ Consigliato: OFF per la velocità, ON per debug/analisi.</translation>
         <translation>Mostra Contorni (più lento di tutti)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="84"/>
         <source>Draws exact detection contours (pixel-precise boundaries).
 Adds ~10-20ms processing overhead (very expensive).
 Shows exact shape detected by algorithm.
@@ -11703,7 +11710,7 @@ Consigliato: OFF per la velocità, ON solo per analisi dettagliate.</translation
         <translation>Usa Colore di Rilevamento (tonalità a 100% sat/val per le anomalie di colore)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="100"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="95"/>
         <source>Color the detection overlay based on detected color.
 For color anomalies: Uses the detected hue at 100% saturation/value.
 For motion detections: Uses default color (green/blue).
@@ -11726,7 +11733,7 @@ Consigliato: ON per il rilevamento colore, OFF per il solo movimento.</translati
         <translation>Rilevamenti Massimi:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="120"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="115"/>
         <source>Maximum number of detections to render on screen (0-1000).
 Prevents rendering slowdown when hundreds of detections occur.
 Shows highest confidence detections first.
@@ -11749,7 +11756,7 @@ Consigliato: 10 per uso generale, 50 per rendering complessi (testo+contorni).</
         <translation>Abilita Voto Temporale (riduce lo sfarfallio)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="136"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="132"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -11765,7 +11772,7 @@ Consigliato: ON in tutti i casi d&apos;uso (predefinito).</translation>
         <translation>Frame Finestra (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="152"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="147"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -11783,7 +11790,7 @@ Consigliato: 5 per 30 fps (finestra ~167 ms), 7 per 60 fps.</translation>
         <translation>Soglia (N su M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="165"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="160"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -11806,7 +11813,7 @@ Consigliato: 3 su 5 (rilevamento nel 60% dei frame).</translation>
         <translation>Abilita Filtro Rapporto d&apos;Aspetto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="183"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="180"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -11820,7 +11827,7 @@ La maggior parte degli utenti può lasciarlo OFF, a meno di rilevare molti falsi
         <translation>Rapporto Min:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="199"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="195"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -11836,7 +11843,7 @@ Esempio: 0,2 ≈ rifiuta se l&apos;altezza è più di 5× la larghezza.</transla
         <translation>Rapporto Max:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="211"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="208"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -11855,7 +11862,7 @@ Valori più alti = consente oggetti più larghi come veicoli o attrezzature lung
         <translation>Abilita Clustering Rilevamenti</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="226"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="223"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -11869,7 +11876,7 @@ La maggior parte degli utenti può lasciarlo OFF, a meno che gli oggetti non app
         <translation>Distanza Clustering (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="240"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="237"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -11896,7 +11903,7 @@ Valori più alti = unisce rilevamenti più distanti (può unire troppo).</transl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="363"/>
         <source>Export finished with problems - see the log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11994,7 +12001,7 @@ Valori più alti = unisce rilevamenti più distanti (può unire troppo).</transl
         <translation>Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="134"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="133"/>
         <source>View</source>
         <translation>Visualizza</translation>
     </message>
@@ -12055,7 +12062,7 @@ Valori più alti = unisce rilevamenti più distanti (può unire troppo).</transl
         <translation>Seleziona File Risultati ADIAT</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="117"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="116"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>File XML (*.xml);;Tutti i File (*)</translation>
     </message>
@@ -12065,7 +12072,7 @@ Valori più alti = unisce rilevamenti più distanti (può unire troppo).</transl
         <translation>Avviso Nome File</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="131"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="128"/>
         <source>The selected file does not appear to be an ADIAT_Data.xml result or an ADIAT_Search project file.
 
 Do you want to continue with this file?</source>
@@ -12087,7 +12094,7 @@ Vuoi continuare con questo file?</translation>
         <translation>Tracciamento Revisione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="51"/>
         <source>Enter your name to track your review activity.
 This helps coordinate reviews across multiple reviewers.</source>
         <translation>Inserisci il tuo nome per tracciare la tua attività di revisione.
@@ -12114,7 +12121,7 @@ Questo aiuta a coordinare le revisioni tra più revisori.</translation>
         <translation>Ricorda il mio nome</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="76"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="74"/>
         <source>Save your name for future review sessions.
 You can change it later in Preferences or by clicking the reviewer name in the viewer.</source>
         <translation>Salva il tuo nome per future sessioni di revisione.
@@ -12136,7 +12143,7 @@ Puoi cambiarlo più avanti nelle Preferenze o cliccando il nome del revisore nel
         <translation>Nome Richiesto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="124"/>
         <source>Please enter your name to continue.</source>
         <translation>Inserisci il tuo nome per continuare.</translation>
     </message>
@@ -12152,12 +12159,12 @@ Puoi cambiarlo più avanti nelle Preferenze o cliccando il nome del revisore nel
 <context>
     <name>SimilarityGalleryView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="173"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
         <source>Reference</source>
         <translation>Riferimento</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
@@ -12233,12 +12240,12 @@ Puoi cambiarlo più avanti nelle Preferenze o cliccando il nome del revisore nel
 <context>
     <name>StreamAlgorithmPage</name>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="91"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="90"/>
         <source>Are you primarily looking for a person?</source>
         <translation>Stai cercando principalmente una persona?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="157"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="156"/>
         <source>Do you know a distinctive target color?</source>
         <translation>Conosci un colore distintivo del target?</translation>
     </message>
@@ -12263,7 +12270,7 @@ Puoi cambiarlo più avanti nelle Preferenze o cliccando il nome del revisore nel
         <translation>Algoritmo Selezionato: {algorithm}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="192"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="191"/>
         <source>{result}
 Secondary Recommendation: {secondary}</source>
         <translation>{result}
@@ -12336,7 +12343,7 @@ Raccomandazione secondaria: {secondary}</translation>
         <translation>Clicca Sfoglia per selezionare un file video...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="341"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="340"/>
         <source>Click Scan to detect available capture devices, then select one from the dropdown.</source>
         <translation>Clicca su Scansiona per rilevare i dispositivi di acquisizione disponibili e seleziona quello desiderato dal menu a discesa.</translation>
     </message>
@@ -12352,7 +12359,7 @@ Raccomandazione secondaria: {secondary}</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="358"/>
         <source>You&apos;ll be prompted for the pairing code when you connect — pairing codes expire about 30 seconds after ADIAT Flight shows them, so don&apos;t generate one until you&apos;re ready.
 
 Finish this setup first, then start sharing in ADIAT Flight and enter the code. Detections reported by ADIAT Flight are ignored — this desktop runs its own analysis on the video.</source>
@@ -12395,17 +12402,17 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation type="unfinished">Seleziona un File di Metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="517"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="515"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="350"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="349"/>
         <source>Enter the RTMP URL provided by your streaming server (rtmp://server:port/app/key).</source>
         <translation>Inserisci l&apos;URL RTMP fornito dal tuo server di streaming (rtmp://server:port/app/key).</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="332"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="327"/>
         <source>Choose the video file you want to analyze. Use Browse to pick a file from disk.
 
 Location data is optional and usually detected automatically — ADIAT reads an .SRT sitting next to the video, or telemetry embedded in the video, on its own. Set it only to override that, or to supply location data the video does not have: a DJI .SRT or a .CSV flight log.</source>
@@ -12427,7 +12434,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>Seleziona File Video</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="494"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="493"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;All Files (*)</source>
         <translation>File Video (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;Tutti i File (*)</translation>
     </message>
@@ -12437,7 +12444,6 @@ Location data is optional and usually detected automatically — ADIAT reads an 
     <message>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="862"/>
         <source>Stream Connection</source>
-        <extracomment>Gap between the HUD and the bottom of the video pane. Flush against the edge reads as an artifact of the window rather than an overlay.</extracomment>
         <translation>Connessione Stream</translation>
     </message>
     <message>
@@ -12461,7 +12467,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>Stream RTMP</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="887"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="879"/>
         <source>Select the type of video source:
 • File: Pre-recorded video file with timeline controls
 • HDMI Capture: Live capture from HDMI capture device
@@ -12500,7 +12506,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>Sfoglia...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="930"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="927"/>
         <source>Open file browser to select a video file for analysis.
 Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</source>
         <translation>Apri il browser dei file per selezionare un file video per l&apos;analisi.
@@ -12517,7 +12523,7 @@ Formati supportati: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation>
         <translation>Scansiona i dispositivi di acquisizione HDMI disponibili</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="966"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="957"/>
         <source>Optional. ADIAT already finds location data on its own, from:
 • an .SRT file sitting next to the video
 • telemetry embedded in the video (newer DJI aircraft)
@@ -12531,12 +12537,12 @@ Choose a file here only to override that, or to supply location data the video d
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="974"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="973"/>
         <source>Optional - usually detected automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="982"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="980"/>
         <source>Browse for an SRT or CSV file with the flight&apos;s location data.
 Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
@@ -12547,7 +12553,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Connetti</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="993"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="992"/>
         <source>Connect to the specified video source and begin processing.</source>
         <translation>Connettiti alla sorgente video specificata e inizia l&apos;elaborazione.</translation>
     </message>
@@ -12557,7 +12563,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Disconnetti</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="999"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="998"/>
         <source>Disconnect from the current video source and stop processing.</source>
         <translation>Disconnettiti dalla sorgente video corrente e interrompi l&apos;elaborazione.</translation>
     </message>
@@ -12597,7 +12603,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Elaborazione: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1020"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1019"/>
         <source>Resolution used for detection processing</source>
         <translation>Risoluzione usata per l&apos;elaborazione del rilevamento</translation>
     </message>
@@ -12617,7 +12623,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>FPS Elaborazione: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1028"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1027"/>
         <source>Actual frames per second being processed</source>
         <translation>Fotogrammi al secondo effettivamente elaborati</translation>
     </message>
@@ -12627,7 +12633,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Tempo: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1034"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1033"/>
         <source>Time in milliseconds to process each frame</source>
         <translation>Tempo in millisecondi per elaborare ogni fotogramma</translation>
     </message>
@@ -12637,7 +12643,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Latenza: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1038"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1037"/>
         <source>End-to-end latency from frame capture to display</source>
         <translation>Latenza end-to-end dalla cattura del fotogramma alla visualizzazione</translation>
     </message>
@@ -12672,7 +12678,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Avvia Registrazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1067"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1066"/>
         <source>Start recording the video stream with detection overlays.</source>
         <translation>Avvia la registrazione dello stream video con sovrapposizioni di rilevamento.</translation>
     </message>
@@ -12682,7 +12688,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Interrompi Registrazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1072"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1071"/>
         <source>Stop the current recording and save to file.</source>
         <translation>Interrompi la registrazione corrente e salva su file.</translation>
     </message>
@@ -12693,7 +12699,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Stato: Non in Registrazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1082"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1081"/>
         <source>Current recording status and output file path</source>
         <translation>Stato di registrazione corrente e percorso del file di output</translation>
     </message>
@@ -12704,7 +12710,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Durata: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1088"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1087"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Statistiche registrazione: Durata, FPS, Fotogrammi</translation>
     </message>
@@ -12714,12 +12720,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Salva in:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1100"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1099"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Cartella in cui verranno salvate le registrazioni video.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1104"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1103"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Scegli una cartella per salvare le registrazioni.</translation>
     </message>
@@ -12729,7 +12735,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>rtmp://server:port/app/stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1174"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1173"/>
         <source>Click Connect to enter your pairing code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12739,7 +12745,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Dispositivo Non Valido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1196"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1195"/>
         <source>Please select a valid HDMI capture device.</source>
         <translation>Seleziona un dispositivo di acquisizione HDMI valido.</translation>
     </message>
@@ -12749,7 +12755,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>URL Non Valido</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1217"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1216"/>
         <source>Please enter a valid stream URL.</source>
         <translation>Inserisci un URL stream valido.</translation>
     </message>
@@ -12811,7 +12817,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished">Seleziona un File di Metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1506"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1503"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12821,7 +12827,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Nessun dispositivo di acquisizione trovato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="868"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="865"/>
         <source>Configure and connect to video source (file, HDMI capture, RTMP stream, or ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12831,12 +12837,12 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="891"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="890"/>
         <source>• ADIAT Flight: Live feed paired with the ADIAT Flight app</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="912"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="907"/>
         <source>Enter or browse for the video source:
 • File: Click to browse for video file (MP4, AVI, MOV, etc.)
 • RTMP Stream: Enter RTMP URL (rtmp://server:port/app/stream)
@@ -12884,7 +12890,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Seleziona File Video</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1484"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1482"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>File Video (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Tutti i File (*)</translation>
     </message>
@@ -12927,7 +12933,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>-- (Dati fotocamera mancanti)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="547"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="546"/>
         <source>Unable to calculate GSD. Sensor dimensions are required.</source>
         <translation>Impossibile calcolare il GSD. Sono richieste le dimensioni del sensore.</translation>
     </message>
@@ -12947,7 +12953,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Principale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="588"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="587"/>
         <source>Sensor</source>
         <translation>Sensore</translation>
     </message>
@@ -12995,12 +13001,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Altri esempi:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>sqm</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>sqft</translation>
     </message>
@@ -13008,7 +13014,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamTelemetryCoordinator</name>
     <message>
-        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="101"/>
+        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="100"/>
         <source>Waiting for telemetry from ADIAT Flight...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +13062,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamViewerWindow</name>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="130"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="129"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Strumento Automatico di Analisi Immagini Drone v{version} - Sponsorizzato da TEXSAR</translation>
     </message>
@@ -13132,7 +13138,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Stato: Non in Registrazione</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="392"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="391"/>
         <source>Current recording status and output file path</source>
         <translation>Stato di registrazione corrente e percorso del file di output</translation>
     </message>
@@ -13143,7 +13149,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Durata: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="398"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="397"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Statistiche registrazione: Durata, FPS, Fotogrammi</translation>
     </message>
@@ -13153,7 +13159,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Salva in:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="407"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="406"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Cartella in cui verranno salvate le registrazioni video.</translation>
     </message>
@@ -13163,7 +13169,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Sfoglia...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="411"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="410"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Scegli una cartella per salvare le registrazioni.</translation>
     </message>
@@ -13173,7 +13179,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="426"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="423"/>
         <source>Save each confirmed detection with the recording: a thumbnail, its position, and a results file that opens in the Image Analysis window.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13183,7 +13189,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="433"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="430"/>
         <source>Save the flight path and detection locations as a map and a KML file. Requires location data from the video or a live ADIAT Flight feed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13193,7 +13199,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="442"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="441"/>
         <source>Watch this recording: video, detections, telemetry and map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13203,7 +13209,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="447"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="446"/>
         <source>Open the folder holding the last recording and its detections.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13223,12 +13229,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Algoritmo:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="610"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="609"/>
         <source>Select which streaming detection algorithm to use</source>
         <translation>Seleziona quale algoritmo di rilevamento in streaming utilizzare</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="619"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="615"/>
         <source>Choose which streaming detection algorithm to run.
 • Color Anomaly &amp; Motion Detection: fused anomaly detectors
 • Color Detection: color-based highlighting</source>
@@ -13242,7 +13248,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Soglia Galleria:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="655"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="653"/>
         <source>Number of frames a detection must be seen before appearing in the Gallery tab</source>
         <translation>Numero di fotogrammi in cui un rilevamento deve essere visto prima di apparire nella scheda Galleria</translation>
     </message>
@@ -13252,7 +13258,7 @@ Not needed for most videos, which already carry it.</source>
         <translation> fotogrammi</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="667"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="663"/>
         <source>Detections must be seen for this many consecutive frames
 before appearing in the Gallery. Higher values reduce
 false positives but delay detection appearance.</source>
@@ -13363,27 +13369,27 @@ i falsi positivi ma ritardano la comparsa del rilevamento.</translation>
         <translation>{state} - {message}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1913"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1912"/>
         <source>Connected</source>
         <translation>Connesso</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="537"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="534"/>
         <source>Save the flight path and detection locations as a map and a KML file. Location data is available for this source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="544"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="541"/>
         <source>Save the flight path and detection locations as a map and a KML file. Nothing is saved unless location data arrives while recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1915"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1914"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1917"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1916"/>
         <source>Connecting</source>
         <translation type="unfinished">Connessione</translation>
     </message>
@@ -13413,7 +13419,7 @@ i falsi positivi ma ritardano la comparsa del rilevamento.</translation>
         <translation>Risultati Rilevamento ({count} trovati):</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2239"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2238"/>
         <source>#{index}: Type({cls}) Pos({x},{y}) Size({w}x{h})</source>
         <translation>#{index}: Tipo({cls}) Pos({x},{y}) Dim({w}x{h})</translation>
     </message>
@@ -13478,7 +13484,7 @@ i falsi positivi ma ritardano la comparsa del rilevamento.</translation>
         <translation>Stream Live</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2514"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2512"/>
         <source>Cannot seek in live stream.
 
 Detection was first seen at frame {frame}.</source>
@@ -13823,12 +13829,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Altri esempi:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>sqm</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>sqft</translation>
     </message>
@@ -13841,7 +13847,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Nessun AOI Contrassegnato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="52"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="49"/>
         <source>There are no flagged AOIs to assign.
 
 Flag at least one AOI in the viewer before using Plan Verification.</source>
@@ -13865,7 +13871,7 @@ Contrassegna almeno un AOI nel visualizzatore prima di usare Pianifica Verifiche
         <translation>Nessun AOI Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="223"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="221"/>
         <source>Select one or more AOIs on the map first.
 Click on markers, or use Rectangle Select for area selection.</source>
         <translation>Seleziona prima uno o più AOI sulla mappa.
@@ -14000,7 +14006,7 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>Assegna Selezione ▶</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="146"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="145"/>
         <source>Assign the selected AOIs on the map to the chosen team</source>
         <translation>Assegna gli AOI selezionati sulla mappa alla squadra scelta</translation>
     </message>
@@ -14015,7 +14021,7 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>Esporta PDF Squadra</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="174"/>
         <source>Generate a PDF report for the selected team only</source>
         <translation>Genera un report PDF solo per la squadra selezionata</translation>
     </message>
@@ -14025,7 +14031,7 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>Esporta Tutti i PDF</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="181"/>
         <source>Generate one PDF per team plus a master summary PDF</source>
         <translation>Genera un PDF per squadra più un PDF riepilogativo</translation>
     </message>
@@ -14050,7 +14056,7 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>Selezione Rettangolare</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="97"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="96"/>
         <source>Draw a rectangle on the map to select multiple AOIs</source>
         <translation>Disegna un rettangolo sulla mappa per selezionare più AOI</translation>
     </message>
@@ -14066,12 +14072,12 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>Vista Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="198"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="195"/>
         <source>Click to select AOI • Ctrl+Click to multi-select • Use Rectangle Select for area selection • Scroll to zoom</source>
         <translation>Clicca per selezionare AOI • Ctrl+Clic per selezione multipla • Usa Selezione Rettangolare per selezione area • Scorri per zoom</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="223"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="222"/>
         <source>Team</source>
         <translation>Squadra</translation>
     </message>
@@ -14145,18 +14151,18 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>dati vecchi {age}s</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="265"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="264"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="57"/>
         <source>ALT —</source>
         <translation>ALT —</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="299"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="297"/>
         <source>no AGL yet - ADIAT Flight found no terrain source here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="301"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="300"/>
         <source>no terrain-referenced AGL available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14176,47 +14182,47 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="307"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="306"/>
         <source>AGL — above the terrain beneath the aircraft; what clearance and image scale depend on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="309"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="308"/>
         <source>ATO — above the takeoff point (the drone&apos;s own reading); equal to AGL only over flat ground</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="325"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="324"/>
         <source>ADIAT Flight (fused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="327"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="326"/>
         <source>laser rangefinder (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="329"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="328"/>
         <source>downward sensor (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="331"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="330"/>
         <source>terrain DEM (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="333"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="332"/>
         <source>desktop DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="335"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="334"/>
         <source>no terrain source — this is the takeoff-relative reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="341"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="339"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="91"/>
         <source>HDG —</source>
         <translation>HDG —</translation>
@@ -14227,7 +14233,7 @@ Clicca sui marker, oppure usa la Selezione Rettangolare per selezionare un&apos;
         <translation>HDG {bearing:03d}° {cardinal}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="354"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="349"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="98"/>
         <source>SPD —</source>
         <translation>SPD —</translation>
@@ -14547,18 +14553,18 @@ Aggressivo</translation>
 <context>
     <name>ThermalHistogramChart</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="98"/>
         <source>No histogram data available</source>
         <translation>Nessun dato istogramma disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="435"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="434"/>
         <source>All Pixels</source>
         <translation>Tutti i Pixel</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="446"/>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="457"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="445"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="456"/>
         <source>AOI Pixels</source>
         <translation>Pixel AOI</translation>
     </message>
@@ -14571,7 +14577,7 @@ Aggressivo</translation>
         <translation>Istogramma Termico Non Disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="34"/>
+        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="33"/>
         <source>No thermal temperature data is available for the current image.</source>
         <translation>Per l&apos;immagine corrente non sono disponibili dati di temperatura termica.</translation>
     </message>
@@ -14628,7 +14634,7 @@ Aggressivo</translation>
         <translation>Passa il mouse sull&apos;istogramma per ispezionare una banda di temperatura.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="30"/>
         <source>No thermal histogram data available</source>
         <translation>Nessun dato disponibile per l&apos;istogramma termico</translation>
     </message>
@@ -14974,7 +14980,7 @@ Aggressivo</translation>
         <translation>Sostituire l&apos;origine dati chioma?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="361"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="359"/>
         <source>A LANDFIRE canopy source is currently configured.
 
 Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay on disk; only the selected source changes.)</source>
@@ -14988,7 +14994,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Elevazione (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="370"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="368"/>
         <source>Canopy height</source>
         <translation>Altezza della chioma</translation>
     </message>
@@ -15119,7 +15125,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Buffer dell&apos;impronta (m):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="110"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
         <translation>Spazio aggiunto attorno alle posizioni della camera affinché le tile scaricate coprano le impronte delle immagini. Dimensionato automaticamente dalla missione; modifica e ricompila per cambiarlo.</translation>
     </message>
@@ -15134,7 +15140,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>USGS 3DEP DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="123"/>
         <source>USGS 3DEP provides 1 m local elevation. Optional when you already have a terrain source configured (AWS Terrain Tiles online, or downloaded 3DEP) — enable it to download higher-resolution data.</source>
         <translation>USGS 3DEP fornisce un&apos;elevazione locale a 1 m. Opzionale quando è già configurata una sorgente del terreno (AWS Terrain Tiles online o 3DEP scaricato): abilitalo per scaricare dati a risoluzione più elevata.</translation>
     </message>
@@ -15164,7 +15170,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Cartella personalizzata...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="152"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="149"/>
         <source>The central library collects tiles from all missions in one place (they merge, nothing gets replaced) and registers automatically. Choose the results folder or a custom folder to keep tiles beside a specific mission instead.</source>
         <translation>La libreria centrale raccoglie i tile di tutte le missioni in un unico posto (si uniscono, nulla viene sostituito) e si registra automaticamente. Scegli la cartella dei risultati o una cartella personalizzata per tenere i tile accanto a una missione specifica.</translation>
     </message>
@@ -15194,32 +15200,32 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="207"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="206"/>
         <source>This area is already covered by your registered tiles.</source>
         <translation>Quest&apos;area è già coperta dai tile registrati.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="210"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="208"/>
         <source>Partially covered by your registered tiles — downloading fills the gaps.</source>
         <translation>Parzialmente coperto dai tile registrati: il download colma le lacune.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="214"/>
         <source>Your downloaded 1 m tiles don&apos;t include this area — without this download, online AWS Terrain Tiles (~30 m) are used here instead.</source>
         <translation>I tile a 1 m scaricati non includono quest&apos;area: senza questo download, qui vengono usati gli AWS Terrain Tiles online (~30 m).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="220"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
         <source>Your downloaded canopy tiles don&apos;t include this area — without this download, POD runs with no canopy attenuation here.</source>
         <translation>I tile della chioma scaricati non includono quest&apos;area: senza questo download, il POD viene eseguito qui senza attenuazione della chioma.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="222"/>
         <source>No local elevation tiles registered — online AWS Terrain Tiles (~30 m) serve as the baseline.</source>
         <translation>Nessun tile di elevazione locale registrato: gli AWS Terrain Tiles online (~30 m) fungono da base.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
         <source>No canopy source is configured yet.</source>
         <translation>Nessuna sorgente di chioma è ancora configurata.</translation>
     </message>
@@ -15260,7 +15266,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Nessun Dato Selezionato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="441"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="440"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Seleziona almeno un tipo di dato da esportare.</translation>
     </message>
@@ -15291,7 +15297,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Salva Esportazione Mappa</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="500"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="499"/>
         <source>KML files (*.kml);;KMZ files (*.kmz)</source>
         <translation>File KML (*.kml);;File KMZ (*.kmz)</translation>
     </message>
@@ -15317,12 +15323,12 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="704"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="716"/>
         <source>POD coverage complete</source>
         <translation>Copertura POD completata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
         <source>POD coverage complete — {count} frame(s) used online elevation (outside local DEM)</source>
         <translation>Copertura POD completata: {count} fotogramma/i hanno usato l&apos;elevazione online (fuori dal DEM locale)</translation>
     </message>
@@ -15342,7 +15348,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>(i dati sulla chioma coprivano il {pct}% dell&apos;area cercata)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="808"/>
         <source>Terrain and canopy aware probability-of-detection heatmap.</source>
         <translation>Mappa di calore della probabilità di rilevamento consapevole di terreno e chioma.</translation>
     </message>
@@ -15362,7 +15368,7 @@ Registrare invece le tile chioma Meta/WRI scaricate? (I file LANDFIRE restano su
         <translation>Sovrapposizione POD</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="826"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="824"/>
         <source>The POD coverage was computed, but embedding it into the exported file failed:
 {error}
 
@@ -15415,7 +15421,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
         <source>(no takeoff elevation — POD is approximate over changing terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15433,12 +15439,12 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
 <context>
     <name>UpdateController</name>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="53"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="52"/>
         <source>Disabled while Offline Only mode is enabled.</source>
         <translation>Disabilitato quando la modalita&apos; Solo offline e&apos; attiva.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="57"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="56"/>
         <source>Check the update feed for a newer ADIAT installer.</source>
         <translation>Controlla il feed degli aggiornamenti per un installer ADIAT piu&apos; recente.</translation>
     </message>
@@ -15448,7 +15454,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>Aggiornamenti disabilitati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="88"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="87"/>
         <source>Update checks are disabled while Offline Only mode is enabled.</source>
         <translation>Il controllo aggiornamenti e&apos; disabilitato quando la modalita&apos; Solo offline e&apos; attiva.</translation>
     </message>
@@ -15470,7 +15476,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>Nessun aggiornamento disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="113"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="112"/>
         <source>You are already running the latest available version of ADIAT.</source>
         <translation>Stai gia&apos; utilizzando la versione piu&apos; recente disponibile di ADIAT.</translation>
     </message>
@@ -15492,7 +15498,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>Installer avviato</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="140"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="139"/>
         <source>The installer has been launched. Close ADIAT when you are ready to continue the update.</source>
         <translation>L&apos;installer e&apos; stato avviato. Chiudi ADIAT quando sei pronto per continuare l&apos;aggiornamento.</translation>
     </message>
@@ -15507,7 +15513,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>ADIAT {new_version} e&apos; disponibile. Stai usando {current_version}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="157"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="156"/>
         <source>Do you want to download and launch the installer now?</source>
         <translation>Vuoi scaricare e avviare subito l&apos;installer?</translation>
     </message>
@@ -15538,7 +15544,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>{value} MB</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="194"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="193"/>
         <source>unknown</source>
         <translation>sconosciuto</translation>
     </message>
@@ -15551,7 +15557,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
     </message>
     <message>
         <location filename="../app/core/controllers/UpdateController.py" line="204"/>
-        <location filename="../app/core/controllers/UpdateController.py" line="211"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="210"/>
         <source>Update download canceled.</source>
         <translation>Download aggiornamento annullato.</translation>
     </message>
@@ -15617,7 +15623,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>Chiudi questa finestra di upscale</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="306"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="302"/>
         <source>Resolution: {width} × {height} pixels | Original: {orig_w} × {orig_h} pixels | Upscale: {level}x | Use mouse wheel to zoom, right-click to pan</source>
         <translation>Risoluzione: {width} × {height} pixel | Originale: {orig_w} × {orig_h} pixel | Upscale: {level}x | Usa la rotella del mouse per lo zoom, tasto destro per spostare</translation>
     </message>
@@ -15636,7 +15642,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>Errore durante l&apos;upscale iniziale: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="388"/>
         <source>Unable to extract visible image portion.</source>
         <translation>Impossibile estrarre la porzione visibile dell&apos;immagine.</translation>
     </message>
@@ -15646,7 +15652,7 @@ I prodotti GeoTIFF POD sono stati comunque scritti accanto all&apos;esportazione
         <translation>Upscale Massimo Raggiunto</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="401"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="399"/>
         <source>Maximum upscale level of {level}x has been reached.
 Further upscaling is not allowed to prevent memory issues.</source>
         <translation>È stato raggiunto il livello massimo di upscale di {level}x.
@@ -15658,7 +15664,7 @@ Ulteriori upscaling non sono consentiti per prevenire problemi di memoria.</tran
         <translation>Immagine Troppo Grande</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="415"/>
         <source>Upscaling would result in an image of {width}×{height} pixels.
 Maximum allowed dimension is {max_dim} pixels.
 
@@ -15674,7 +15680,7 @@ Prova a ingrandire una zona più piccola prima di effettuare l&apos;upscale.</tr
         <translation>Immagine Troppo Piccola</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="430"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="428"/>
         <source>Visible portion is too small ({width}×{height} pixels).
 Please zoom in to a larger area before upscaling.</source>
         <translation>La porzione visibile è troppo piccola ({width}×{height} pixel).
@@ -15689,7 +15695,7 @@ Per favore ingrandisci un&apos;area più grande prima di effettuare l&apos;upsca
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="487"/>
         <source>Upscaling image with AI enhancement...
 From {width}×{height} to {new_width}×{new_height} pixels
 This may take a few seconds.</source>
@@ -15721,7 +15727,7 @@ Potrebbe richiedere alcuni secondi.</translation>
         <translation>Metodo Non Disponibile</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="605"/>
         <source>Real-ESRGAN is not yet implemented.
 Falling back to Lanczos interpolation.</source>
         <translation>Real-ESRGAN non è ancora implementato.
@@ -15931,7 +15937,7 @@ Mostra informazioni in tempo reale durante l&apos;estrazione dei fotogrammi:
 Mostra il totale dei fotogrammi estratti al termine.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="58"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="57"/>
         <source>Select a Video File</source>
         <translation>Seleziona un File Video</translation>
     </message>
@@ -15941,7 +15947,7 @@ Mostra il totale dei fotogrammi estratti al termine.</translation>
         <translation>Seleziona un File di Metadati</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="74"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="73"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)</source>
         <translation>File di metadati (*.srt *.csv);;File SRT (*.srt);;Log di volo CSV (*.csv)</translation>
     </message>
@@ -15951,7 +15957,7 @@ Mostra il totale dei fotogrammi estratti al termine.</translation>
         <translation>Seleziona Cartella</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="111"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="110"/>
         <source>Please set the video file and output directory.</source>
         <translation>Imposta il file video e la cartella di output.</translation>
     </message>
@@ -16024,7 +16030,7 @@ Usa per confrontare l&apos;immagine originale con i risultati del rilevamento.</
         <translation>Mostra Overlay</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1346"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1343"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -16042,7 +16048,7 @@ Mostra tutte le AOI di tutte le immagini in una vista a griglia</translation>
         <translation>Mostra AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1364"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1363"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="328"/>
         <source>Open Histogram</source>
         <translation>Apri Istogramma</translation>
@@ -16090,7 +16096,7 @@ Mostra tutte le AOI di tutte le immagini in una vista a griglia</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2158"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2157"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="427"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation>Riferimento dimensioni persona (Ctrl+P)</translation>
@@ -16294,7 +16300,7 @@ L&apos;ordinamento aiuta a dare priorità alla revisione di oggetti più grandi 
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="139"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="138"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Strumento Automatico di Analisi Immagini Drone v{version} - Sponsorizzato da TEXSAR</translation>
     </message>
@@ -16319,7 +16325,7 @@ L&apos;ordinamento aiuta a dare priorità alla revisione di oggetti più grandi 
         <translation>Caricamento Risultati Non Riuscito</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="189"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -16349,7 +16355,7 @@ Il visualizzatore verrà chiuso.</translation>
         <translation>Caricamento risultati rilevamenti da {n} immagini...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="307"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="304"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Metadati e informazioni dell&apos;immagine.
@@ -16371,7 +16377,7 @@ Clicca su Coordinate GPS per copiare, condividere o aprire in applicazioni di ma
         <translation>Nessun Dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="721"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>No dataset is currently loaded.</source>
         <translation>Nessun dataset è attualmente caricato.</translation>
     </message>
@@ -16381,7 +16387,7 @@ Clicca su Coordinate GPS per copiare, condividere o aprire in applicazioni di ma
         <translation>Genera Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="732"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="729"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -16426,7 +16432,7 @@ Continuare?</translation>
         <translation>Cache Generata</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="806"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -16444,7 +16450,7 @@ Il visualizzatore ora caricherà miniature e colori molto più velocemente.</tra
         <translation>Errore Generazione Cache</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="840"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="839"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -16458,7 +16464,7 @@ Il visualizzatore ora caricherà miniature e colori molto più velocemente.</tra
         <translation>AOI Non Visibile</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1028"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -16472,7 +16478,7 @@ Per selezionare questa AOI, cancella o regola i tuoi filtri.</translation>
         <translation>Aggiorna Dimensioni Immagini</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1228"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1224"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -16486,7 +16492,7 @@ Vuoi leggere le dimensioni dai file immagine e aggiornare il file dei risultati?
         <translation>Lettura dimensioni immagini ({done}/{total})...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1355"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1354"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Mostra Pixel di Interesse (H o Ctrl+I)</translation>
     </message>
@@ -16506,7 +16512,7 @@ Vuoi leggere le dimensioni dai file immagine e aggiornare il file dei risultati?
         <translation>Dipendenza Mancante</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1797"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1794"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>Il modulo qimage2ndarray è richiesto per la funzione di upscale.
@@ -16518,19 +16524,19 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Errore di Upscale</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1806"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1805"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Si è verificato un errore durante l&apos;apertura della finestra di upscale:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2161"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation>Riferimento dimensioni persona non disponibile: nessun GSD per questa immagine</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2261"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2258"/>
         <source>Unknown Reviewer</source>
         <translation>Revisore Sconosciuto</translation>
     </message>
@@ -16553,7 +16559,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>L&apos;orologio della fotocamera di queste immagini sembra configurato in modo errato:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
         <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
         <translation>ADIAT può scrivere un&apos;ora di scatto corretta nei metadati dell&apos;immagine. L&apos;operazione non è distruttiva: i campi EXIF originali non vengono modificati e i calcoli di sole e ombre useranno l&apos;ora corretta. Confronta l&apos;anteprima con l&apos;orario reale del volo: se differisce di 12 ore, correggi l&apos;errore del quadrante dell&apos;orologio.</translation>
     </message>
@@ -16568,7 +16574,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Errore del quadrante da correggere:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="129"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
         <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
         <translation>Nome del fuso orario IANA (es. America/Los_Angeles) o uno scostamento UTC fisso in ore (es. -7)</translation>
     </message>
@@ -16649,6 +16655,124 @@ Installalo usando: pip install qimage2ndarray</translation>
     </message>
 </context>
 <context>
+    <name>WaldoFlightLogDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="126"/>
+        <source>WALDO Flight Track Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="150"/>
+        <source>An aircraft track log can supply the true per-image camera attitude (bank and pitch) and a GPS-accurate capture time, making image footprints and AOI positions substantially more accurate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="162"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished">Ricorda la mia scelta per questa cartella</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="171"/>
+        <source>Reading image metadata...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="182"/>
+        <source>Apply Flight Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="186"/>
+        <source>Not Now</source>
+        <translation type="unfinished">Non ora</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="190"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annulla</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="193"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="246"/>
+        <source>The track log does not match these images: {reason}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="258"/>
+        <source>Camera clock is {n:.1f} s {direction} of GPS time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>behind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="261"/>
+        <source>Track log: {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="263"/>
+        <source>Images sit {d:.0f} m from the flight track on average ({p:.0%} matched)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="269"/>
+        <source>Attitude channel verified against turn physics (correlation {c:.2f}, recorded {lag:+.0f} s late)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="273"/>
+        <source>Bank during capture: {lo:+.1f}° to {hi:+.1f}°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="277"/>
+        <source>Attitude channel is NOT reliable (correlation {c:.2f}) - only the capture-time refinement will be stamped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="305"/>
+        <source>Stamping flight-log attitude...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="324"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="347"/>
+        <source>Stamped:          {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="348"/>
+        <source>Already current:  {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="349"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Errori:           {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="355"/>
+        <source>Cancelled - remaining images are unstamped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WaldoPrePassDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="58"/>
@@ -16681,7 +16805,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Pre-pass WALDO completato</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="148"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="147"/>
         <source>WALDO Pre-Pass Cancelled</source>
         <translation>Pre-pass WALDO annullato</translation>
     </message>
@@ -16739,7 +16863,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Riepilogo Importazione</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="61"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="58"/>
         <source>&lt;b&gt;Matched images:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;CSV entries without match:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Result images without CSV data:&lt;/b&gt; {unmatched_images}</source>
         <translation>&lt;b&gt;Immagini abbinate:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;Voci CSV senza corrispondenza:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Immagini di risultato senza dati CSV:&lt;/b&gt; {unmatched_images}</translation>
     </message>
@@ -16749,12 +16873,12 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Altitudine &amp; GSD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="78"/>
         <source>&lt;b&gt;AGL computed from terrain:&lt;/b&gt; {agl_count} of {matched_count} images&lt;br&gt;&lt;br&gt;Per-image AGL is derived from the CSV altitude (ASL) minus terrain elevation at each GPS location. GSD will be calculated automatically using the camera sensor data and focal length.</source>
         <translation>&lt;b&gt;AGL calcolata dal terreno:&lt;/b&gt; {agl_count} di {matched_count} immagini&lt;br&gt;&lt;br&gt;L&apos;AGL per immagine è derivata dall&apos;altitudine CSV (ASL) meno la quota del terreno in corrispondenza di ciascuna posizione GPS. Il GSD verrà calcolato automaticamente usando i dati del sensore della fotocamera e la lunghezza focale.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="89"/>
         <source>&lt;b&gt;Terrain data unavailable&lt;/b&gt; - AGL could not be computed.&lt;br&gt;&lt;br&gt;Orientation (yaw/pitch/roll) will still be applied from the CSV. GSD and altitude displays require terrain data or a manual altitude override (Shift+O) after import.</source>
         <translation>&lt;b&gt;Dati del terreno non disponibili&lt;/b&gt; - impossibile calcolare l&apos;AGL.&lt;br&gt;&lt;br&gt;L&apos;orientamento (yaw/pitch/roll) verrà comunque applicato dal CSV. Le visualizzazioni di GSD e altitudine richiedono i dati del terreno o un override manuale dell&apos;altitudine (Maiusc+O) dopo l&apos;importazione.</translation>
     </message>
@@ -16777,7 +16901,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Salva File Zip</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="132"/>
         <source>Zip files (*.zip)</source>
         <translation>File Zip (*.zip)</translation>
     </message>
@@ -16810,7 +16934,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Opzioni Esportazione ZIP</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="30"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="26"/>
         <source>Choose what to export:
 
 - Native: Original images, TIFF masks, and XML (paths made portable).
@@ -16836,7 +16960,7 @@ Installalo usando: pip install qimage2ndarray</translation>
         <translation>Includi immagini senza AOI contrassegnate</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="53"/>
         <source>When unchecked, only images with at least one flagged AOI will be exported.
 When checked, all images will be exported regardless of flagged AOI status.</source>
         <translation>Quando deselezionato, verranno esportate solo le immagini con almeno una AOI contrassegnata.
@@ -16851,6 +16975,24 @@ Quando selezionato, verranno esportate tutte le immagini indipendentemente dallo
         <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="60"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
+    </message>
+</context>
+<context>
+    <name>_CalibrateWorker</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="66"/>
+        <source>No images with resolvable GPS + capture time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="68"/>
+        <source>No ForeFlight track log found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="73"/>
+        <source>Calibrating {name}...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/app_nl.ts
+++ b/translations/app_nl.ts
@@ -125,12 +125,12 @@ GPU-versnelling verbetert de verwerkingssnelheid van AI-modellen aanzienlijk.</t
 <context>
     <name>AIPersonDetectorController</name>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="82"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="81"/>
         <source>GPU Not Available</source>
         <translation>GPU niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="88"/>
+        <location filename="../app/algorithms/images/AIPersonDetector/controllers/AIPersonDetectorController.py" line="87"/>
         <source>GPU Available</source>
         <translation>GPU beschikbaar</translation>
     </message>
@@ -203,7 +203,7 @@ toegeeflijk</translation>
         <translation>AOI-opmerking</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="38"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOICommentDialog.py" line="37"/>
         <source>Add a comment for this flagged AOI (max 256 characters):</source>
         <translation>Voeg een opmerking toe voor deze gemarkeerde AOI (max. 256 tekens):</translation>
     </message>
@@ -287,7 +287,7 @@ toegeeflijk</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1092"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1091"/>
         <source>Terrain-corrected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -297,12 +297,12 @@ toegeeflijk</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1105"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1102"/>
         <source>Flat terrain assumed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1539"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1538"/>
         <source>Temperature sorting unavailable (no thermal data)</source>
         <translation>Sorteren op temperatuur niet beschikbaar (geen thermische gegevens)</translation>
     </message>
@@ -312,7 +312,7 @@ toegeeflijk</translation>
         <translation>Kan AOI niet verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1895"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1892"/>
         <source>Only manually created AOIs can be deleted. Algorithm-detected AOIs cannot be deleted.</source>
         <translation>Alleen handmatig gemaakte AOI&apos;s kunnen worden verwijderd. Door algoritmen gedetecteerde AOI&apos;s kunnen niet worden verwijderd.</translation>
     </message>
@@ -322,7 +322,7 @@ toegeeflijk</translation>
         <translation>AOI verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1904"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIController.py" line="1903"/>
         <source>Are you sure you want to delete this AOI? This action cannot be undone.</source>
         <translation>Weet u zeker dat u deze AOI wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.</translation>
     </message>
@@ -596,7 +596,7 @@ toegeeflijk</translation>
         <translation>Maskerafbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="610"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="609"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)</source>
         <translation>Afbeeldingen (*.png *.jpg *.jpeg *.bmp *.tiff);;Alle bestanden (*)</translation>
     </message>
@@ -606,7 +606,7 @@ toegeeflijk</translation>
         <translation>Ongeldige afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="620"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOIFilterDialog.py" line="619"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>Kan de geselecteerde afbeelding niet laden. Kies een geldig afbeeldingsbestand.</translation>
     </message>
@@ -659,12 +659,12 @@ toegeeflijk</translation>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="383"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="380"/>
         <source>Showing the {count} nearest images containing this AOI; there are more. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="388"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="385"/>
         <source>Found AOI in {count} image(s). Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to navigate to that image.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,7 +677,7 @@ toegeeflijk</translation>
         <translation>Geen AOI geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="194"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="193"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Selecteer eerst een AOI door erop te klikken in het miniaturenpaneel.</translation>
     </message>
@@ -687,7 +687,7 @@ toegeeflijk</translation>
         <translation>Kan GPS niet berekenen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="409"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="406"/>
         <source>Unable to calculate GPS coordinates for this AOI.
 
 This may be due to missing image metadata (GPS, altitude, or camera info).</source>
@@ -728,7 +728,7 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
         <translation>Geen buren gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="438"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="437"/>
         <source>The AOI was not found in any neighboring images.</source>
         <translation>De AOI is niet gevonden in naburige afbeeldingen.</translation>
     </message>
@@ -745,7 +745,7 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="587"/>
+        <location filename="../app/core/controllers/images/viewer/neighbor/AOINeighborTrackingController.py" line="584"/>
         <source> (no detections)</source>
         <translation> (geen detecties)</translation>
     </message>
@@ -770,7 +770,7 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
         <translation>Geen AOI geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="143"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="142"/>
         <source>Please select an AOI first by clicking on it in the thumbnail panel.</source>
         <translation>Selecteer eerst een AOI door erop te klikken in het miniaturenpaneel.</translation>
     </message>
@@ -813,7 +813,7 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
         <translation>Geen vergelijkbare AOI&apos;s</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="280"/>
+        <location filename="../app/core/controllers/images/viewer/similarity/AOISimilarityController.py" line="279"/>
         <source>No other AOIs could be analyzed for similarity.</source>
         <translation>Er konden geen andere AOI&apos;s op overeenkomst worden geanalyseerd.</translation>
     </message>
@@ -865,7 +865,7 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
         <translation>Vergelijkbare AOI&apos;s</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="479"/>
         <source>Top {shown} of {total} AOIs ranked by similarity to {reference}. Use mouse wheel to zoom, right-click drag to pan. Click a thumbnail to jump to that AOI.</source>
         <translation>Top {shown} van {total} AOI&apos;s gerangschikt op overeenkomst met {reference}. Gebruik het muiswiel om te zoomen, sleep met de rechtermuisknop om te pannen. Klik op een miniatuur om naar die AOI te gaan.</translation>
     </message>
@@ -936,7 +936,7 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
         <translation>AOI #{number}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="584"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="582"/>
         <source>the selected AOI</source>
         <translation>de geselecteerde AOI</translation>
     </message>
@@ -944,15 +944,15 @@ Dit kan komen door ontbrekende afbeeldingsmetagegevens (GPS, hoogte of camera-in
 <context>
     <name>AOIUIComponent</name>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="251"/>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="347"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="250"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="346"/>
         <source>AOI Information
 Right-click to copy data to clipboard</source>
         <translation>AOI-informatie
 Rechtsklik om gegevens naar klembord te kopiëren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="257"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="256"/>
         <source>
 
 Score Type: {type}
@@ -973,7 +973,7 @@ Ruwe score: {score} ({method})</translation>
         <translation>Markering AOI verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="387"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="386"/>
         <source>Flag AOI</source>
         <translation>AOI markeren</translation>
     </message>
@@ -989,7 +989,7 @@ Click to edit comment</source>
 Klik om opmerking te bewerken</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="415"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="411"/>
         <source>No comment yet.
 Click to add a comment for this AOI.
 
@@ -1002,7 +1002,7 @@ Gebruik opmerkingen om belangrijke details, waarnemingen
 of benodigde acties voor deze detectie vast te leggen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="429"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="428"/>
         <source>Calculate and show GPS location for this AOI</source>
         <translation>GPS-locatie voor deze AOI berekenen en tonen</translation>
     </message>
@@ -1017,7 +1017,7 @@ of benodigde acties voor deze detectie vast te leggen.</translation>
         <translation>Gebied</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="485"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="484"/>
         <source>Areas</source>
         <translation>Gebieden</translation>
     </message>
@@ -1027,12 +1027,12 @@ of benodigde acties voor deze detectie vast te leggen.</translation>
         <translation>{filtered} van {total} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="496"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="495"/>
         <source>Area of Interest</source>
         <translation>Interessegebied</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="498"/>
+        <location filename="../app/core/controllers/images/viewer/aoi/AOIUIComponent.py" line="497"/>
         <source>Areas of Interest</source>
         <translation>Interessegebieden</translation>
     </message>
@@ -1055,7 +1055,7 @@ of benodigde acties voor deze detectie vast te leggen.</translation>
 <context>
     <name>AlertManager</name>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="295"/>
+        <location filename="../app/core/services/AlertService.py" line="294"/>
         <source>ADIAT - Color Detection Alerts</source>
         <translation>ADIAT - Kleurdetectiewaarschuwingen</translation>
     </message>
@@ -1065,7 +1065,7 @@ of benodigde acties voor deze detectie vast te leggen.</translation>
         <translation>ADIAT - Kleurdetectiewaarschuwing</translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="613"/>
+        <location filename="../app/core/services/AlertService.py" line="610"/>
         <source>Detected {count} object(s)
 Average confidence: {avg_confidence:.2f}
 Total area: {area:.0f} pixels
@@ -1076,7 +1076,7 @@ Totale oppervlakte: {area:.0f} pixels
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="621"/>
+        <location filename="../app/core/services/AlertService.py" line="620"/>
         <source>
 Details:
 </source>
@@ -1085,7 +1085,7 @@ Details:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/services/AlertService.py" line="625"/>
+        <location filename="../app/core/services/AlertService.py" line="624"/>
         <source>  #{index}: ({x},{y}) {w}x{h} conf:{confidence:.2f}
 </source>
         <translation>  #{index}: ({x},{y}) {w}x{h} betr:{confidence:.2f}
@@ -1113,7 +1113,7 @@ Details:
         <translation>Gebruikt u thermische afbeeldingen?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="157"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="156"/>
         <source>Are you looking for anomalies within a specific temperature range?</source>
         <translation>Zoekt u afwijkingen binnen een specifiek temperatuurbereik?</translation>
     </message>
@@ -1123,7 +1123,7 @@ Details:
         <translation>Wilt u specifiek personen detecteren?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="169"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="168"/>
         <source>Do you want to detect anomalies relative to local surroundings?</source>
         <translation>Wilt u afwijkingen ten opzichte van de lokale omgeving detecteren?</translation>
     </message>
@@ -1138,12 +1138,12 @@ Details:
         <translation>Wilt u het kleurbereik handmatig aanpassen?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="194"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="193"/>
         <source>Do your images contain complex backgrounds or structures?</source>
         <translation>Bevatten uw afbeeldingen complexe achtergronden of structuren?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="201"/>
+        <location filename="../app/core/controllers/images/guidePages/AlgorithmSelectionPage.py" line="200"/>
         <source>Do your images include shadows or areas with uneven lighting?</source>
         <translation>Bevatten uw afbeeldingen schaduwen of gebieden met ongelijkmatige verlichting?</translation>
     </message>
@@ -1179,7 +1179,7 @@ Details:
 <context>
     <name>AlignImageDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="53"/>
         <source>This saved alignment looks mirrored - re-place each corner handle on its matching photo corner (coloured squares).</source>
         <translation>Deze opgeslagen uitlijning lijkt gespiegeld: plaats elke hoekgreep opnieuw op de bijbehorende fotohoek (gekleurde vierkantjes).</translation>
     </message>
@@ -1189,7 +1189,7 @@ Details:
         <translation>Afbeelding uitlijnen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="136"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="130"/>
         <source>Rotate the drone image to line it up with the map. The small coloured squares mark the photo&apos;s corners - drag each corner handle onto the map where its matching-coloured photo corner belongs. For extra accuracy, add tie points: put the IMAGE end on a feature in the drone photo and the MAP end on the same feature on the map.</source>
         <translation>Draai de drone-afbeelding zodat deze op de kaart aansluit. De kleine gekleurde vierkantjes markeren de hoeken van de foto: sleep elke hoekgreep op de kaart naar de plek waar de fotohoek met dezelfde kleur hoort. Voeg voor extra nauwkeurigheid verbindingspunten toe: plaats het AFBEELDING-uiteinde op een herkenbaar punt in de dronefoto en het KAART-uiteinde op hetzelfde punt op de kaart.</translation>
     </message>
@@ -1235,7 +1235,7 @@ Details:
         <translation>Hoeken lijken gespiegeld</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AlignImageDialog.py" line="220"/>
         <source>The four corners appear mirrored - the drone image would map to the ground flipped.
 
 Each corner handle is colour-matched to a corner of the drone photo (the small coloured squares). Make sure every handle sits where its matching photo corner belongs.</source>
@@ -1275,7 +1275,7 @@ Elke hoekgreep is op kleur gekoppeld aan een hoek van de dronefoto (de kleine ge
         <translation>meter</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="100"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="98"/>
         <source>feet</source>
         <translation>voet</translation>
     </message>
@@ -1285,7 +1285,7 @@ Elke hoekgreep is op kleur gekoppeld aan een hoek van de dronefoto (de kleine ge
         <translation>Negatieve hoogte gedetecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="113"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="111"/>
         <source>WARNING! Relative Altitude is negative. Enter an AGL altitude to be used for GSD calculations (in {unit}):</source>
         <translation>WAARSCHUWING! De relatieve hoogte is negatief. Voer een AGL-hoogte in voor GSD-berekeningen (in {unit}):</translation>
     </message>
@@ -1295,7 +1295,7 @@ Elke hoekgreep is op kleur gekoppeld aan een hoek van de dronefoto (de kleine ge
         <translation>Hoogte overschrijven</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/AltitudeController.py" line="132"/>
         <source>Enter a custom AGL altitude to be used for GSD calculations for all images (in {unit}):</source>
         <translation>Voer een aangepaste AGL-hoogte in voor GSD-berekeningen voor alle afbeeldingen (in {unit}):</translation>
     </message>
@@ -1367,7 +1367,7 @@ Elke hoekgreep is op kleur gekoppeld aan een hoek van de dronefoto (de kleine ge
         <translation>Ontbrekende koersen gedetecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="135"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="132"/>
         <source>Some images are missing bearing/heading information. We can estimate bearings from a flight track file (KML/GPX/CSV) or calculate them automatically from image GPS coordinates.</source>
         <translation>Sommige afbeeldingen missen koers-/richtingsinformatie. We kunnen koersen schatten uit een vluchtspoorbestand (KML/GPX/CSV) of ze automatisch berekenen op basis van GPS-coördinaten van de afbeeldingen.</translation>
     </message>
@@ -1402,7 +1402,7 @@ Elke hoekgreep is op kleur gekoppeld aan een hoek van de dronefoto (de kleine ge
         <translation>Spoorbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="262"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="261"/>
         <source>Track Files (*.kml *.gpx *.csv);;KML Files (*.kml);;GPX Files (*.gpx);;CSV Files (*.csv);;All Files (*.*)</source>
         <translation>Spoorbestanden (*.kml *.gpx *.csv);;KML-bestanden (*.kml);;GPX-bestanden (*.gpx);;CSV-bestanden (*.csv);;Alle bestanden (*.*)</translation>
     </message>
@@ -1442,7 +1442,7 @@ Elke hoekgreep is op kleur gekoppeld aan een hoek van de dronefoto (de kleine ge
         <translation>Koersberekening mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="393"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="391"/>
         <source>An error occurred during bearing calculation:
 
 {error}
@@ -1470,7 +1470,7 @@ Controleer uw invoerbestanden en probeer het opnieuw.</translation>
         <translation>Koersherstel niet nodig</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="440"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="437"/>
         <source>Bearing recovery requires multiple images to calculate direction of travel.
 
 With only one image, bearing recovery cannot be performed.</source>
@@ -1479,7 +1479,7 @@ With only one image, bearing recovery cannot be performed.</source>
 Met slechts één afbeelding kan koersherstel niet worden uitgevoerd.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="482"/>
+        <location filename="../app/core/views/images/viewer/dialogs/BearingRecoveryDialog.py" line="452"/>
         <source>
 &lt;h3&gt;What is Bearing Recovery?&lt;/h3&gt;
 
@@ -1558,14 +1558,14 @@ Doorgaan zonder koersherstel. Sommige functies werken mogelijk niet correct.&lt;
         <translation>Gecachete gegevens niet gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="57"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="56"/>
         <source>The following cached items were not found:
 </source>
         <translation>De volgende gecachete items zijn niet gevonden:
 </translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="71"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="66"/>
         <source>Without cached data, thumbnails and colors will be generated on-demand, which may cause delays when viewing results.
 
 If you have previously processed this dataset and have an ADIAT_Results folder with cached data, you can locate it now to improve performance.</source>
@@ -1594,7 +1594,7 @@ Als u deze dataset eerder hebt verwerkt en een ADIAT_Results-map met gecachete g
         <translation>Ongeldige cachemap</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="143"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CacheLocationDialog.py" line="138"/>
         <source>The selected folder does not contain thumbnail cache directory.
 
 Expected to find:
@@ -1658,7 +1658,7 @@ Selecteer een geldige ADIAT_Results-map.</translation>
         <translation>Inloggegevens bijgewerkt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="517"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="516"/>
         <source>Credentials have been updated and the map list has been refreshed.</source>
         <translation>De inloggegevens zijn bijgewerkt en de kaartlijst is vernieuwd.</translation>
     </message>
@@ -1668,7 +1668,7 @@ Selecteer een geldige ADIAT_Results-map.</translation>
         <translation>Bijwerken mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="526"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="523"/>
         <source>Failed to refresh account data with new credentials.
 
 Please check your credentials and try again.</source>
@@ -1691,7 +1691,7 @@ Controleer uw inloggegevens en probeer het opnieuw.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="544"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="542"/>
         <source>Credentials have been updated. Please close and reopen this dialog to refresh the map list.</source>
         <translation>De inloggegevens zijn bijgewerkt. Sluit en open dit dialoogvenster opnieuw om de kaartlijst te vernieuwen.</translation>
     </message>
@@ -1701,7 +1701,7 @@ Controleer uw inloggegevens en probeer het opnieuw.</translation>
         <translation>Geen kaart geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="561"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAPIMapDialog.py" line="560"/>
         <source>Please select a map from the list.</source>
         <translation>Selecteer een kaart uit de lijst.</translation>
     </message>
@@ -1757,7 +1757,7 @@ Controleer uw inloggegevens en probeer het opnieuw.</translation>
         <translation>Laden mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="416"/>
         <source>Failed to load CalTopo. Please check your internet connection and try again.</source>
         <translation>Kan CalTopo niet laden. Controleer uw internetverbinding en probeer het opnieuw.</translation>
     </message>
@@ -1772,7 +1772,7 @@ Controleer uw inloggegevens en probeer het opnieuw.</translation>
         <translation>Geen kaart geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="480"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="477"/>
         <source>Please navigate to a CalTopo map before capturing the session.
 
 The map URL should contain a map ID (e.g., /m/ABC123 or #id=ABC123).</source>
@@ -1786,7 +1786,7 @@ De kaart-URL moet een kaart-ID bevatten (bijv. /m/ABC123 of #id=ABC123).</transl
         <translation>Browser niet gereed</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="488"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="487"/>
         <source>The CalTopo browser is still loading. Please wait a moment and try again.</source>
         <translation>De CalTopo-browser laadt nog. Wacht even en probeer het opnieuw.</translation>
     </message>
@@ -1802,12 +1802,12 @@ De kaart-URL moet een kaart-ID bevatten (bijv. /m/ABC123 of #id=ABC123).</transl
         <translation>Authenticatie mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="513"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="512"/>
         <source>Browser not initialized. Please try again.</source>
         <translation>Browser niet geïnitialiseerd. Probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="768"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoAuthDialog.py" line="764"/>
         <source>Could not read your CalTopo session.
 
 Make sure you are signed in to CalTopo in this window and have opened your map, then click &apos;I&apos;m Logged In - Export Data&apos; again.</source>
@@ -1834,7 +1834,7 @@ Controleer of u in dit venster bij CalTopo bent aangemeld en uw kaart hebt geope
         <translation>CalTopo Team API-inloggegevens</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="87"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="85"/>
         <source>Enter your CalTopo Team API credentials.
 These can be found in the Team Admin page under Service Accounts.</source>
         <translation>Voer uw CalTopo Team API-inloggegevens in.
@@ -1945,7 +1945,7 @@ Deze zijn te vinden op de Team Admin-pagina onder Service Accounts.</translation
         <translation>Ongeldig referentiegeheim</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="268"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="263"/>
         <source>The Credential Secret cannot be used to sign a CalTopo request.
 
 Copy it exactly as shown on the CalTopo Team Admin page under Service Accounts - it is a long base64 string, not the Credential ID or the Team ID.
@@ -1968,7 +1968,7 @@ Details: {error}</translation>
         <translation>Inloggegevens geldig</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="319"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="318"/>
         <source>The credentials are valid and successfully authenticated with CalTopo API.</source>
         <translation>De inloggegevens zijn geldig en authenticatie met de CalTopo API is geslaagd.</translation>
     </message>
@@ -1978,7 +1978,7 @@ Details: {error}</translation>
         <translation>Inloggegevens ongeldig</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="332"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoCredentialDialog.py" line="325"/>
         <source>The credentials failed to authenticate with CalTopo API.
 
 Please check:
@@ -2013,13 +2013,13 @@ Controleer:
     <name>CalTopoExportController</name>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="488"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1297"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1298"/>
         <source>Offline Mode Enabled</source>
         <translation>Offline-modus ingeschakeld</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="495"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1304"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="490"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1300"/>
         <source>Offline Only is turned on in Preferences:
 
 • Map tiles will not be retrieved.
@@ -2035,13 +2035,13 @@ Schakel Alleen offline uit om naar CalTopo te exporteren.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="501"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1310"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1311"/>
         <source>Nothing Selected</source>
         <translation>Niets geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="505"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1314"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="503"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1313"/>
         <source>Select at least one data type (flagged AOIs, drone/image locations, or coverage area) to export.</source>
         <translation>Selecteer ten minste één gegevenstype (gemarkeerde AOI&apos;s, drone-/afbeeldingslocaties of dekkingsgebied) om te exporteren.</translation>
     </message>
@@ -2066,7 +2066,7 @@ Schakel Alleen offline uit om naar CalTopo te exporteren.</translation>
         <translation>Voorbereidingsfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="563"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="562"/>
         <source>An error occurred while preparing export data:
 
 {error}</source>
@@ -2090,14 +2090,14 @@ Schakel Alleen offline uit om naar CalTopo te exporteren.</translation>
         <translation>dekkingsgebied</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="582"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="579"/>
         <source>No flagged AOIs, geotagged image locations, or coverage areas are available.
 Flag some AOIs with the &apos;F&apos; key or ensure your images have GPS metadata.</source>
         <translation>Geen gemarkeerde AOI&apos;s, geotagde afbeeldingslocaties of dekkingsgebieden beschikbaar.
 Markeer enkele AOI&apos;s met de &apos;F&apos;-toets of zorg dat uw afbeeldingen GPS-metagegevens hebben.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="590"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="585"/>
         <source>Found {count} flagged AOI(s), but could not extract GPS coordinates.
 
 This usually means:
@@ -2114,30 +2114,11 @@ Dit betekent meestal:
 Zorg dat uw afbeeldingen GPS-coördinaten bevatten.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="596"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="593"/>
         <source>No geotagged drone/image locations were found.
 Ensure your images contain GPS metadata and try again.</source>
         <translation>Geen geotagde drone-/afbeeldingslocaties gevonden.
 Zorg dat uw afbeeldingen GPS-metagegevens bevatten en probeer het opnieuw.</translation>
-    </message>
-    <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="605"/>
-        <source>No coverage area polygons could be calculated.
-
-This usually means:
-• The images don&apos;t have GPS data in their EXIF metadata
-• The images are not nadir (gimbal pitch must be between -85° and -95°)
-• GSD (ground sample distance) could not be calculated
-
-Please ensure your images have GPS coordinates and are nadir shots.</source>
-        <translation>Er konden geen polygonen voor het dekkingsgebied worden berekend.
-
-Dit betekent meestal:
-• De afbeeldingen hebben geen GPS-gegevens in hun EXIF-metagegevens
-• De afbeeldingen zijn niet nadir (gimbal-pitch moet tussen -85° en -95° zijn)
-• GSD (ground sample distance) kon niet worden berekend
-
-Zorg dat uw afbeeldingen GPS-coördinaten hebben en nadirale opnamen zijn.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="608"/>
@@ -2145,18 +2126,18 @@ Zorg dat uw afbeeldingen GPS-coördinaten hebben en nadirale opnamen zijn.</tran
         <translation>Er zijn geen {types} beschikbaar om te exporteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="612"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="613"/>
         <source>Nothing to Export</source>
         <translation>Niets te exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="637"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="680"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="638"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="681"/>
         <source>No Map Selected</source>
         <translation>Geen kaart geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="643"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="640"/>
         <source>Please navigate to a CalTopo map before clicking &apos;I&apos;m Logged In&apos;.
 
 The map URL should look like:
@@ -2167,7 +2148,7 @@ De kaart-URL moet er zo uitzien:
 https://caltopo.com/map.html#...&amp;id=ABC123</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="686"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="683"/>
         <source>No CalTopo map was selected, so there was nothing to export to.
 
 Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - Export Data&apos;.</source>
@@ -2176,7 +2157,7 @@ Open your map in the CalTopo window before clicking &apos;I&apos;m Logged In - E
 Open uw kaart in het CalTopo-venster voordat u op &apos;Ik ben aangemeld - Gegevens exporteren&apos; klikt.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1615"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1613"/>
         <source>Nothing could be exported to CalTopo.
 
 The reason was written to the log (adiat_logs.txt) and the console.</source>
@@ -2190,7 +2171,7 @@ De reden is vastgelegd in het logbestand (adiat_logs.txt) en de console.</transl
         <translation>Geüploade foto&apos;s: {uploaded} van {total}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1631"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1630"/>
         <source>Successfully exported all {total} item(s) to CalTopo.
 
 The items should now be visible on your map.</source>
@@ -2199,7 +2180,7 @@ The items should now be visible on your map.</source>
 De items zouden nu op uw kaart zichtbaar moeten zijn.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1641"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1639"/>
         <source>Exported {created} of {total} item(s) to CalTopo.{photos}
 
 Details for anything that failed were written to the log (adiat_logs.txt) and the console.</source>
@@ -2208,24 +2189,24 @@ Details for anything that failed were written to the log (adiat_logs.txt) and th
 Details over wat is mislukt, staan in het logbestand (adiat_logs.txt) en de console.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1627"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1628"/>
         <source>Export Successful</source>
         <translation>Export geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1636"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1637"/>
         <source>Partial Success</source>
         <translation>Gedeeltelijk geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1610"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1611"/>
         <source>Export Failed</source>
         <translation>Export mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="718"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1377"/>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1572"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="719"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1378"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1573"/>
         <source>Export Error</source>
         <translation>Exportfout</translation>
     </message>
@@ -2240,7 +2221,7 @@ Details over wat is mislukt, staan in het logbestand (adiat_logs.txt) en de cons
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1057"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1055"/>
         <source>Coverage area: {sqkm:.3f} km² ({acres:.2f} acres)
 Area in square meters: {sqm:.0f} m²
 Number of corners: {count}</source>
@@ -2249,14 +2230,27 @@ Gebied in vierkante meter: {sqm:.0f} m²
 Aantal hoeken: {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1534"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1535"/>
         <source>Exporting to CalTopo</source>
         <translation>Exporteren naar CalTopo</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1265"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1266"/>
         <source>Logged Out</source>
         <translation>Afgemeld</translation>
+    </message>
+    <message>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="598"/>
+        <source>No coverage area polygons could be calculated.
+
+This usually means:
+• The images don&apos;t have GPS data in their EXIF metadata
+• The images are not nadir (gimbal pitch must be between -85° and -95°;
+  WALDO images: boresight within 40° of nadir)
+• GSD (ground sample distance) could not be calculated
+
+Please ensure your images have GPS coordinates and are near-nadir shots.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1267"/>
@@ -2264,17 +2258,17 @@ Aantal hoeken: {count}</translation>
         <translation>Succesvol afgemeld bij CalTopo.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1425"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1426"/>
         <source>Loading CalTopo Maps</source>
         <translation>CalTopo-kaarten laden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1428"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
         <source>Connecting to CalTopo...</source>
         <translation>Verbinden met CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1429"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1430"/>
         <source>Fetching account data and maps...</source>
         <translation>Accountgegevens en kaarten ophalen...</translation>
     </message>
@@ -2293,7 +2287,7 @@ Aantal hoeken: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="695"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="696"/>
         <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1490"/>
         <source>Authentication Failed</source>
         <translation>Authenticatie mislukt</translation>
@@ -2313,7 +2307,7 @@ Aantal hoeken: {count}</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1497"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1492"/>
         <source>CalTopo did not accept these credentials.
 
 The reason was written to the log (adiat_logs.txt) and the console.
@@ -2326,12 +2320,12 @@ De reden is vastgelegd in het logbestand (adiat_logs.txt) en de console.
 Wilt u uw team-ID, referentie-ID en referentiegeheim opnieuw invoeren?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1537"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
         <source>Exporting to CalTopo...</source>
         <translation>Exporteren naar CalTopo...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1538"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CalTopoExportController.py" line="1539"/>
         <source>Preparing data and exporting...</source>
         <translation>Gegevens voorbereiden en exporteren...</translation>
     </message>
@@ -2349,7 +2343,7 @@ Wilt u uw team-ID, referentie-ID en referentiegeheim opnieuw invoeren?</translat
         <translation>CalTopo-exportmethode selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="62"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="61"/>
         <source>Choose how you want to authenticate with CalTopo:</source>
         <translation>Kies hoe u zich bij CalTopo wilt authenticeren:</translation>
     </message>
@@ -2364,7 +2358,7 @@ Wilt u uw team-ID, referentie-ID en referentiegeheim opnieuw invoeren?</translat
         <translation>API (aanbevolen voor CalTopo Team-account)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="77"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="75"/>
         <source>Use CalTopo Team API with service account credentials.
 Best for Teams accounts with service accounts configured.</source>
         <translation>Gebruik de CalTopo Team API met serviceaccount-inloggegevens.
@@ -2376,14 +2370,14 @@ Ideaal voor Team-accounts met geconfigureerde serviceaccounts.</translation>
         <translation>Aanmelden via browser</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="81"/>
         <source>Use browser-based authentication.
 Log in through an embedded browser window.</source>
         <translation>Gebruik browsergebaseerde authenticatie.
 Meld u aan via een ingebed browservenster.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="98"/>
+        <location filename="../app/core/views/images/viewer/dialogs/CalTopoMethodDialog.py" line="96"/>
         <source>API method requires Team ID and Credential Secret from your
 CalTopo Team Admin page. Browser method uses your regular login.</source>
         <translation>De API-methode vereist een Team-ID en inloggegeven-sleutel van uw
@@ -2413,7 +2407,7 @@ CalTopo Team Admin-pagina. De browsermethode gebruikt uw normale aanmelding.</tr
         <translation>Temporeel stemmen inschakelen (flikker verminderen)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="42"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="38"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -2429,7 +2423,7 @@ Aanbevolen: AAN voor alle gebruikssituaties (standaard).</translation>
         <translation>Vensterframes (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="53"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -2447,7 +2441,7 @@ Aanbevolen: 5 voor 30fps (~167ms venster), 7 voor 60fps.</translation>
         <translation>Drempel (N van M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="71"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="66"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -2470,7 +2464,7 @@ Aanbevolen: 3 van 5 (detectie in 60% van de frames).</translation>
         <translation>Filtering van beeldverhouding inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="85"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -2484,7 +2478,7 @@ De meeste gebruikers kunnen dit UIT laten, tenzij u veel lange, smalle valse det
         <translation>Min. verhouding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="104"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="100"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -2500,7 +2494,7 @@ Voorbeeld: 0,2 = wijs af als hoogte meer dan 5x breedte is.</translation>
         <translation>Max. verhouding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="116"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="113"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -2519,7 +2513,7 @@ Hogere waarden = sta bredere objecten toe zoals voertuigen of lange uitrusting.<
         <translation>Detectieclustering inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="131"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="128"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -2533,7 +2527,7 @@ De meeste gebruikers kunnen dit UIT laten, tenzij objecten gefragmenteerd lijken
         <translation>Clusterafstand (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/CleanupTab.py" line="142"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -2562,7 +2556,7 @@ Click to change color</source>
 Klik om kleur te wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="79"/>
+        <location filename="../app/algorithms/Shared/views/HSVColorRowWidget.py" line="78"/>
         <source>HSV: ({h}°, {s}%, {v}%)
 RGB: ({r}, {g}, {b})
 Click to change color</source>
@@ -2609,7 +2603,7 @@ Klik om kleur te wijzigen</translation>
         <translation>Bewegingsdetectie inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="153"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="149"/>
         <source>Turn ON to highlight moving objects in the scene.
 Most users can leave all other settings at their defaults.
 Works best for stationary or slow-moving cameras and can be combined
@@ -2645,7 +2639,7 @@ met kleurgebaseerde afwijkingsdetectie voor robuustere resultaten.</translation>
         <translation>KNN</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="179"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="174"/>
         <source>Motion detection algorithm (advanced setting):
 
 • FRAME_DIFF – Fast and simple; very sensitive to any motion.
@@ -2672,7 +2666,7 @@ Weet u het niet zeker, laat dit op MOG2 staan.</translation>
         <translation>Bewegingsdrempel:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="200"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="196"/>
         <source>Minimum pixel intensity change to consider as motion (1-255).
 Lower values = more sensitive, detects subtle motion, more false positives.
 Higher values = less sensitive, only strong motion, fewer false positives.
@@ -2688,7 +2682,7 @@ Aanbevolen: 10 voor algemeen gebruik, 5 voor subtiele beweging, 15-20 voor scèn
         <translation>Blur-kernel (oneven):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="215"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="210"/>
         <source>Gaussian blur kernel size (must be odd: 1, 3, 5, 7, etc.).
 Smooths the frame before motion detection to reduce noise.
 Larger values = more smoothing, less noise, less detail.
@@ -2706,7 +2700,7 @@ Aanbevolen: 5 voor algemeen gebruik, 1 voor geen blur, 7-9 voor ruisachtige vide
         <translation>Morfologie-kernel:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="230"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="225"/>
         <source>Morphological operation kernel size (odd numbers: 1, 3, 5, etc.).
 Removes small noise and fills holes in detections.
 Larger values = remove more noise, merge nearby detections.
@@ -2729,7 +2723,7 @@ Aanbevolen: 3 voor algemeen gebruik, 1 voor precieze randen, 5-7 voor ruisachtig
         <translation>Vensterframes (M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="251"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="246"/>
         <source>Size of temporal window for persistence filtering (2-30 frames).
 Motion must appear in N out of M consecutive frames to be confirmed.
 Larger values = longer memory, more stable, slower response.
@@ -2747,7 +2741,7 @@ Aanbevolen: 3 voor 30fps-video (100ms venster), 5 voor 60fps.</translation>
         <translation>Drempel (N van M):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="264"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="259"/>
         <source>Number of frames within window where motion must appear (N of M).
 Higher values = more stringent, filters flickering false positives.
 Lower values = more lenient, detects brief/intermittent motion.
@@ -2770,7 +2764,7 @@ Aanbevolen: 2 (beweging in 2 van de laatste 3 frames).</translation>
         <translation>Historieframes:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="285"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="280"/>
         <source>Number of frames to learn background model (10-500).
 Only applies to MOG2 and KNN algorithms.
 Longer history = adapts slower to lighting changes, more stable.
@@ -2788,7 +2782,7 @@ Aanbevolen: 50 (~1,7 sec bij 30fps) voor algemeen gebruik.</translation>
         <translation>Variantiedrempel:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="298"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="293"/>
         <source>Variance threshold for background/foreground classification (1.0-100.0).
 Only applies to MOG2 and KNN algorithms.
 Lower values = more sensitive, detects subtle changes, more false positives.
@@ -2806,7 +2800,7 @@ Aanbevolen: 10,0 voor binnen, 15-20 voor buiten met variërende verlichting.</tr
         <translation>Schaduwen detecteren (langzamer)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="307"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="303"/>
         <source>Enables shadow detection in MOG2 background subtractor.
 Helps distinguish shadows from actual objects (reduces false positives).
 Adds ~10-20% processing overhead.
@@ -2828,7 +2822,7 @@ Aanbevolen: AAN voor buitenscènes met sterke schaduwen, UIT voor snelheid.</tra
         <translation>Min. objectgebied (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="328"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="323"/>
         <source>Minimum detection area in pixels (1-100000).
 Filters out very small detections such as noise, insects, or raindrops.
 Lower values = detect smaller objects (more noise).
@@ -2847,7 +2841,7 @@ Aanbevolen: 5-10 voor beweging ter grootte van een persoon, 50-100 voor voertuig
         <translation>Max. objectgebied (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="341"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="336"/>
         <source>Maximum detection area in pixels (10-1000000).
 Filters out very large regions such as full-frame lighting changes or giant shadows.
 Lower values = only small/medium objects.
@@ -2870,7 +2864,7 @@ Aanbevolen: 1000 voor personen, 10000 voor voertuigen, hoger voor zeer grote obj
         <translation>Pauzeren bij camerabeweging</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="357"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="353"/>
         <source>Automatically pauses motion detection when camera is moving/panning.
 Prevents false positives caused by camera movement (entire scene appears to move).
 Detects camera movement by measuring percentage of frame with motion.
@@ -2886,7 +2880,7 @@ Aanbevolen: AAN voor handheld/drone-beelden, UIT voor stationaire statiefcamera&
         <translation>Drempel:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="371"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="366"/>
         <source>Percentage of frame with motion to consider as camera movement (1-100%).
 If more than this % of pixels show motion, pause detection.
 Lower values = detect camera movement sooner (more pauses).
@@ -2904,7 +2898,7 @@ Aanbevolen: 15% voor drone/handheld, 30% voor schokkerig statief.</translation>
         <translation>Geavanceerde bewegingsinstellingen tonen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="386"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="383"/>
         <source>Advanced users can expand this to adjust the motion algorithm
 and detailed thresholds (sensitivity, filters, background model).
 If you are unsure, leave this unchecked and use the defaults.</source>
@@ -2918,7 +2912,7 @@ Weet u het niet zeker, laat dit uitgevinkt en gebruik de standaardinstellingen.<
         <translation>Kleurgebaseerde afwijkingsdetectie inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="409"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="405"/>
         <source>Detects pixels whose colors are statistically rare in the frame.
 Conceptually similar to MRMap&apos;s rarity-based detection for images.
 Works well for: bright colored clothing, vehicles, equipment in natural scenes.
@@ -2939,7 +2933,7 @@ Kan worden gecombineerd met bewegingsdetectie voor robuustere detectie.</transla
         <translation>Kleurresolutie (bins):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="430"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="424"/>
         <source>Controls how finely colors are grouped into histogram bins (3-8 bits).
 Analogous to MRMap&apos;s color binning.
 Lower values (3-4) = fewer bins → faster, more grouping, fewer but stronger detections.
@@ -2964,7 +2958,7 @@ en hoger alleen wanneer u zeer subtiele kleurverschillen wilt vinden.</translati
         <translation>Zeldzaamheidsdrempel (% van kleuren):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="448"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="442"/>
         <source>Sensitivity threshold for how rare a color must be to be flagged (0-100%).
 Computed from the distribution of color-bin counts in the frame, similar in role
 to MRMap&apos;s detection threshold.
@@ -2979,7 +2973,7 @@ Gemiddelde waarden (25-40%) = gebalanceerd (aanbevolen voor algemeen gebruik).
 Hogere waarden (40-60%) = gevoeliger: omvat meer voorkomende kleuren (meer detecties).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="464"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="459"/>
         <source>Minimum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s minimum AOI area.
 Lower values = detect smaller colored objects (more noise).
@@ -2992,7 +2986,7 @@ Hogere waarden = alleen grotere gekleurde gebieden (minder ruis).
 Aanbevolen: 15 voor doelen ter grootte van een persoon, 50+ voor voertuigen of grote objecten.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="477"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="472"/>
         <source>Maximum area in pixels for a color anomaly to be treated as an object of interest.
 Conceptually matches MRMap&apos;s maximum AOI area.
 Lower values = only detect smaller colored objects.
@@ -3020,7 +3014,7 @@ Aanbevolen: 50000 voor algemeen gebruik, 10000 voor zoekacties met alleen kleine
         <translation>Verbonden componenten</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="491"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="486"/>
         <source>Method for extracting blob regions from the detection mask:
 
 Find Contours: Traditional OpenCV contour detection (default).
@@ -3062,7 +3056,7 @@ Verbonden componenten: gebruikt cv2.connectedComponentsWithStats.
         <translation>LAB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="518"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="509"/>
         <source>Color space for histogram-based anomaly detection:
 
 RGB: Uses all 3 color channels. Fast, but sensitive to lighting.
@@ -3094,7 +3088,7 @@ LAB (a,b chromaticiteit): gebruikt a,b-kanalen - lichtinvariant, perceptueel uni
         <translation>HSV min. verzadiging:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="535"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="529"/>
         <source>Minimum saturation for HSV mode (0-255).
 Pixels below this saturation are ignored (grays, whites, blacks).
 These have undefined/noisy hue values.
@@ -3114,7 +3108,7 @@ Aanbevolen: 30-50 voor algemeen gebruik.</translation>
         <translation>LAB min. chroma:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="555"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="549"/>
         <source>Minimum chroma (color intensity) for LAB mode (0-128).
 Chroma = distance from neutral gray in a,b plane.
 Pixels below this are ignored (near-neutral grays).
@@ -3139,7 +3133,7 @@ Aanbevolen: 10-20 voor algemeen gebruik.</translation>
         <translation>Vergelijkbare kleuren toestaan (tintuitbreiding)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="577"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="573"/>
         <source>Lets the detector treat similar colors as the same object.
 For example, a red jacket that looks slightly orange in some frames will still be grouped together.
 Turn this OFF if you only care about one very specific color shade.
@@ -3155,7 +3149,7 @@ Zet dit AAN als u een hele familie kleuren wilt (bijv. alle warme rood/oranje-ti
         <translation>Kleurovereenkomst-bereik:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="590"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="586"/>
         <source>How wide to stretch the color match around each detected color.
 Smaller values = stay very close to the original color (more specific).
 Larger values = include a wider range of similar colors (more forgiving).
@@ -3181,7 +3175,7 @@ Aanbevolen: lage waarden voor nauwkeurige kleuren, hogere waarden wanneer licht 
         <translation>Kleuruitsluiting inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="609"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="605"/>
         <source>Exclude specific background colors from color anomaly detection.
 Useful for ignoring dominant scene colors such as grass, sky, or buildings.
 Click on the color wheel below to choose colors to ignore.
@@ -3197,7 +3191,7 @@ Geselecteerde kleuren worden gemarkeerd met een donkere rand.</translation>
         <translation>Klik op het kleurwiel om kleuren uit te sluiten (stappen van 20°, 0-360°):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="621"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="618"/>
         <source>Click on any color segment to toggle exclusion on/off.
 Segments represent broad color ranges (e.g., blues, greens, reds).
 Use this to teach the system which background colors to ignore.</source>
@@ -3216,7 +3210,7 @@ Gebruik dit om het systeem te leren welke achtergrondkleuren genegeerd moeten wo
         <translation>Fusie inschakelen (wanneer zowel beweging als kleur zijn ingeschakeld)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="645"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="641"/>
         <source>Combines motion and color detections when both are enabled.
 Only active when both Motion and Color detection are ON.
 Different modes control how detections are merged.
@@ -3252,7 +3246,7 @@ Aanbevolen: AAN voor robuuste multimodale detectie.</translation>
         <translation>BEWEGINGS_PRIORITEIT</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="666"/>
+        <location filename="../app/algorithms/streaming/ColorAnomalyAndMotionDetection/views/ColorAnomalyAndMotionDetectionControlWidget.py" line="657"/>
         <source>How to combine motion and color detections:
 
 • UNION: Show all detections from both (most detections).
@@ -3407,7 +3401,7 @@ agressief</translation>
         <translation>Kleur toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="115"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="111"/>
         <source>Add a new color range to detect.
 Choose from HSV Color Picker, Image, List, or Recent Colors.
 You can add multiple color ranges to detect different colors simultaneously.</source>
@@ -3421,7 +3415,7 @@ U kunt meerdere kleurbereiken toevoegen om verschillende kleuren tegelijk te det
         <translation>Bereik bekijken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="139"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="134"/>
         <source>View HSV color ranges for all configured colors.
 Opens a viewer dialog for each color range showing
 the hue, saturation, and value ranges that will be detected.
@@ -3442,7 +3436,7 @@ Handig om meerkleurendetectie te begrijpen en fijn af te stemmen.</translation>
         <translation>Min. objectgebied (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="190"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="184"/>
         <source>Minimum detection area in pixels (10-50000).
 Filters out very small detections (noise, small objects, fragments).
 Lower values = detect smaller objects, more detections, more noise.
@@ -3460,7 +3454,7 @@ Aanbevolen: 100 voor algemeen gebruik, 50 voor kleine objecten, 200-500 voor gro
         <translation>Max. objectgebied (px):</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="205"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="199"/>
         <source>Maximum detection area in pixels (100-500000).
 Filters out very large detections (shadows, lighting changes, entire scene).
 Lower values = only small/medium objects.
@@ -3478,7 +3472,7 @@ Aanbevolen: 100000 voor algemeen gebruik, 50000 voor kleine objecten, 200000+ vo
         <translation>Betrouwbaarheidsdrempel:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="224"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/views/ColorDetectionControlWidget.py" line="215"/>
         <source>Minimum confidence score to accept a detection (0-100%).
 Confidence is calculated from:
 • Size score: area relative to max area
@@ -3551,7 +3545,7 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>Kleurbereiken: {count} kleuren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="330"/>
+        <location filename="../app/algorithms/streaming/ColorDetection/controllers/ColorDetectionWizardController.py" line="329"/>
         <source>Please add at least one color to detect.</source>
         <translation>Voeg ten minste één kleur toe om te detecteren.</translation>
     </message>
@@ -3564,7 +3558,7 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>Tinthistogram niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="62"/>
+        <location filename="../app/core/controllers/images/viewer/ColorHistogramController.py" line="59"/>
         <source>No color image data is available for the current image.</source>
         <translation>Er zijn geen kleurafbeeldingsgegevens beschikbaar voor de huidige afbeelding.</translation>
     </message>
@@ -3619,14 +3613,14 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>Bereik resetten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="65"/>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="174"/>
         <location filename="../resources/views/images/viewer/ColorHistogramDialog.ui" line="127"/>
         <source>Hover over the histogram to inspect a hue band.</source>
         <translation>Beweeg over het histogram om een tintband te inspecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ColorHistogramDialog.py" line="30"/>
         <source>No hue histogram data available</source>
         <translation>Geen tinthistogramgegevens beschikbaar</translation>
     </message>
@@ -3681,8 +3675,8 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>HSV</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="57"/>
-        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="62"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="56"/>
+        <location filename="../app/algorithms/Shared/views/ColorListDialog.py" line="61"/>
         <source>Uses</source>
         <translation>Toepassingen</translation>
     </message>
@@ -3751,7 +3745,7 @@ Aanbevolen: 50% voor gebalanceerde filtering, 30% voor meer detecties, 70% voor 
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: ({h}°, {s}%, {v}%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="446"/>
+        <location filename="../app/algorithms/Shared/views/ColorPickerImageViewer.py" line="445"/>
         <source>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (hover)</source>
         <translation>RGB: ({r}, {g}, {b}) {hex} | HSV: {h}°, {s}%, {v}% (onder cursor)</translation>
     </message>
@@ -3811,7 +3805,7 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de kleurbereiken 
         <translation>Geen kleuren geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="325"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeController.py" line="324"/>
         <source>Please add at least one color to detect.</source>
         <translation>Voeg ten minste één kleur toe om te detecteren.</translation>
     </message>
@@ -3839,7 +3833,7 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de kleurbereiken 
         <translation>Originele afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="219"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="216"/>
         <source>Original image preview.
 Shows the unmodified input image for reference.
 Use this to compare with the filtered result below.</source>
@@ -3853,7 +3847,7 @@ Gebruik dit om te vergelijken met het gefilterde resultaat hieronder.</translati
         <translation>Gefilterd resultaat</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="232"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="228"/>
         <source>Filtered result preview.
 Shows pixels that match your current HSV color range settings.
 Updates in real-time as you adjust the color and range values.
@@ -3869,7 +3863,7 @@ Overeenkomende pixels worden getoond, niet-overeenkomende pixels verschijnen zwa
         <translation>Alleen masker tonen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="241"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="237"/>
         <source>Toggle between masked color result and grayscale mask.
 • Unchecked (default): Shows the original image with matching colors visible
 • Checked: Shows a black and white mask where white = matching pixels
@@ -3900,7 +3894,7 @@ Gebruik de maskerweergave om duidelijk te zien welke pixels worden gedetecteerd.
         <translation>Testen op afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="273"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="270"/>
         <source>Test current HSV range settings on the loaded image.
 Manually triggers a preview update to see detection results.
 Preview updates automatically as you adjust settings.</source>
@@ -3914,7 +3908,7 @@ Voorvertoning werkt automatisch bij wanneer u instellingen aanpast.</translation
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="284"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="282"/>
         <source>Cancel color selection.
 Discards all changes and closes the dialog without applying the color range.</source>
         <translation>Annuleer kleurselectie.
@@ -3926,7 +3920,7 @@ Gooit alle wijzigingen weg en sluit het dialoogvenster zonder het kleurbereik to
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="292"/>
+        <location filename="../app/algorithms/Shared/views/ColorRangeDialog.py" line="289"/>
         <source>Apply color selection.
 Saves the current HSV color range settings and closes the dialog.
 The selected color range will be used for image analysis.</source>
@@ -4012,7 +4006,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Bereik bekijken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="259"/>
+        <location filename="../app/algorithms/images/ColorRange/controllers/ColorRangeWizardController.py" line="258"/>
         <source>Please add at least one color to detect.</source>
         <translation>Voeg ten minste één kleur toe om te detecteren.</translation>
     </message>
@@ -4096,7 +4090,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Noord-georiënteerde weergave (gedraaid {angle:.1f}°)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="445"/>
+        <location filename="../app/core/controllers/images/viewer/CoordinateController.py" line="444"/>
         <source>Original bearing: {bearing:.1f}° | Rotation applied: {rotation:.1f}°</source>
         <translation>Oorspronkelijke koers: {bearing:.1f}° | Toegepaste rotatie: {rotation:.1f}°</translation>
     </message>
@@ -4144,7 +4138,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Batches aan zoekopdracht toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="79"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="78"/>
         <source>Add more batch XML files to the current search project</source>
         <translation>Meer batch-XML-bestanden toevoegen aan het huidige zoekproject</translation>
     </message>
@@ -4169,7 +4163,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Geselecteerde batch beoordelen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="118"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="116"/>
         <source>Open the selected batch&apos;s results in the Viewer to review (same as double-clicking the batch).</source>
         <translation>Open de resultaten van de geselecteerde batch in de Viewer om ze te beoordelen (hetzelfde als dubbelklikken op de batch).</translation>
     </message>
@@ -4288,7 +4282,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Nog geen beoordelaars</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="315"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="312"/>
         <source>Batch review status and assignments. Load reviewer XMLs to update progress. Double-click a batch to open its results in the Viewer.</source>
         <translation>Status en toewijzingen voor batchcontrole. Laad XML-bestanden van reviewers om de voortgang bij te werken. Dubbelklik op een batch om de resultaten in de Viewer te openen.</translation>
     </message>
@@ -4313,12 +4307,12 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Beoordelingen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="329"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="328"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="350"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="349"/>
         <source>Consolidated AOI data from all reviews. Shows flag counts and reviewer comments.</source>
         <translation>Geconsolideerde AOI-gegevens uit alle beoordelingen. Toont aantallen markeringen en opmerkingen van beoordelaars.</translation>
     </message>
@@ -4338,7 +4332,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Aantal markeringen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="363"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="362"/>
         <source>Comments</source>
         <translation>Opmerkingen</translation>
     </message>
@@ -4348,7 +4342,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Nieuw zoekproject</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="381"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="380"/>
         <source>Enter project name:</source>
         <translation>Voer projectnaam in:</translation>
     </message>
@@ -4358,7 +4352,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Coördinatorinformatie</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="391"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="390"/>
         <source>Enter your name:</source>
         <translation>Voer uw naam in:</translation>
     </message>
@@ -4373,7 +4367,7 @@ Klik op afbeeldingen om ze naar de sectie Geselecteerd hierboven te verplaatsen.
         <translation>Initiële batch-XML-bestanden selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="409"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="403"/>
         <source>You can select multiple ADIAT_Data.xml files from different folders.
 
 Tips:
@@ -4393,11 +4387,11 @@ Tips:
         <translation>Batch ADIAT_Data.xml-bestanden selecteren (houd Ctrl ingedrukt voor meerdere)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="420"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="435"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="559"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="606"/>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="661"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="419"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="434"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="558"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="605"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="660"/>
         <source>XML Files (*.xml)</source>
         <translation>XML-bestanden (*.xml)</translation>
     </message>
@@ -4433,7 +4427,7 @@ Tips:
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="454"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="453"/>
         <source>Failed to save project file.</source>
         <translation>Kan projectbestand niet opslaan.</translation>
     </message>
@@ -4448,12 +4442,12 @@ Tips:
         <translation>Zoekproject openen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="465"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="464"/>
         <source>Search Project Files (ADIAT_Search_*.xml);;All XML Files (*.xml)</source>
         <translation>Zoekprojectbestanden (ADIAT_Search_*.xml);;Alle XML-bestanden (*.xml)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="475"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="474"/>
         <source>Project loaded successfully!</source>
         <translation>Project succesvol geladen!</translation>
     </message>
@@ -4465,12 +4459,12 @@ Tips:
 {path}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="508"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="507"/>
         <source>Failed to load project file.</source>
         <translation>Kan projectbestand niet laden.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="519"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="518"/>
         <source>Project saved successfully!</source>
         <translation>Project succesvol opgeslagen!</translation>
     </message>
@@ -4485,7 +4479,7 @@ Tips:
         <translation>Geen project</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="530"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="529"/>
         <source>Please create or open a project first.</source>
         <translation>Maak of open eerst een project.</translation>
     </message>
@@ -4500,7 +4494,7 @@ Tips:
         <translation>Meer batch-XML-bestanden toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="547"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="540"/>
         <source>Select additional ADIAT_Data.xml batch files to add to this search.
 
 Tips:
@@ -4522,7 +4516,7 @@ Tips:
         <translation>Toe te voegen Batch ADIAT_Data.xml-bestanden selecteren (houd Ctrl ingedrukt voor meerdere)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="581"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="579"/>
         <source>Successfully added {count} batch(es) to the project!
 Total batches: {total}</source>
         <translation>{count} batch(es) succesvol toegevoegd aan het project!
@@ -4534,7 +4528,7 @@ Totaal aantal batches: {total}</translation>
         <translation>Geen batches toegevoegd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="593"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="591"/>
         <source>No batches were added. Check that the XML files are valid ADIAT_Data.xml files.</source>
         <translation>Er zijn geen batches toegevoegd. Controleer of de XML-bestanden geldige ADIAT_Data.xml-bestanden zijn.</translation>
     </message>
@@ -4549,7 +4543,7 @@ Totaal aantal batches: {total}</translation>
         <translation>Geen batches</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="618"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="617"/>
         <source>No batches found in project.</source>
         <translation>Geen batches gevonden in het project.</translation>
     </message>
@@ -4564,12 +4558,12 @@ Totaal aantal batches: {total}</translation>
         <translation>Tot welke batch behoort deze beoordeling?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="643"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="642"/>
         <source>Review data loaded and merged successfully!</source>
         <translation>Beoordelingsgegevens succesvol geladen en samengevoegd!</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="649"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="648"/>
         <source>Failed to load review data.</source>
         <translation>Kan beoordelingsgegevens niet laden.</translation>
     </message>
@@ -4596,7 +4590,7 @@ Totaal aantal batches: {total}</translation>
         <translation>Geen batch geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="760"/>
+        <location filename="../app/core/controllers/coordinator/CoordinatorWindow.py" line="759"/>
         <source>Select a batch in the table, then click Review Selected Batch.</source>
         <translation>Selecteer een batch in de tabel en klik vervolgens op Geselecteerde batch beoordelen.</translation>
     </message>
@@ -4609,7 +4603,7 @@ Totaal aantal batches: {total}</translation>
         <translation>KML van dekkingsomvang genereren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="131"/>
         <source>Generate a KML file showing the geographic coverage extent of all images?
 
 This will create polygon(s) representing the area covered by all images. Overlapping image areas will be merged into a single polygon.</source>
@@ -4623,7 +4617,7 @@ Hiermee worden polygonen gemaakt die het gebied vertegenwoordigen dat door alle 
         <translation>KML van dekkingsomvang opslaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="148"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="147"/>
         <source>KML files (*.kml)</source>
         <translation>KML-bestanden (*.kml)</translation>
     </message>
@@ -4677,7 +4671,7 @@ Hiermee worden polygonen gemaakt die het gebied vertegenwoordigen dat door alle 
         <translation>Dekkingsomvang</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="285"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="278"/>
         <source>Could not calculate coverage extent.
 
 Images processed: {processed}
@@ -4686,36 +4680,29 @@ Images skipped: {skipped}
 Images may be skipped for the following reasons:
   • Missing GPS data in EXIF
   • No valid GSD (missing altitude/focal length)
-  • Gimbal not nadir (must be -85° to -95°)</source>
-        <translation>Kan dekkingsomvang niet berekenen.
-
-Verwerkte afbeeldingen: {processed}
-Overgeslagen afbeeldingen: {skipped}
-
-Afbeeldingen kunnen om de volgende redenen worden overgeslagen:
-  • Ontbrekende GPS-gegevens in EXIF
-  • Geen geldige GSD (ontbrekende hoogte/brandpuntsafstand)
-  • Gimbal niet nadir (moet tussen -85° en -95° zijn)</translation>
+  • Gimbal not nadir (must be -85° to -95°;
+    WALDO: boresight within 40° of nadir)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="300"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="301"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="302"/>
         <source>{value:.2f} acres</source>
         <translation>{value:.2f} acres</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="305"/>
         <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="306"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="307"/>
         <source>{value:.3f} km²</source>
         <translation>{value:.3f} km²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="309"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="310"/>
         <source>Coverage extent KML saved: {area}</source>
         <translation>KML van dekkingsomvang opgeslagen: {area}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="324"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="319"/>
         <source>
 
 Images may be skipped for:
@@ -4730,12 +4717,12 @@ Afbeeldingen kunnen worden overgeslagen vanwege:
   • Gimbal niet nadir</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="327"/>
         <source>Coverage Extent KML Generated</source>
         <translation>KML van dekkingsomvang gegenereerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="334"/>
+        <location filename="../app/core/controllers/images/viewer/exports/CoverageExtentExportController.py" line="329"/>
         <source>Coverage extent KML file created successfully!
 
 File: {file}
@@ -4883,7 +4870,7 @@ miniatuur</translation>
 <context>
     <name>FlightMapView</name>
     <message>
-        <location filename="../app/core/views/components/FlightMapView.py" line="553"/>
+        <location filename="../app/core/views/components/FlightMapView.py" line="550"/>
         <source>QtWebEngine not available — install PySide6-Addons for the interactive map. Showing list view instead.</source>
         <translation type="unfinished">QtWebEngine is niet beschikbaar — installeer PySide6-Addons voor de interactieve kaart. De lijstweergave wordt getoond.</translation>
     </message>
@@ -4942,7 +4929,7 @@ miniatuur</translation>
         <translation>drone heeft {current}/{limit} kijkers</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="99"/>
+        <location filename="../app/core/views/flight/FlightPairingDialog.py" line="98"/>
         <source>known device — same fingerprint as last pair</source>
         <translation>bekend apparaat — zelfde vingerafdruk als bij vorige koppeling</translation>
     </message>
@@ -4991,7 +4978,7 @@ miniatuur</translation>
         <translation>Feed hernoemen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/FlightTile.py" line="526"/>
+        <location filename="../app/core/views/flight/FlightTile.py" line="524"/>
         <source>Nickname for this drone (persists across new pairing codes via the aircraft serial number). Leave blank to clear.</source>
         <translation>Bijnaam voor deze drone (blijft behouden bij nieuwe koppelcodes via het serienummer van de drone). Laat leeg om te wissen.</translation>
     </message>
@@ -5123,7 +5110,7 @@ miniatuur</translation>
 <context>
     <name>FlightTileController</name>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="219"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="218"/>
         <source>Looking up code {code} and connecting to the drone.</source>
         <translation>Code {code} opzoeken en verbinding maken met de drone.</translation>
     </message>
@@ -5133,12 +5120,12 @@ miniatuur</translation>
         <translation>Geef dit apparaat een naam</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="297"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="295"/>
         <source>Give this publisher a name so you can recognise it next time (e.g. &apos;Operator A&apos;s M4E&apos;).</source>
         <translation>Geef deze zender een naam zodat u hem de volgende keer herkent (bijv. &apos;M4E van operator A&apos;).</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="318"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="313"/>
         <source>Device &apos;{label}&apos; presented a different DTLS fingerprint than the last time you paired with it. This could mean the controller was reset, a different controller is using the label, or somebody is impersonating it.
 
 Reject if you weren&apos;t expecting this.</source>
@@ -5147,12 +5134,12 @@ Reject if you weren&apos;t expecting this.</source>
 Wijs af als u dit niet verwachtte.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="483"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="480"/>
         <source>Pairing ended before video could start. Ask the operator to generate a new code and try again.</source>
         <translation>De koppeling eindigde voordat de video kon starten. Vraag de operator een nieuwe code te genereren en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1007"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1006"/>
         <source>Waiting for video before recording can start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5172,7 +5159,7 @@ Wijs af als u dit niet verwachtte.</translation>
         <translation type="unfinished">Opname opgeslagen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1157"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="1156"/>
         <source>No finished recording to replay yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5192,12 +5179,12 @@ Wijs af als u dit niet verwachtte.</translation>
         <translation>Vingerafdruk komt niet overeen — &apos;{label}&apos;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="332"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="330"/>
         <source>Fingerprint changed on {ts}; previous identity was overwritten after operator review.</source>
         <translation>Vingerafdruk gewijzigd op {ts}; de vorige identiteit is overschreven na controle door de operator.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightTileController.py" line="425"/>
+        <location filename="../app/core/controllers/flight/FlightTileController.py" line="422"/>
         <source>This drone already has {current} viewers connected (maximum {limit}). Ask one to disconnect, or try again later.</source>
         <translation>Deze drone heeft al {current} kijkers verbonden (maximum {limit}). Vraag iemand de verbinding te verbreken of probeer het later opnieuw.</translation>
     </message>
@@ -5210,7 +5197,7 @@ Wijs af als u dit niet verwachtte.</translation>
         <translation>Nieuwe vluchtsessie</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="558"/>
+        <location filename="../app/core/controllers/flight/FlightViewerController.py" line="555"/>
         <source>Mobile started a new flight under code {code}. The previous session&apos;s detections are still saved on this computer. Discard them, or keep them archived?</source>
         <translation>Mobile is een nieuwe vlucht gestart met code {code}. De detecties van de vorige sessie staan nog op deze computer. Wilt u ze verwijderen of gearchiveerd bewaren?</translation>
     </message>
@@ -5378,7 +5365,7 @@ Wijs af als u dit niet verwachtte.</translation>
         <translation>Verwerkingsgebiedmasker inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="58"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="55"/>
         <source>Enable to restrict detection processing to a specific region of the video.
 Useful for excluding edges, UI overlays, or focusing on specific areas.
 Improves performance by not processing masked regions.</source>
@@ -5392,7 +5379,7 @@ Verbetert de prestaties door gemaskeerde gebieden niet te verwerken.</translatio
         <translation>Framebuffer inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="72"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="69"/>
         <source>Exclude a uniform border from all edges of the video.
 Enter the number of pixels to exclude from each edge.
 The inner area will be processed for detections.</source>
@@ -5411,7 +5398,7 @@ Het binnengebied wordt verwerkt voor detecties.</translation>
         <translation>Buffer (pixels):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="91"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="87"/>
         <source>Number of pixels to exclude from all edges (0-1000).
 A value of 50 excludes 50 pixels from top, bottom, left, and right.
 Useful for removing UI overlays or camera lens distortion at edges.
@@ -5427,7 +5414,7 @@ Deze waarde is gebaseerd op de oorspronkelijke videoresolutie.</translation>
         <translation>Afbeeldingsmasker inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="102"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="99"/>
         <source>Load a black/white image as a custom mask.
 White areas will be processed, black areas excluded.
 The mask will be scaled to match the video resolution.</source>
@@ -5483,7 +5470,7 @@ Het masker wordt geschaald om overeen te komen met de videoresolutie.</translati
         <translation>Maskeroverlay op video tonen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="145"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="142"/>
         <source>Display the processing region on the rendered video.
 Frame mode: Shows a cyan rectangle outline of the processed area.
 Image mask: Shows a semi-transparent overlay of excluded regions.</source>
@@ -5502,7 +5489,7 @@ Afbeeldingsmasker: toont een semi-transparante overlay van uitgesloten gebieden.
         <translation>{error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="231"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="229"/>
         <source>Could not load the selected image. Please choose a valid image file.</source>
         <translation>Kan de geselecteerde afbeelding niet laden. Kies een geldig afbeeldingsbestand.</translation>
     </message>
@@ -5512,7 +5499,7 @@ Afbeeldingsmasker: toont een semi-transparante overlay van uitgesloten gebieden.
         <translation>Onjuiste beeldverhouding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/FrameTab.py" line="243"/>
+        <location filename="../app/core/views/streaming/components/FrameTab.py" line="240"/>
         <source>{error}
 
 The mask will be scaled to fit, which may cause distortion.
@@ -5533,7 +5520,7 @@ Wilt u doorgaan?</translation>
         <translation>Geen GPS-gegevens gevonden in afbeeldingen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="192"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="191"/>
         <source>POD overlay cleared — the elevation/canopy source changed. Recalculate to refresh it.</source>
         <translation>POD-overlay gewist — de hoogte-/bladerdakbron is gewijzigd. Herbereken om te vernieuwen.</translation>
     </message>
@@ -5548,17 +5535,17 @@ Wilt u doorgaan?</translation>
         <translation>POD-dekking berekenen?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="235"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="234"/>
         <source>Coverage data is ready. Calculate the probability-of-detection heatmap for this mission now? (May take several minutes.)</source>
         <translation>De dekkingsgegevens zijn gereed. Nu de detectiekans-heatmap voor deze missie berekenen? (Kan enkele minuten duren.)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="295"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="293"/>
         <source>Your local USGS 3DEP tiles only partially cover this mission.</source>
         <translation>Uw lokale USGS 3DEP-tegels dekken deze missie slechts gedeeltelijk.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="298"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="296"/>
         <source>Your local USGS 3DEP tiles do not cover this mission.</source>
         <translation>Uw lokale USGS 3DEP-tegels dekken deze missie niet.</translation>
     </message>
@@ -5568,7 +5555,7 @@ Wilt u doorgaan?</translation>
         <translation>Dekking lokale hoogtegegevens</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="304"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="302"/>
         <source>Frames outside the local tiles will use online AWS Terrain Tiles (~30 m) elevation instead. You can download 1 m tiles for this area first, or continue with the fallback.</source>
         <translation>Frames buiten de lokale tegels gebruiken in plaats daarvan online AWS Terrain Tiles-hoogte (~30 m). U kunt eerst 1 m-tegels voor dit gebied downloaden of doorgaan met de fallback.</translation>
     </message>
@@ -5598,7 +5585,7 @@ Wilt u doorgaan?</translation>
         <translation>Kroongegevens downloaden?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="391"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="386"/>
         <source>No canopy-height data is configured for this mission.
 
 Download elevation and canopy tiles for this area now so the canopy overlay and terrain-aware detection coverage can use them?
@@ -5641,7 +5628,7 @@ Hiermee wordt Meta/WRI-kroonhoogte (1 m) gedownload en ingesteld als bron voor k
         <translation>Onbekend</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="603"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="602"/>
         <source>Altitude basis: reported ATO (approximate over terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5683,7 +5670,7 @@ Hiermee wordt Meta/WRI-kroonhoogte (1 m) gedownload en ingesteld als bron voor k
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1300"/>
+        <location filename="../app/core/controllers/images/viewer/GPSMapController.py" line="1297"/>
         <source>Move this AOI to {lat:.6f}, {lon:.6f}?
 
 That is {dist:.1f} m from its previous position. The corrected location is saved with the results and used for exports.</source>
@@ -5804,17 +5791,17 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>POD berekenen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="180"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="179"/>
         <source>Compute the terrain-aware probability-of-detection heatmap for this mission (may take several minutes)</source>
         <translation>Bereken de terreinbewuste detectiekans-heatmap voor deze missie (kan enkele minuten duren)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="189"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="188"/>
         <source>Click point to select • Drag to pan • Scroll to zoom • Drag AOI marker to correct its location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="274"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="273"/>
         <source>Downloading tiles is disabled in Offline Only mode</source>
         <translation>Tegels downloaden is uitgeschakeld in de modus alleen offline</translation>
     </message>
@@ -5839,7 +5826,7 @@ That is {dist:.1f} m from its previous position. The corrected location is saved
         <translation>Probleem met laden van kaarttegels</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="395"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GPSMapDialog.py" line="394"/>
         <source>{error}
 
 The map will continue to work with cached tiles where available.</source>
@@ -5861,12 +5848,12 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1422"/>
         <source>Position corrected by user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1424"/>
+        <location filename="../app/core/views/images/viewer/widgets/GPSMapView.py" line="1423"/>
         <source>Drag to correct the location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5890,7 +5877,7 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
         <translation>AOI</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="411"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="410"/>
         <source>AOIs</source>
         <translation>AOI&apos;s</translation>
     </message>
@@ -5901,12 +5888,12 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
         <translation>{count} {label}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="431"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="430"/>
         <source>Area of Interest</source>
         <translation>Interessegebied</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="433"/>
+        <location filename="../app/core/controllers/images/viewer/gallery/GalleryUIComponent.py" line="432"/>
         <source>Areas of Interest</source>
         <translation>Interessegebieden</translation>
     </message>
@@ -5914,7 +5901,7 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
 <context>
     <name>GeneralSettingsPage</name>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="122"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="121"/>
         <source>Select AOI Highlight Color</source>
         <translation>AOI-markeerkleur selecteren</translation>
     </message>
@@ -5924,7 +5911,7 @@ De kaart blijft werken met gecachete tegels waar beschikbaar.</translation>
         <translation>Benchmark voltooid</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="164"/>
+        <location filename="../app/core/controllers/images/guidePages/GeneralSettingsPage.py" line="161"/>
         <source>Detected {count} CPU core(s).
 
 Recommended number of processes: {recommended}
@@ -5955,7 +5942,7 @@ De schuifregelaar is ingesteld op {recommended} processen.</translation>
         <translation>Raster toepassen op alle afbeeldingen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="326"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="322"/>
         <source>{n} image(s) already have review progress recorded at a different grid size.
 
 Reset their progress and apply {rows}×{cols} to them too?
@@ -5973,7 +5960,7 @@ Ja reset ze; Nee houdt ze op hun huidige grootte.</translation>
         <translation>Afbeelding volledig beoordeeld; doorgaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="629"/>
+        <location filename="../app/core/controllers/images/viewer/grid/GridReviewController.py" line="628"/>
         <source>cell {cell}/{cells} — image {image}/{images} — run {percent}% reviewed</source>
         <translation>cel {cell}/{cells} — afbeelding {image}/{images} — reeks {percent}% beoordeeld</translation>
     </message>
@@ -5981,7 +5968,7 @@ Ja reset ze; Nee houdt ze op hun huidige grootte.</translation>
 <context>
     <name>GridReviewDialog</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/GridReviewDialog.py" line="52"/>
         <source>Suggested: {rows}×{cols} (person ≈ {px} px on screen at cell zoom)</source>
         <translation>Voorstel: {rows}×{cols} (persoon ≈ {px} px op scherm bij celzoom)</translation>
     </message>
@@ -6265,7 +6252,7 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de kleurbereiken 
         <translation>HSV-kleurbereikassistent - Klikselectie</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="709"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="694"/>
         <source>Interactive image viewer with color selection.
 
 NAVIGATION:
@@ -6309,7 +6296,7 @@ WEERGAVE:
         <translation>Bladeren...</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="748"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="743"/>
         <source>Browse for an image file to load.
 Opens a file dialog to select an image from your computer.
 • Supported formats: PNG, JPG, JPEG, BMP
@@ -6327,7 +6314,7 @@ De afbeelding wordt weergegeven in de hoofdviewer aan de linkerkant.</translatio
         <translation>Resetten</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="761"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="755"/>
         <source>Reset all selections and start over.
 • Clears all selected pixels (white overlay)
 • Resets HSV ranges to defaults
@@ -6347,14 +6334,14 @@ Gebruik dit om opnieuw te beginnen zonder de afbeelding opnieuw te laden.</trans
         <translation>Selectiestraal:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="770"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="768"/>
         <source>Size of the circular selection cursor.
 Determines how many pixels are sampled when you CTRL+Click.</source>
         <translation>Grootte van de cirkelvormige selectiecursor.
 Bepaalt hoeveel pixels worden bemonsterd wanneer u CTRL+klikt.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="788"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="777"/>
         <source>Set the selection cursor radius in pixels.
 • Range: 1-50 pixels
 • Default: 1 pixel (single pixel selection)
@@ -6384,14 +6371,14 @@ Sneltoetsen: [ verlaag, ] verhoog met 2 pixels</translation>
         <translation>Kleurtolerantie:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="797"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="795"/>
         <source>HSV color matching tolerance.
 Controls how similar colors must be to get selected.</source>
         <translation>HSV-kleurovereenkomst-tolerantie.
 Bepaalt hoe vergelijkbaar kleuren moeten zijn om geselecteerd te worden.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="817"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="803"/>
         <source>Set color tolerance for similar pixel detection.
 • Range: 0-50
 • Default: 2
@@ -6422,7 +6409,7 @@ Lagere tolerantie:
 • Kan sommige pixels van de doelkleur missen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="826"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="825"/>
         <source>CTRL+Click: Select similar colors | CTRL+SHIFT+Click: Remove | [ ] : Radius</source>
         <translation>CTRL+klik: vergelijkbare kleuren selecteren | CTRL+SHIFT+klik: verwijderen | [ ] : straal</translation>
     </message>
@@ -6432,7 +6419,7 @@ Lagere tolerantie:
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="840"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="833"/>
         <source>Show detailed help and instructions.
 Opens a dialog with:
 • Step-by-step usage instructions
@@ -6454,7 +6441,7 @@ Klik hier als u niet zeker weet hoe u dit hulpmiddel moet gebruiken.</translatio
         <translation>Geselecteerde kleur</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="863"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="861"/>
         <source>Average color of all selected pixels.
 Shows the center/mean color that will be used for HSV range detection.</source>
         <translation>Gemiddelde kleur van alle geselecteerde pixels.
@@ -6466,14 +6453,14 @@ Toont de midden-/gemiddelde kleur die wordt gebruikt voor HSV-bereikdetectie.</t
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="870"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="868"/>
         <source>Visual preview of the average selected color.
 This is the center color calculated from all selected pixels.</source>
         <translation>Visuele voorvertoning van de gemiddeld geselecteerde kleur.
 Dit is de middenkleur berekend uit alle geselecteerde pixels.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="878"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="876"/>
         <source>Color swatch showing the average of all selected pixels.
 This becomes the center color for HSV range detection.</source>
         <translation>Kleurstaal met het gemiddelde van alle geselecteerde pixels.
@@ -6485,14 +6472,14 @@ Dit wordt de middenkleur voor HSV-bereikdetectie.</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="885"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="883"/>
         <source>Hexadecimal representation of the selected color.
 Format: #RRGGBB</source>
         <translation>Hexadecimale weergave van de geselecteerde kleur.
 Formaat: #RRGGBB</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="891"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="889"/>
         <source>Hex color code of the average selected color.
 Can be used to identify the exact RGB color value.</source>
         <translation>Hex-kleurcode van de gemiddeld geselecteerde kleur.
@@ -6504,14 +6491,14 @@ Kan worden gebruikt om de exacte RGB-kleurwaarde te identificeren.</translation>
         <translation>HSV:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="898"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="896"/>
         <source>HSV values of the selected color.
 H = Hue (0-360°), S = Saturation (0-100%), V = Value (0-100%)</source>
         <translation>HSV-waarden van de geselecteerde kleur.
 H = tint (0-360°), S = verzadiging (0-100%), V = waarde (0-100%)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="904"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="902"/>
         <source>HSV color values of the average selected color.
 This is the center point of your color range.</source>
         <translation>HSV-kleurwaarden van de gemiddeld geselecteerde kleur.
@@ -6523,7 +6510,7 @@ Dit is het middenpunt van uw kleurbereik.</translation>
         <translation>HSV-bereiken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="916"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="912"/>
         <source>HSV color range configuration.
 Defines the detection range for each HSV channel.
 Center values are calculated from selected pixels.
@@ -6594,7 +6581,7 @@ Bufferwaarden voegen extra tolerantie toe om kleurvariaties te vangen.</translat
         <translation>Tintkanaal (kleurtype): 0-360 graden op kleurwiel</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="950"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="947"/>
         <source>Center hue value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-360° (red=0°, green=120°, blue=240°)</source>
@@ -6603,7 +6590,7 @@ Automatisch berekend uit uw selectie.
 Bereik: 0-360° (rood=0°, groen=120°, blauw=240°)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="963"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="957"/>
         <source>Hue lower bound buffer (subtract from center).
 • Range: 0-360°
 • Adds tolerance below the center hue
@@ -6618,7 +6605,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 WAARSCHUWING: totaal tintbereik (min + plus) &gt; 60° kan valse positieven veroorzaken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="977"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="971"/>
         <source>Hue upper bound buffer (add to center).
 • Range: 0-360°
 • Adds tolerance above the center hue
@@ -6633,7 +6620,7 @@ WARNING: Total hue range (minus + plus) &gt; 60° may cause false positives</sou
 WAARSCHUWING: totaal tintbereik (min + plus) &gt; 60° kan valse positieven veroorzaken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="986"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="983"/>
         <source>Final hue detection range.
 Shows the complete min-max hue range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6647,7 +6634,7 @@ Berekend als: (midden - min-buffer) tot (midden + plus-buffer)</translation>
         <translation>WAARSCHUWING: een te breed tintbereik kan leiden tot valse positieven!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="998"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="994"/>
         <source>Hue range warning.
 Your total hue range exceeds 60°.
 Wide hue ranges may detect many different colors.
@@ -6668,7 +6655,7 @@ Overweeg de buffers te versmallen voor nauwkeurigere detectie.</translation>
         <translation>Verzadigingskanaal (kleurintensiteit): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1011"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1008"/>
         <source>Center saturation value (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=gray, 100%=vivid color)</source>
@@ -6677,7 +6664,7 @@ Automatisch berekend uit uw selectie.
 Bereik: 0-100% (0%=grijs, 100%=levendige kleur)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1024"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1018"/>
         <source>Saturation lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center saturation
@@ -6692,7 +6679,7 @@ WARNING: Lower bound &lt; 25% may include unwanted gray/desaturated colors</sour
 WAARSCHUWING: ondergrens &lt; 25% kan ongewenste grijze/ontzadigde kleuren bevatten</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1037"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1032"/>
         <source>Saturation upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center saturation
@@ -6705,7 +6692,7 @@ WAARSCHUWING: ondergrens &lt; 25% kan ongewenste grijze/ontzadigde kleuren bevat
 • Hogere verzadiging is over het algemeen veilig om te verhogen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1046"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1043"/>
         <source>Final saturation detection range.
 Shows the complete min-max saturation range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6719,7 +6706,7 @@ Berekend als: (midden - min-buffer) tot (midden + plus-buffer)</translation>
         <translation>WAARSCHUWING: een te laag verzadigingsniveau kan leiden tot valse positieven!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1058"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1054"/>
         <source>Saturation range warning.
 Your lower saturation bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -6740,7 +6727,7 @@ Kan ongewenste grijze of ontzadigde objecten detecteren.</translation>
         <translation>Waardekanaal (helderheid): 0-100%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1071"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1068"/>
         <source>Center value/brightness (average of selected pixels).
 Automatically calculated from your selection.
 Range: 0-100% (0%=black, 100%=bright)</source>
@@ -6749,7 +6736,7 @@ Automatisch berekend uit uw selectie.
 Bereik: 0-100% (0%=zwart, 100%=helder)</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1084"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1078"/>
         <source>Value lower bound buffer (subtract from center).
 • Range: 0-100%
 • Adds tolerance below the center brightness
@@ -6764,7 +6751,7 @@ WARNING: Lower bound &lt; 25% may include unwanted shadows or dark objects</sour
 WAARSCHUWING: ondergrens &lt; 25% kan ongewenste schaduwen of donkere objecten bevatten</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1097"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1092"/>
         <source>Value upper bound buffer (add to center).
 • Range: 0-100%
 • Adds tolerance above the center brightness
@@ -6777,7 +6764,7 @@ WAARSCHUWING: ondergrens &lt; 25% kan ongewenste schaduwen of donkere objecten b
 • Hogere helderheid is over het algemeen veilig om te verhogen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1106"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1103"/>
         <source>Final value/brightness detection range.
 Shows the complete min-max brightness range that will be detected.
 Calculated as: (center - minus buffer) to (center + plus buffer)</source>
@@ -6791,7 +6778,7 @@ Berekend als: (midden - min-buffer) tot (midden + plus-buffer)</translation>
         <translation>WAARSCHUWING: een te laag waardeniveau kan leiden tot valse positieven!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1118"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1114"/>
         <source>Value range warning.
 Your lower value bound is below 25%.
 Low value includes very dark colors.
@@ -6807,7 +6794,7 @@ Kan ongewenste schaduwen of donkere objecten detecteren.</translation>
         <translation>Statistieken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1128"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1126"/>
         <source>Statistics about your current selection.
 Shows how many pixels are selected and what percentage of the image they represent.</source>
         <translation>Statistieken over uw huidige selectie.
@@ -6820,7 +6807,7 @@ Toont hoeveel pixels zijn geselecteerd en welk percentage van de afbeelding ze v
         <translation>Geselecteerde pixels: 0</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1135"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1132"/>
         <source>Number of pixels currently selected.
 Shows the total count of white-highlighted pixels in the main viewer.
 Updates in real-time as you select colors.</source>
@@ -6835,7 +6822,7 @@ Wordt in realtime bijgewerkt terwijl u kleuren selecteert.</translation>
         <translation>Dekking: 0%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1143"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1139"/>
         <source>Percentage of image covered by selection.
 Shows what portion of the total image is selected.
 • Low %: Precise selection, may miss some target pixels
@@ -6851,14 +6838,14 @@ Toont welk deel van de totale afbeelding is geselecteerd.
         <translation>Maskervoorbeeld</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1152"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1150"/>
         <source>Black and white preview of the detection mask.
 Shows what pixels will be detected with current HSV ranges and buffers.</source>
         <translation>Zwart-witvoorvertoning van het detectiemasker.
 Toont welke pixels worden gedetecteerd met de huidige HSV-bereiken en buffers.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1166"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1161"/>
         <source>Grayscale mask preview.
 • White pixels: Will be detected with current settings
 • Black pixels: Will NOT be detected
@@ -6876,7 +6863,7 @@ Gebruik dit om te verifiëren dat uw HSV-bereik het doel vastlegt zonder valse p
         <translation>Afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1180"/>
         <source>Images (*.png *.jpg *.jpeg *.bmp)</source>
         <translation>Afbeeldingen (*.png *.jpg *.jpeg *.bmp)</translation>
     </message>
@@ -6891,7 +6878,7 @@ Gebruik dit om te verifiëren dat uw HSV-bereik het doel vastlegt zonder valse p
         <translation>Dekking: {0:.1f}%</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1503"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVColorRangeAssistant.py" line="1476"/>
         <source>
 &lt;h2&gt;HSV Color Range Assistant - Help&lt;/h2&gt;
 
@@ -6959,8 +6946,8 @@ Klik op de knop BLADEREN om een afbeelding te openen.&lt;/p&gt;
         <translation>Geen kleuren geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="121"/>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="126"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="125"/>
         <source>Add Color</source>
         <translation>Kleur toevoegen</translation>
     </message>
@@ -6970,7 +6957,7 @@ Klik op de knop BLADEREN om een afbeelding te openen.&lt;/p&gt;
         <translation>Tintuitbreiding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="181"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="178"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -6979,7 +6966,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 Pixels met verzadiging onder {1}% of waarde onder {2}% worden uitgesloten.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="469"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeController.py" line="468"/>
         <source>Please add at least one color to detect.</source>
         <translation>Voeg ten minste één kleur toe om te detecteren.</translation>
     </message>
@@ -7010,7 +6997,7 @@ Pixels met verzadiging onder {1}% of waarde onder {2}% worden uitgesloten.</tran
         <translation>Tintuitbreiding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="104"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="101"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -7019,7 +7006,7 @@ Pixels with saturation below {1}% or value below {2}% are excluded.</source>
 Pixels met verzadiging onder {1}% of waarde onder {2}% worden uitgesloten.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="409"/>
+        <location filename="../app/algorithms/images/HSVColorRange/controllers/HSVColorRangeWizardController.py" line="408"/>
         <source>Please add at least one color to detect.</source>
         <translation>Voeg ten minste één kleur toe om te detecteren.</translation>
     </message>
@@ -7048,14 +7035,14 @@ tolerantie:</translation>
         <translation>HEX:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="95"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="93"/>
         <source>Hexadecimal color code input.
 Enter colors as hex codes (e.g., #FF0000 for red).</source>
         <translation>Invoer van hexadecimale kleurcode.
 Voer kleuren in als hex-codes (bijv. #FF0000 voor rood).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="107"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="102"/>
         <source>Enter a hexadecimal color code.
 • Format: #RRGGBB (e.g., #FF0000 for red, #00FF00 for green)
 • Also accepts short format: #RGB (e.g., #F00 for red)
@@ -7073,7 +7060,7 @@ De kleur wordt automatisch geconverteerd naar HSV.</translation>
         <translation>Terugzetten naar standaard</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="120"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="114"/>
         <source>Reset to default color and ranges.
 • Color: Pure red (H:0°, S:100%, V:100%)
 • Hue range: ±20° (total 40° range)
@@ -7093,7 +7080,7 @@ Gebruik dit om opnieuw te beginnen met standaardinstellingen.</translation>
         <translation>Verzadiging / waarde</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="144"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="141"/>
         <source>Saturation and Value (brightness) selector.
 Saturation controls color intensity (left=gray, right=vivid).
 Value controls brightness (bottom=dark, top=bright).</source>
@@ -7102,7 +7089,7 @@ Verzadiging bepaalt de kleurintensiteit (links=grijs, rechts=levendig).
 Waarde bepaalt de helderheid (onder=donker, boven=helder).</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="157"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="149"/>
         <source>Interactive Saturation/Value selector.
 • Click anywhere to set the center color&apos;s saturation and brightness
 • White circle = current center color position
@@ -7126,14 +7113,14 @@ Grotere bereiken detecteren meer kleurvariaties, maar kunnen ongewenste kleuren 
         <translation>Tint</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="171"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="169"/>
         <source>Hue (color type) selector.
 Hue represents the actual color: red, orange, yellow, green, cyan, blue, purple, magenta.</source>
         <translation>Tint (kleurtype)-selector.
 Tint vertegenwoordigt de werkelijke kleur: rood, oranje, geel, groen, cyaan, blauw, paars, magenta.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="184"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="176"/>
         <source>Interactive Hue color ring selector.
 • Click on the ring to select a hue (color type)
 • White line = current center hue
@@ -7157,7 +7144,7 @@ Waarschuwing: tintbereiken breder dan 60° kunnen te veel kleuren detecteren.</t
         <translation>Afbeelding gebruiken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="215"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="208"/>
         <source>Open HSV Color Range Assistant.
 Advanced tool for selecting colors from an image:
 • Load an image from your input folder
@@ -7179,7 +7166,7 @@ Aanbevolen voor het vinden van het beste kleurbereik voor uw doel.</translation>
         <translation>Schermkleur kiezen</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="228"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="222"/>
         <source>Pick a color from anywhere on your screen.
 Opens a color picker that lets you:
 • Click anywhere on your screen to sample a color
@@ -7199,7 +7186,7 @@ Bereiken blijven ongewijzigd - pas handmatig aan na het kiezen.</translation>
         <translation>Toevoegen aan aangepaste kleuren</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="241"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="235"/>
         <source>Save current color to Custom Colors palette.
 Adds the current center color to the first empty slot in Custom Colors.
 • Only saves the color, not the ranges
@@ -7219,7 +7206,7 @@ Nuttig voor het opbouwen van een palet van veelgebruikte kleuren.</translation>
         <translation>Basiskleuren:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="259"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="256"/>
         <source>Preset basic color palette.
 Quick access to common colors like red, orange, yellow, green, cyan, blue, purple, and grayscale.
 Click any color swatch to set it as the center color.</source>
@@ -7228,7 +7215,7 @@ Snelle toegang tot veelvoorkomende kleuren zoals rood, oranje, geel, groen, cyaa
 Klik op een kleurstaal om deze als middenkleur in te stellen.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="269"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="264"/>
         <source>Basic color swatches.
 Click any color to quickly set it as your center color.
 • Top row: Primary colors and tints
@@ -7246,7 +7233,7 @@ Nuttig voor het snel selecteren van standaardkleuren.</translation>
         <translation>Aangepaste kleuren:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="280"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="277"/>
         <source>Your saved custom color palette.
 Colors you&apos;ve saved using &apos;Add to Custom Colors&apos; button.
 Click any saved color to reuse it.</source>
@@ -7255,7 +7242,7 @@ Kleuren die u hebt opgeslagen met de knop &apos;Toevoegen aan aangepaste kleuren
 Klik op een opgeslagen kleur om deze opnieuw te gebruiken.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="291"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="285"/>
         <source>Custom color swatches.
 Click any color to set it as your center color.
 • Empty slots shown as gray
@@ -7270,7 +7257,7 @@ Klik op een kleur om deze als uw middenkleur in te stellen.
 Bouw uw eigen palet van veelgebruikte kleuren.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="464"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="461"/>
         <source>Current HSV color range summary.
 Shows the center color and detection ranges in real-time.
 Warning indicators appear when ranges may cause detection issues.</source>
@@ -7294,7 +7281,7 @@ Waarschuwingen verschijnen wanneer bereiken detectieproblemen kunnen veroorzaken
         <translation>Verz.-bereik:</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="471"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="470"/>
         <source>Val Range:</source>
         <translation>Waardebereik:</translation>
     </message>
@@ -7320,7 +7307,7 @@ Warning shown if lower bound &lt; 25%.</source>
 Waarschuwing getoond als ondergrens &lt; 25%.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="477"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="475"/>
         <source>Value detection range (minus/plus from center).
 Warning shown if lower bound &lt; 25%.</source>
         <translation>Waardedetectiebereik (min/plus vanaf midden).
@@ -7332,7 +7319,7 @@ Waarschuwing getoond als ondergrens &lt; 25%.</translation>
         <translation>⚠ Te breed!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="506"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="502"/>
         <source>Hue range warning.
 Your hue range is wider than 60° total.
 Wide hue ranges may detect too many different colors.
@@ -7349,7 +7336,7 @@ Overweeg het bereik te versmallen voor nauwkeurigere detectie.</translation>
         <translation>⚠ Te laag!</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="519"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="515"/>
         <source>Saturation range warning.
 Your saturation lower bound is below 25%.
 Low saturation includes grayish/washed out colors.
@@ -7360,7 +7347,7 @@ Lage verzadiging omvat grijsachtige/uitgewassen kleuren.
 Kan onbedoelde grijze of ontzadigde kleuren detecteren.</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="532"/>
+        <location filename="../app/algorithms/images/HSVColorRange/views/HSVRangePickerWidget.py" line="528"/>
         <source>Value range warning.
 Your value lower bound is below 25%.
 Low value includes very dark colors.
@@ -7409,7 +7396,7 @@ Kan schaduwen of donkere onbedoelde objecten detecteren.</translation>
         <translation>Hoog (400)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="117"/>
+        <location filename="../app/core/views/images/viewer/dialogs/HeatmapViewerDialog.py" line="114"/>
         <source>Hot zones (colored) show high-density detection areas. Gray zones are below the threshold. Adjust the threshold to control what counts as a hot zone.</source>
         <translation>Hot zones (gekleurd) tonen detectiegebieden met hoge dichtheid. Grijze zones liggen onder de drempel. Pas de drempel aan om te bepalen wat als hot zone telt.</translation>
     </message>
@@ -7783,7 +7770,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>• Brandpuntsafstand is vereist (beschikbaar uit EXIF-gegevens van afbeelding)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="486"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="485"/>
         <source>GSD calculation requires an actual image file to extract focal length.</source>
         <translation>GSD-berekening vereist een werkelijk afbeeldingsbestand om de brandpuntsafstand te extraheren.</translation>
     </message>
@@ -7803,7 +7790,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Primair</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="529"/>
+        <location filename="../app/core/controllers/images/guidePages/ImageCapturePage.py" line="527"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
@@ -7844,7 +7831,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Aangepast</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="65"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="61"/>
         <source>Select a preset resolution for processing. Lower resolutions are faster but less detailed.
 &apos;Original&apos; uses the video&apos;s native resolution (no downsampling).
 720P (1280x720) provides excellent balance between speed and detection accuracy.
@@ -7860,7 +7847,7 @@ Selecteer &apos;Aangepast&apos; om breedte en hoogte handmatig in te stellen.</t
         <translation>Breedte:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="81"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="78"/>
         <source>Custom processing width in pixels (320-3840).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7874,7 +7861,7 @@ Lagere waarden = snellere verwerking, minder detail.</translation>
         <translation>Hoogte:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="94"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="91"/>
         <source>Custom processing height in pixels (240-2160).
 Only enabled when &apos;Custom&apos; resolution is selected.
 Lower values = faster processing, less detail.</source>
@@ -7898,7 +7885,7 @@ Lagere waarden = snellere verwerking, minder detail.</translation>
         <translation>Bron-FPS</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="143"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="133"/>
         <source>Limit the frame rate for processing.
 
 • Source FPS - Follow the source cadence (live sources may apply a safety cap)
@@ -7930,7 +7917,7 @@ Detecties blijven behouden tussen overgeslagen frames voor visuele continuïteit
         <translation>Renderen op verwerkingsresolutie (sneller voor hoge resolutie)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="155"/>
+        <location filename="../app/core/views/streaming/components/InputProcessingTab.py" line="151"/>
         <source>Renders detection overlays at processing resolution instead of original video resolution.
 Significantly faster for high-resolution videos (1080p+) with minimal visual impact.
 Example: Processing at 720p but video is 4K - renders at 720p then upscales.
@@ -8180,7 +8167,7 @@ Lagere waarden = gevoeliger detectie.</translation>
         <translation>Drempeluitbreiding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="53"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="50"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8194,7 +8181,7 @@ pixels erbuiten worden toegevoegd als ze verbonden zijn via andere geschikte pix
         <translation>Tintuitbreiding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="62"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapController.py" line="59"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -8273,7 +8260,7 @@ agressief</translation>
         <translation>Drempeluitbreiding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="72"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="69"/>
         <source>When enabled, expand each AOI to also include pixels with histogram bin-counts
 below (threshold + {0}). Pixels inside the cluster rectangle are added unconditionally;
 pixels outside are added if they are connected through other qualifying pixels.</source>
@@ -8287,7 +8274,7 @@ pixels erbuiten worden toegevoegd als ze verbonden zijn via andere geschikte pix
         <translation>Tintuitbreiding</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="81"/>
+        <location filename="../app/algorithms/images/MRMap/controllers/MRMapWizardController.py" line="78"/>
         <source>When enabled, expand each AOI through neighbors whose hue is within +/- {0}
 (OpenCV units) of the mean hue of the original detected pixels.
 Pixels with saturation below {1}% or value below {2}% are excluded.</source>
@@ -9306,12 +9293,12 @@ Stel vragen, meld problemen en stel nieuwe functies voor.</translation>
         <translation>YouTube-kanaal</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="90"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="89"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Geautomatiseerd drone-beeldanalyse-instrument v{version} - Gesponsord door TEXSAR</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="326"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="288"/>
         <source>Select the detection algorithm for your image analysis task:
 
 HSV COLOR RANGE: Detects brightly colored objects (clothing, vehicles, tents)
@@ -9388,7 +9375,7 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
   • Beperking: detecteert alleen personen, langzamere verwerking</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="385"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="384"/>
         <source>Select AOI Highlight Color</source>
         <translation>AOI-markeerkleur selecteren</translation>
     </message>
@@ -9404,7 +9391,7 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>Een referentie-afbeelding selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="436"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="435"/>
         <source>Images (*.png *.jpg)</source>
         <translation>Afbeeldingen (*.png *.jpg)</translation>
     </message>
@@ -9415,21 +9402,21 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>Waarde aangepast</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="500"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="498"/>
         <source>Maximum area has been adjusted to {value} pixels to maintain valid range.
 (Minimum area must be less than maximum area)</source>
         <translation>Het maximale gebied is aangepast naar {value} pixels om een geldig bereik te behouden.
 (Minimumgebied moet kleiner zijn dan maximumgebied)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="532"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="530"/>
         <source>Minimum area has been adjusted to {value} pixels to maintain valid range.
 (Maximum area must be greater than minimum area)</source>
         <translation>Het minimale gebied is aangepast naar {value} pixels om een geldig bereik te behouden.
 (Maximumgebied moet groter zijn dan minimumgebied)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="645"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="644"/>
         <source>Please set the input and output directories.</source>
         <translation>Stel de invoer- en uitvoermappen in.</translation>
     </message>
@@ -9439,12 +9426,12 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>--- Beeldverwerking starten ---</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="886"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="885"/>
         <source>Could not parse XML file. Check file paths in &quot;{file_name}&quot;</source>
         <translation>Kan XML-bestand niet parseren. Controleer bestandspaden in &quot;{file_name}&quot;</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="909"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="908"/>
         <source>Area of Interest Limit ({limit}) exceeded. Continue?</source>
         <translation>Limiet voor interessegebieden ({limit}) overschreden. Doorgaan?</translation>
     </message>
@@ -9507,7 +9494,7 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>Bestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1155"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1154"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>XML-bestanden (*.xml);;Alle bestanden (*)</translation>
     </message>
@@ -9527,7 +9514,7 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>Geen resultaten gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1232"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1231"/>
         <source>No ADIAT_DATA.XML files were found in the selected folder.</source>
         <translation>Er zijn geen ADIAT_DATA.XML-bestanden gevonden in de geselecteerde map.</translation>
     </message>
@@ -9611,12 +9598,12 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation> Zoekcoördinator openen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1779"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1778"/>
         <source>Open the Search Coordinator to review every batch in this run.</source>
         <translation>Open de Zoekcoördinator om elke batch in deze run te beoordelen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/MainWindow.py" line="1785"/>
+        <location filename="../app/core/controllers/images/MainWindow.py" line="1784"/>
         <source>Open the Results Viewer to review detection results.</source>
         <translation>Open de resultatenviewer om detectieresultaten te beoordelen.</translation>
     </message>
@@ -9727,7 +9714,7 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>POD-dekkingsheatmap (terreinbewust)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="107"/>
         <source>Compute a terrain and canopy aware probability-of-detection raster for the whole mission (all non-hidden images, independent of the selections above). KML exports embed the heatmap in the KML/KMZ as an image overlay; the GeoTIFF products (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json) are also written — the GeoTIFF can be imported into CalTopo Map Sheets. May take several minutes.</source>
         <translation>Berekent een terrein- en bladerdakbewust detectiekans-raster voor de hele missie (alle niet-verborgen afbeeldingen, onafhankelijk van de selecties hierboven). KML-exports sluiten de heatmap als afbeeldingsoverlay in het KML/KMZ-bestand in; de GeoTIFF-producten (coverage_pod.tif, coverage_looks.tif, coverage_gaps.geojson, stats.json) worden ook geschreven — de GeoTIFF kan in CalTopo Map Sheets worden geïmporteerd. Kan enkele minuten duren.</translation>
     </message>
@@ -9772,7 +9759,7 @@ AI-PERSOONSDETECTOR: deep-learning model voor nauwkeurige persoonsdetectie
         <translation>Beide</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="145"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MapExportDialog.py" line="142"/>
         <source>Large Image uploads the same multi-zoom composite used in the PDF report
 (full image with 3x and 6x insets). AOI Thumbnail uploads a zoomed crop
 centered on the detection. Both uploads each.</source>
@@ -9841,7 +9828,7 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de drempels te op
         <translation>Geen kleuren geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="300"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterController.py" line="299"/>
         <source>Please add at least one color to detect.</source>
         <translation>Voeg ten minste één kleur toe om te detecteren.</translation>
     </message>
@@ -9867,7 +9854,7 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de drempels te op
         <translation>Bereik bekijken</translation>
     </message>
     <message>
-        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="219"/>
+        <location filename="../app/algorithms/images/MatchedFilter/controllers/MatchedFilterWizardController.py" line="218"/>
         <source>Please add at least one target color to detect.</source>
         <translation>Voeg ten minste één doelkleur toe om te detecteren.</translation>
     </message>
@@ -9886,7 +9873,7 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de drempels te op
         <translation>Schaduw meten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="90"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="87"/>
         <source>When checked, the two clicks estimate the height of a vertical object from its shadow. Click the base of the object first, then the tip of its shadow.</source>
         <translation>Indien ingeschakeld schatten de twee klikken de hoogte van een verticaal object op basis van de schaduw. Klik eerst op de basis van het object en daarna op de punt van de schaduw.</translation>
     </message>
@@ -9937,17 +9924,17 @@ Gebruik dit om te zien welke kleuren worden gedetecteerd en om de drempels te op
         <translation>Toch gebruiken</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="140"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="137"/>
         <source>Force the estimate with the current base/tip clicks even though the drawn line doesn&apos;t match the expected shadow direction. Use only when you&apos;re confident the geometry is correct.</source>
         <translation>Forceer de schatting met de huidige basis-/puntklikken, ook al komt de getekende lijn niet overeen met de verwachte schaduwrichting. Gebruik dit alleen als u zeker weet dat de geometrie klopt.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="181"/>
         <source>Click the BASE of the object first, then the TIP of its shadow.</source>
         <translation>Klik eerst op de BASIS van het object en daarna op de PUNT van de schaduw.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="187"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="185"/>
         <source>Click on the image to place the first point,
 then click again to place the second point.</source>
         <translation>Klik op de afbeelding om het eerste punt te plaatsen,
@@ -9975,7 +9962,7 @@ klik daarna nogmaals om het tweede punt te plaatsen.</translation>
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="467"/>
-        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="554"/>
+        <location filename="../app/core/views/images/viewer/dialogs/MeasureDialog.py" line="553"/>
         <source>Rejected</source>
         <translation>Afgewezen</translation>
     </message>
@@ -10107,7 +10094,7 @@ klik daarna nogmaals om het tweede punt te plaatsen.</translation>
         <translation type="unfinished">Onbekend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="177"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOINeighborGalleryDialog.py" line="175"/>
         <source> (Current)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10129,7 +10116,7 @@ klik daarna nogmaals om het tweede punt te plaatsen.</translation>
         <translation>Geen afbeeldingen om te exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="156"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="153"/>
         <source>There are no images available to include in the PDF report.
 
 All images may be hidden or there are no images in the dataset.</source>
@@ -10138,7 +10125,7 @@ All images may be hidden or there are no images in the dataset.</source>
 Mogelijk zijn alle afbeeldingen verborgen of bevat de dataset geen afbeeldingen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="166"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="162"/>
         <source>There are no images with flagged AOIs to include in the PDF report.
 
 Please flag at least one AOI, or check &apos;Include images without flagged AOIs&apos; to include all images in the report.</source>
@@ -10152,7 +10139,7 @@ Markeer ten minste één AOI of vink &apos;Afbeeldingen zonder gemarkeerde AOI&a
         <translation>PDF-bestand opslaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="175"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="174"/>
         <source>PDF files (*.pdf)</source>
         <translation>PDF-bestanden (*.pdf)</translation>
     </message>
@@ -10177,7 +10164,7 @@ Markeer ten minste één AOI of vink &apos;Afbeeldingen zonder gemarkeerde AOI&a
         <translation>Geslaagd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="278"/>
+        <location filename="../app/core/controllers/images/viewer/exports/PDFExportController.py" line="277"/>
         <source>PDF report generated successfully!</source>
         <translation>PDF-rapport succesvol gegenereerd!</translation>
     </message>
@@ -10235,7 +10222,7 @@ Markeer ten minste één AOI of vink &apos;Afbeeldingen zonder gemarkeerde AOI&a
         <translation>Afbeeldingen zonder gemarkeerde AOI&apos;s opnemen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="64"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PDFExportDialog.py" line="62"/>
         <source>When checked, all images will be included in the PDF report, even if they don&apos;t have any flagged AOIs. When unchecked, only images with flagged AOIs will be included.</source>
         <translation>Indien aangevinkt, worden alle afbeeldingen opgenomen in het PDF-rapport, ook als ze geen gemarkeerde AOI&apos;s hebben. Indien uitgevinkt, worden alleen afbeeldingen met gemarkeerde AOI&apos;s opgenomen.</translation>
     </message>
@@ -10280,7 +10267,7 @@ Markeer ten minste één AOI of vink &apos;Afbeeldingen zonder gemarkeerde AOI&a
   ... en nog {count}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="134"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="131"/>
         <source>{count} source image(s) not found at expected locations:
 
 {files}
@@ -10308,7 +10295,7 @@ Selecteer de map die de bronafbeeldingen bevat.</translation>
         <translation>Sommige afbeeldingen ontbreken nog</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="168"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="165"/>
         <source>{count} detection mask(s) not found at expected locations:
 
 {files}
@@ -10326,7 +10313,7 @@ Selecteer de map die de maskerbestanden bevat.</translation>
         <translation>Detectiemaskers niet gevonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="140"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="138"/>
         <source>Found {found} of {total} images.
 
 Still missing:
@@ -10337,7 +10324,7 @@ Nog ontbrekend:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="145"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="142"/>
         <source>None of the {total} missing images were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10358,7 +10345,7 @@ Verwachte bestandsnamen:
         <translation>Sommige maskers ontbreken nog</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="174"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="172"/>
         <source>Found {found} of {total} masks.
 
 Still missing:
@@ -10369,7 +10356,7 @@ Nog ontbrekend:
 {missing}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="179"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="176"/>
         <source>None of the {total} missing masks were found in that folder (including its subfolders).
 
 Expected to find files named:
@@ -10390,7 +10377,7 @@ Verwachte bestandsnamen:
         <translation>Toch doorgaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="414"/>
+        <location filename="../app/core/controllers/images/viewer/path/PathValidationController.py" line="410"/>
         <source>
 
 {count} of these appear more than once in that folder, so which capture they belong to cannot be determined:
@@ -10438,7 +10425,7 @@ Choose the specific flight/sortie folder rather than a folder containing several
         <translation>Terreinhoogte gebruiken (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="363"/>
         <source>Rotate the person on the ground to line it up with an object</source>
         <translation>Draai de persoon op de grond om deze met een object uit te lijnen</translation>
     </message>
@@ -10474,173 +10461,193 @@ Choose the specific flight/sortie folder rather than a folder containing several
     </message>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="402"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1247"/>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1254"/>
+        <source>Flight track log...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="404"/>
+        <source>Attach a ForeFlight track log CSV to stamp true aircraft attitude (bank/pitch) and GPS-accurate capture times onto these images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="411"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1364"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1371"/>
         <source>Trace shadow...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="406"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
         <source>Derive the time of day from a real shadow: click the base of an object casting a shadow (rock, tree, post), then the tip of its shadow. The solved time drives the rendered shadows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="413"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="419"/>
         <source>Drag the white handle to position the reference person. Silhouettes are drawn at true ground scale for this image&apos;s altitude and camera angle.</source>
         <translation>Sleep de witte greep om de referentiepersoon te plaatsen. Silhouetten worden op ware terreinschaal getekend voor de hoogte en camerahoek van deze afbeelding.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="427"/>
         <source>Recenter</source>
         <translation>Centreren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="420"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="429"/>
         <source>Bring the reference person to the center of the current view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="421"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="430"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="487"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="497"/>
         <source>No camera clock fault or applied correction was found for this folder.</source>
         <translation>Er is geen cameraklokfout of toegepaste correctie gevonden voor deze map.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="539"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="596"/>
+        <source>Select ForeFlight track log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="598"/>
+        <source>Track logs (*.csv);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="653"/>
         <source>Perspective overlay unavailable: this image is missing the altitude or lens metadata needed to project a person.</source>
         <translation>Perspectiefoverlay niet beschikbaar: deze afbeelding mist de hoogte- of lensmetadata die nodig zijn om een persoon te projecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="595"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="709"/>
         <source>Zoomed to the reference person: at this altitude a person spans only a few pixels.</source>
         <translation>Ingezoomd op de referentiepersoon: op deze hoogte beslaat een persoon slechts enkele pixels.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="638"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="753"/>
         <source>no image loaded</source>
         <translation>geen afbeelding geladen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="643"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="758"/>
         <source>image metadata could not be read</source>
         <translation>afbeeldingsmetadata konden niet worden gelezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="647"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="762"/>
         <source>image has no GPS coordinates</source>
         <translation>afbeelding heeft geen GPS-coördinaten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="659"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="774"/>
         <source>capture time / timezone not in metadata</source>
         <translation>opnametijd / tijdzone ontbreekt in metadata</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="670"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="785"/>
         <source>sun position could not be computed</source>
         <translation>zonnestand kon niet worden berekend</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="684"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="799"/>
         <source>Sun at capture: {elev:.0f}° above horizon, azimuth {az:.0f}°.</source>
         <translation>Zon bij opname: {elev:.0f}° boven de horizon, azimut {az:.0f}°.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="688"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="804"/>
         <source>Capture time zone estimated from GPS location.</source>
         <translation>Tijdzone van opname geschat op basis van GPS-locatie.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="691"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="807"/>
         <source>Using repaired capture time (camera clock fault).</source>
         <translation>Gecorrigeerde opnametijd wordt gebruikt (cameraklokfout).</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="694"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="810"/>
         <source>Time of day derived from the traced shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="699"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="815"/>
         <source>the sun was below the horizon at capture</source>
         <translation>de zon stond tijdens de opname onder de horizon</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="701"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="817"/>
         <source>sun position unavailable</source>
         <translation>zonnestand niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="702"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="818"/>
         <source>Shadow unavailable: {reason}.</source>
         <translation>Schaduw niet beschikbaar: {reason}.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="801"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="917"/>
         <source>Place the person and shadow on the DEM terrain surface</source>
         <translation>Plaats de persoon en schaduw op het DEM-terreinoppervlak</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="805"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="921"/>
         <source>Terrain (DEM) data is not available for this image</source>
         <translation>Terreingegevens (DEM) zijn niet beschikbaar voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1065"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1181"/>
         <source>Choose Overlay Color</source>
         <translation>Overlaykleur kiezen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1222"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1339"/>
         <source>Cancel trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1341"/>
         <source>Shadow trace: on the image, click the BASE of an object casting a shadow (rock, tree, post), then click the TIP of its shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1265"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1382"/>
         <source>Shadow trace: now click the TIP of the shadow.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1351"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1467"/>
         <source>Shadow trace: the traced points could not be projected to the ground - try two points further apart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1357"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1473"/>
         <source>Shadow trace: the image is missing the capture date or GPS position needed to solve the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1373"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1488"/>
         <source>Shadow trace: no daylight sun position matches that direction on the capture date. Check the traced direction (base first, then shadow tip).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1376"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1493"/>
         <source>Clear traced time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1380"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1495"/>
         <source>Time solved from the traced shadow: {time} (sun azimuth {az:.0f}°, {elev:.0f}° above horizon).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1387"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1502"/>
         <source>The traced direction looked reversed and was interpreted tip-to-base.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1391"/>
+        <location filename="../app/core/views/images/viewer/dialogs/PersonReferenceDialog.py" line="1506"/>
         <source>Note: another time of day matches this direction almost as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11049,7 +11056,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Taal:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="105"/>
+        <location filename="../app/core/controllers/Preferences.py" line="104"/>
         <source>AWS Terrain Tiles (online, ~30 m) is always available as the baseline; local USGS 3DEP adds 1 m detail where downloaded.</source>
         <translation>AWS Terrain Tiles (online, ~30 m) is altijd beschikbaar als basis; lokale USGS 3DEP voegt 1 m detail toe waar gedownload.</translation>
     </message>
@@ -11090,8 +11097,8 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Map met de GeoTIFF-tegels</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="146"/>
-        <location filename="../app/core/controllers/Preferences.py" line="400"/>
+        <location filename="../app/core/controllers/Preferences.py" line="145"/>
+        <location filename="../app/core/controllers/Preferences.py" line="399"/>
         <source>3DEP is inactive until both paths are set — the AWS Terrain Tiles baseline is used. Use Download tiles… or Browse.</source>
         <translation>3DEP is inactief totdat beide paden zijn ingesteld — de AWS Terrain Tiles-basis wordt gebruikt. Gebruik Tegels downloaden… of Bladeren.</translation>
     </message>
@@ -11116,8 +11123,8 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Pad naar de kroon-manifest-CSV</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="230"/>
-        <location filename="../app/core/controllers/Preferences.py" line="480"/>
+        <location filename="../app/core/controllers/Preferences.py" line="229"/>
+        <location filename="../app/core/controllers/Preferences.py" line="479"/>
         <source>Canopy is disabled until both paths are set — use Download tiles… or Browse.</source>
         <translation>Kroon is uitgeschakeld totdat beide paden zijn ingesteld — gebruik Tegels downloaden… of Bladeren.</translation>
     </message>
@@ -11127,7 +11134,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Tegels downloaden...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="242"/>
+        <location filename="../app/core/controllers/Preferences.py" line="241"/>
         <source>Download DEM and/or canopy tiles for an area of interest and register them here. Note: the canopy download uses Meta/WRI data and registers it as the canopy source.</source>
         <translation>Download DEM- en/of kroontegels voor een interessegebied en registreer ze hier. Let op: de kroondownload gebruikt Meta/WRI-gegevens en registreert die als kroonbron.</translation>
     </message>
@@ -11138,7 +11145,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>{version}_{date}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="406"/>
+        <location filename="../app/core/controllers/Preferences.py" line="405"/>
         <source>The registered 3DEP files no longer exist on disk — the AWS Terrain Tiles baseline is used. Re-download or fix the paths.</source>
         <translation>De geregistreerde 3DEP-bestanden bestaan niet meer op schijf — de AWS Terrain Tiles-basis wordt gebruikt. Download opnieuw of corrigeer de paden.</translation>
     </message>
@@ -11159,7 +11166,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Map met 3DEP-tegels selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="486"/>
+        <location filename="../app/core/controllers/Preferences.py" line="485"/>
         <source>The registered canopy files no longer exist on disk — canopy is disabled. Re-download or fix the paths.</source>
         <translation>De geregistreerde bladerdakbestanden bestaan niet meer op schijf — bladerdak is uitgeschakeld. Download opnieuw of corrigeer de paden.</translation>
     </message>
@@ -11208,7 +11215,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="625"/>
+        <location filename="../app/core/controllers/Preferences.py" line="624"/>
         <source>Terrain service not available.</source>
         <translation>Terreinservice niet beschikbaar.</translation>
     </message>
@@ -11218,7 +11225,7 @@ Alle wijzigingen worden automatisch opgeslagen wanneer ze worden gewijzigd.</tra
         <translation>Terreincache wissen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="634"/>
+        <location filename="../app/core/controllers/Preferences.py" line="632"/>
         <source>Are you sure you want to clear all cached terrain elevation data?
 
 This will require re-downloading tiles when terrain elevation is used.</source>
@@ -11247,7 +11254,7 @@ Hierdoor moeten tegels opnieuw worden gedownload wanneer terreinhoogte wordt geb
         <translation>Een dronesensorbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="662"/>
+        <location filename="../app/core/controllers/Preferences.py" line="661"/>
         <source>CSV Files (*.csv)</source>
         <translation>CSV-bestanden (*.csv)</translation>
     </message>
@@ -11257,7 +11264,7 @@ Hierdoor moeten tegels opnieuw worden gedownload wanneer terreinhoogte wordt geb
         <translation>Herstart vereist</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/Preferences.py" line="689"/>
+        <location filename="../app/core/controllers/Preferences.py" line="688"/>
         <source>Please restart the application for language changes to take effect.</source>
         <translation>Start de applicatie opnieuw om taalwijzigingen door te voeren.</translation>
     </message>
@@ -11632,7 +11639,7 @@ agressief</translation>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="64"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="55"/>
         <source>Shape to draw around detections:
 
 • Box: Rectangle around detection bounding box.
@@ -11671,7 +11678,7 @@ agressief</translation>
         <translation>Tekstlabels tonen (langzamer)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="79"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="75"/>
         <source>Displays text labels near detections showing detection information.
 Adds ~5-15ms processing overhead depending on detection count.
 Labels show: detection type, confidence, area.
@@ -11687,7 +11694,7 @@ Aanbevolen: UIT voor snelheid, AAN voor debugging/analyse.</translation>
         <translation>Contouren tonen (langzaamst)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="88"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="84"/>
         <source>Draws exact detection contours (pixel-precise boundaries).
 Adds ~10-20ms processing overhead (very expensive).
 Shows exact shape detected by algorithm.
@@ -11703,7 +11710,7 @@ Aanbevolen: UIT voor snelheid, AAN alleen voor gedetailleerde analyse.</translat
         <translation>Detectiekleur gebruiken (tint bij 100% verz./waarde voor kleurafwijkingen)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="100"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="95"/>
         <source>Color the detection overlay based on detected color.
 For color anomalies: Uses the detected hue at 100% saturation/value.
 For motion detections: Uses default color (green/blue).
@@ -11726,7 +11733,7 @@ Aanbevolen: AAN voor kleurdetectie, UIT voor alleen beweging.</translation>
         <translation>Max. detecties:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="120"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="115"/>
         <source>Maximum number of detections to render on screen (0-1000).
 Prevents rendering slowdown when hundreds of detections occur.
 Shows highest confidence detections first.
@@ -11749,7 +11756,7 @@ Aanbevolen: 10 voor algemeen gebruik, 50 voor complex renderen (tekst+contouren)
         <translation>Temporeel stemmen inschakelen (flikker verminderen)</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="136"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="132"/>
         <source>Smooths detections across frames using temporal consistency.
 Detections must appear in N out of M consecutive frames to be confirmed.
 Significantly reduces flickering false positives.
@@ -11765,7 +11772,7 @@ Aanbevolen: AAN voor alle gebruikssituaties (standaard).</translation>
         <translation>Vensterframes (M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="152"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="147"/>
         <source>Size of temporal voting window (2-30 frames).
 Detections must appear in N out of M consecutive frames.
 Larger values = longer memory, more stable, slower response to new objects.
@@ -11783,7 +11790,7 @@ Aanbevolen: 5 voor 30fps (~167ms venster), 7 voor 60fps.</translation>
         <translation>Drempel (N van M):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="165"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="160"/>
         <source>Number of frames within window where detection must appear (N of M).
 Higher values = more stringent, filters transient false positives.
 Lower values = more lenient, faster response to new objects.
@@ -11806,7 +11813,7 @@ Aanbevolen: 3 van 5 (detectie in 60% van de frames).</translation>
         <translation>Filtering van beeldverhouding inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="183"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="180"/>
         <source>Filter out very thin or stretched detections based on width/height.
 Useful for removing wires, long shadows, or other non-object shapes.
 Most users can leave this OFF unless you see many long skinny false detections.</source>
@@ -11820,7 +11827,7 @@ De meeste gebruikers kunnen dit UIT laten, tenzij u veel lange, smalle valse det
         <translation>Min. verhouding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="199"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="195"/>
         <source>Minimum width/height ratio to keep (0.1-10.0).
 Lower values = allow taller, thinner detections.
 Higher values = require detections to be more square.
@@ -11836,7 +11843,7 @@ Voorbeeld: 0,2 ≈ wijs af als hoogte meer dan 5× breedte is.</translation>
         <translation>Max. verhouding:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="211"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="208"/>
         <source>Maximum width/height ratio to keep (0.1-20.0).
 Lower values = reject very wide, thin detections.
 Higher values = allow wider objects such as vehicles or long equipment.</source>
@@ -11855,7 +11862,7 @@ Hogere waarden = sta bredere objecten toe zoals voertuigen of lange uitrusting.<
         <translation>Detectieclustering inschakelen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="226"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="223"/>
         <source>Optionally merge nearby detections into a single, larger detection.
 Useful when one object appears as many small adjacent detections.
 Most users can leave this OFF unless objects look fragmented.</source>
@@ -11869,7 +11876,7 @@ De meeste gebruikers kunnen dit UIT laten, tenzij objecten gefragmenteerd lijken
         <translation>Clusterafstand (px):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="240"/>
+        <location filename="../app/core/views/streaming/components/RenderingTab.py" line="237"/>
         <source>Maximum distance between detection centers to merge them (0-500 pixels).
 Lower values = only merge very close detections.
 Higher values = merge detections that are farther apart (may over-merge).</source>
@@ -11896,7 +11903,7 @@ Hogere waarden = voeg verder uit elkaar liggende detecties samen (kan oversamenv
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/ReplayWindow.py" line="363"/>
         <source>Export finished with problems - see the log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11994,7 +12001,7 @@ Hogere waarden = voeg verder uit elkaar liggende detecties samen (kan oversamenv
         <translation>Kaart</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="134"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ResultsFolderDialog.py" line="133"/>
         <source>View</source>
         <translation>Weergave</translation>
     </message>
@@ -12055,7 +12062,7 @@ Hogere waarden = voeg verder uit elkaar liggende detecties samen (kan oversamenv
         <translation>ADIAT-resultatenbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="117"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="116"/>
         <source>XML Files (*.xml);;All Files (*)</source>
         <translation>XML-bestanden (*.xml);;Alle bestanden (*)</translation>
     </message>
@@ -12065,7 +12072,7 @@ Hogere waarden = voeg verder uit elkaar liggende detecties samen (kan oversamenv
         <translation>Waarschuwing bestandsnaam</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="131"/>
+        <location filename="../app/core/controllers/images/guidePages/ReviewOrNewPage.py" line="128"/>
         <source>The selected file does not appear to be an ADIAT_Data.xml result or an ADIAT_Search project file.
 
 Do you want to continue with this file?</source>
@@ -12087,7 +12094,7 @@ Wilt u doorgaan met dit bestand?</translation>
         <translation>Beoordelingstracering</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="53"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="51"/>
         <source>Enter your name to track your review activity.
 This helps coordinate reviews across multiple reviewers.</source>
         <translation>Voer uw naam in om uw beoordelingsactiviteit te volgen.
@@ -12114,7 +12121,7 @@ Dit helpt bij de coördinatie van beoordelingen door meerdere beoordelaars.</tra
         <translation>Mijn naam onthouden</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="76"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="74"/>
         <source>Save your name for future review sessions.
 You can change it later in Preferences or by clicking the reviewer name in the viewer.</source>
         <translation>Sla uw naam op voor toekomstige beoordelingssessies.
@@ -12136,7 +12143,7 @@ U kunt deze later wijzigen in Voorkeuren of door op de beoordelaarsnaam in de vi
         <translation>Naam vereist</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ReviewerNameDialog.py" line="124"/>
         <source>Please enter your name to continue.</source>
         <translation>Voer uw naam in om door te gaan.</translation>
     </message>
@@ -12152,12 +12159,12 @@ U kunt deze later wijzigen in Voorkeuren of door op de beoordelaarsnaam in de vi
 <context>
     <name>SimilarityGalleryView</name>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="173"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="172"/>
         <source>Reference</source>
         <translation>Referentie</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/AOISimilarityResultsDialog.py" line="181"/>
         <source>Unknown</source>
         <translation>Onbekend</translation>
     </message>
@@ -12233,12 +12240,12 @@ U kunt deze later wijzigen in Voorkeuren of door op de beoordelaarsnaam in de vi
 <context>
     <name>StreamAlgorithmPage</name>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="91"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="90"/>
         <source>Are you primarily looking for a person?</source>
         <translation>Zoekt u voornamelijk naar een persoon?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="157"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="156"/>
         <source>Do you know a distinctive target color?</source>
         <translation>Kent u een onderscheidende doelkleur?</translation>
     </message>
@@ -12263,7 +12270,7 @@ U kunt deze later wijzigen in Voorkeuren of door op de beoordelaarsnaam in de vi
         <translation>Geselecteerd algoritme: {algorithm}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="192"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamAlgorithmPage.py" line="191"/>
         <source>{result}
 Secondary Recommendation: {secondary}</source>
         <translation>{result}
@@ -12326,7 +12333,7 @@ Secundaire aanbeveling: {secondary}</translation>
         <translation>4K</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="332"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="327"/>
         <source>Choose the video file you want to analyze. Use Browse to pick a file from disk.
 
 Location data is optional and usually detected automatically — ADIAT reads an .SRT sitting next to the video, or telemetry embedded in the video, on its own. Set it only to override that, or to supply location data the video does not have: a DJI .SRT or a .CSV flight log.</source>
@@ -12343,7 +12350,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>Klik op Bladeren om een videobestand te selecteren...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="341"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="340"/>
         <source>Click Scan to detect available capture devices, then select one from the dropdown.</source>
         <translation>Klik op Scannen om beschikbare opnameapparaten te detecteren en selecteer er een uit de keuzelijst.</translation>
     </message>
@@ -12359,7 +12366,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="350"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="349"/>
         <source>Enter the RTMP URL provided by your streaming server (rtmp://server:port/app/key).</source>
         <translation>Voer de RTMP-URL in die door uw streamingserver wordt verstrekt (rtmp://server:port/app/key).</translation>
     </message>
@@ -12374,7 +12381,7 @@ Location data is optional and usually detected automatically — ADIAT reads an 
         <translation>rtmp://server:port/app/streamKey</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="364"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="358"/>
         <source>You&apos;ll be prompted for the pairing code when you connect — pairing codes expire about 30 seconds after ADIAT Flight shows them, so don&apos;t generate one until you&apos;re ready.
 
 Finish this setup first, then start sharing in ADIAT Flight and enter the code. Detections reported by ADIAT Flight are ignored — this desktop runs its own analysis on the video.</source>
@@ -12417,7 +12424,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Videobestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="494"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="493"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;All Files (*)</source>
         <translation>Videobestanden (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm);;Alle bestanden (*)</translation>
     </message>
@@ -12427,7 +12434,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation type="unfinished">Een metagegevensbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="517"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamConnectionPage.py" line="515"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12437,7 +12444,6 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
     <message>
         <location filename="../app/core/controllers/streaming/shared_widgets.py" line="862"/>
         <source>Stream Connection</source>
-        <extracomment>Gap between the HUD and the bottom of the video pane. Flush against the edge reads as an artifact of the window rather than an overlay.</extracomment>
         <translation>Streamverbinding</translation>
     </message>
     <message>
@@ -12461,7 +12467,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>RTMP-stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="887"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="879"/>
         <source>Select the type of video source:
 • File: Pre-recorded video file with timeline controls
 • HDMI Capture: Live capture from HDMI capture device
@@ -12483,7 +12489,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Klik om naar videobestand te bladeren...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="868"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="865"/>
         <source>Configure and connect to video source (file, HDMI capture, RTMP stream, or ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12493,12 +12499,12 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="891"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="890"/>
         <source>• ADIAT Flight: Live feed paired with the ADIAT Flight app</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="912"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="907"/>
         <source>Enter or browse for the video source:
 • File: Click to browse for video file (MP4, AVI, MOV, etc.)
 • RTMP Stream: Enter RTMP URL (rtmp://server:port/app/stream)
@@ -12523,7 +12529,7 @@ Finish this setup first, then start sharing in ADIAT Flight and enter the code. 
         <translation>Bladeren...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="930"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="927"/>
         <source>Open file browser to select a video file for analysis.
 Supported formats: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</source>
         <translation>Open de bestandsbrowser om een videobestand voor analyse te selecteren.
@@ -12540,7 +12546,7 @@ Ondersteunde formaten: MP4, AVI, MOV, MKV, FLV, WMV, M4V, 3GP, WebM</translation
         <translation>Scannen op beschikbare HDMI-opnameapparaten</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="966"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="957"/>
         <source>Optional. ADIAT already finds location data on its own, from:
 • an .SRT file sitting next to the video
 • telemetry embedded in the video (newer DJI aircraft)
@@ -12554,12 +12560,12 @@ Choose a file here only to override that, or to supply location data the video d
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="974"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="973"/>
         <source>Optional - usually detected automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="982"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="980"/>
         <source>Browse for an SRT or CSV file with the flight&apos;s location data.
 Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
@@ -12570,7 +12576,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="993"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="992"/>
         <source>Connect to the specified video source and begin processing.</source>
         <translation>Verbind met de opgegeven videobron en start de verwerking.</translation>
     </message>
@@ -12580,7 +12586,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Verbinding verbreken</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="999"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="998"/>
         <source>Disconnect from the current video source and stop processing.</source>
         <translation>Verbreek de verbinding met de huidige videobron en stop de verwerking.</translation>
     </message>
@@ -12620,7 +12626,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Verwerking: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1020"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1019"/>
         <source>Resolution used for detection processing</source>
         <translation>Resolutie gebruikt voor detectieverwerking</translation>
     </message>
@@ -12640,7 +12646,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Verw.-FPS: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1028"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1027"/>
         <source>Actual frames per second being processed</source>
         <translation>Werkelijk verwerkte frames per seconde</translation>
     </message>
@@ -12650,7 +12656,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Tijd: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1034"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1033"/>
         <source>Time in milliseconds to process each frame</source>
         <translation>Tijd in milliseconden om elk frame te verwerken</translation>
     </message>
@@ -12660,7 +12666,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Latentie: -- ms</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1038"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1037"/>
         <source>End-to-end latency from frame capture to display</source>
         <translation>End-to-end-latentie van frame-opname tot weergave</translation>
     </message>
@@ -12695,7 +12701,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Opname starten</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1067"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1066"/>
         <source>Start recording the video stream with detection overlays.</source>
         <translation>Start opname van de videostream met detectie-overlays.</translation>
     </message>
@@ -12705,7 +12711,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Opname stoppen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1072"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1071"/>
         <source>Stop the current recording and save to file.</source>
         <translation>Stop de huidige opname en sla op in een bestand.</translation>
     </message>
@@ -12716,7 +12722,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Status: niet aan het opnemen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1082"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1081"/>
         <source>Current recording status and output file path</source>
         <translation>Huidige opnamestatus en pad naar uitvoerbestand</translation>
     </message>
@@ -12727,7 +12733,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Duur: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1088"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1087"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Opnamestatistieken: duur, FPS, frames</translation>
     </message>
@@ -12737,12 +12743,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Opslaan naar:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1100"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1099"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Map waarin video-opnamen worden opgeslagen.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1104"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1103"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Kies een map om opnamen op te slaan.</translation>
     </message>
@@ -12752,7 +12758,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>rtmp://server:port/app/stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1174"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1173"/>
         <source>Click Connect to enter your pairing code</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12762,7 +12768,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Ongeldig apparaat</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1196"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1195"/>
         <source>Please select a valid HDMI capture device.</source>
         <translation>Selecteer een geldig HDMI-opnameapparaat.</translation>
     </message>
@@ -12772,7 +12778,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Ongeldige URL</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1217"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1216"/>
         <source>Please enter a valid stream URL.</source>
         <translation>Voer een geldige stream-URL in.</translation>
     </message>
@@ -12874,7 +12880,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Videobestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1484"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1482"/>
         <source>Video Files (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;All Files (*)</source>
         <translation>Videobestanden (*.mp4 *.avi *.mov *.mkv *.flv *.wmv *.m4v *.3gp *.webm *.mpg *.mpeg *.ts *.mts *.m2ts);;Alle bestanden (*)</translation>
     </message>
@@ -12884,7 +12890,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished">Een metagegevensbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1506"/>
+        <location filename="../app/core/controllers/streaming/shared_widgets.py" line="1503"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv);;All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12927,7 +12933,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>-- (Ontbrekende cameragegevens)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="547"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="546"/>
         <source>Unable to calculate GSD. Sensor dimensions are required.</source>
         <translation>Kan GSD niet berekenen. Sensorafmetingen zijn vereist.</translation>
     </message>
@@ -12947,7 +12953,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Primair</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="588"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamImageCapturePage.py" line="587"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
@@ -12995,12 +13001,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Meer voorbeelden:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/streaming/guidePages/StreamTargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>ft²</translation>
     </message>
@@ -13008,7 +13014,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamTelemetryCoordinator</name>
     <message>
-        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="101"/>
+        <location filename="../app/core/controllers/streaming/components/StreamTelemetryCoordinator.py" line="100"/>
         <source>Waiting for telemetry from ADIAT Flight...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13056,7 +13062,7 @@ Not needed for most videos, which already carry it.</source>
 <context>
     <name>StreamViewerWindow</name>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="130"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="129"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Geautomatiseerd drone-beeldanalyse-instrument v{version} - Gesponsord door TEXSAR</translation>
     </message>
@@ -13132,7 +13138,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Status: niet aan het opnemen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="392"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="391"/>
         <source>Current recording status and output file path</source>
         <translation>Huidige opnamestatus en pad naar uitvoerbestand</translation>
     </message>
@@ -13143,7 +13149,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Duur: --</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="398"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="397"/>
         <source>Recording statistics: Duration, FPS, Frames</source>
         <translation>Opnamestatistieken: duur, FPS, frames</translation>
     </message>
@@ -13153,7 +13159,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Opslaan naar:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="407"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="406"/>
         <source>Directory where video recordings will be saved.</source>
         <translation>Map waarin video-opnamen worden opgeslagen.</translation>
     </message>
@@ -13163,7 +13169,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Bladeren...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="411"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="410"/>
         <source>Choose a folder to store recordings.</source>
         <translation>Kies een map om opnamen op te slaan.</translation>
     </message>
@@ -13173,7 +13179,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="426"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="423"/>
         <source>Save each confirmed detection with the recording: a thumbnail, its position, and a results file that opens in the Image Analysis window.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13183,7 +13189,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="433"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="430"/>
         <source>Save the flight path and detection locations as a map and a KML file. Requires location data from the video or a live ADIAT Flight feed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13193,7 +13199,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="442"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="441"/>
         <source>Watch this recording: video, detections, telemetry and map.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13203,7 +13209,7 @@ Not needed for most videos, which already carry it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="447"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="446"/>
         <source>Open the folder holding the last recording and its detections.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13223,12 +13229,12 @@ Not needed for most videos, which already carry it.</source>
         <translation>Algoritme:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="610"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="609"/>
         <source>Select which streaming detection algorithm to use</source>
         <translation>Selecteer welk streamingdetectie-algoritme moet worden gebruikt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="619"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="615"/>
         <source>Choose which streaming detection algorithm to run.
 • Color Anomaly &amp; Motion Detection: fused anomaly detectors
 • Color Detection: color-based highlighting</source>
@@ -13242,7 +13248,7 @@ Not needed for most videos, which already carry it.</source>
         <translation>Galerijdrempel:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="655"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="653"/>
         <source>Number of frames a detection must be seen before appearing in the Gallery tab</source>
         <translation>Aantal frames waarin een detectie moet worden gezien voordat deze in het tabblad Galerij verschijnt</translation>
     </message>
@@ -13252,7 +13258,7 @@ Not needed for most videos, which already carry it.</source>
         <translation> frames</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="667"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="663"/>
         <source>Detections must be seen for this many consecutive frames
 before appearing in the Gallery. Higher values reduce
 false positives but delay detection appearance.</source>
@@ -13363,27 +13369,27 @@ valse positieven, maar vertragen het verschijnen van detecties.</translation>
         <translation>{state} - {message}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1913"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1912"/>
         <source>Connected</source>
         <translation>Verbonden</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="537"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="534"/>
         <source>Save the flight path and detection locations as a map and a KML file. Location data is available for this source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="544"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="541"/>
         <source>Save the flight path and detection locations as a map and a KML file. Nothing is saved unless location data arrives while recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1915"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1914"/>
         <source>Disconnected</source>
         <translation>Verbinding verbroken</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1917"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="1916"/>
         <source>Connecting</source>
         <translation type="unfinished">Verbinden</translation>
     </message>
@@ -13413,7 +13419,7 @@ valse positieven, maar vertragen het verschijnen van detecties.</translation>
         <translation>Detectieresultaten ({count} gevonden):</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2239"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2238"/>
         <source>#{index}: Type({cls}) Pos({x},{y}) Size({w}x{h})</source>
         <translation>#{index}: type({cls}) pos({x},{y}) grootte({w}x{h})</translation>
     </message>
@@ -13478,7 +13484,7 @@ valse positieven, maar vertragen het verschijnen van detecties.</translation>
         <translation>Live-stream</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2514"/>
+        <location filename="../app/core/controllers/streaming/StreamViewerWindow.py" line="2512"/>
         <source>Cannot seek in live stream.
 
 Detection was first seen at frame {frame}.</source>
@@ -13823,12 +13829,12 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Meer voorbeelden:</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="104"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="103"/>
         <source>sqm</source>
         <translation>m²</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="108"/>
+        <location filename="../app/core/controllers/images/guidePages/TargetSizePage.py" line="106"/>
         <source>sqft</source>
         <translation>ft²</translation>
     </message>
@@ -13841,7 +13847,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <translation>Geen gemarkeerde AOI&apos;s</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="52"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="49"/>
         <source>There are no flagged AOIs to assign.
 
 Flag at least one AOI in the viewer before using Plan Verification.</source>
@@ -13865,7 +13871,7 @@ Markeer ten minste één AOI in de viewer voordat u Plan-verificatie gebruikt.</
         <translation>Geen AOI&apos;s geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="223"/>
+        <location filename="../app/core/controllers/images/viewer/TeamPlanningController.py" line="221"/>
         <source>Select one or more AOIs on the map first.
 Click on markers, or use Rectangle Select for area selection.</source>
         <translation>Selecteer eerst een of meer AOI&apos;s op de kaart.
@@ -13990,7 +13996,7 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation>Rechthoek selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="97"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="96"/>
         <source>Draw a rectangle on the map to select multiple AOIs</source>
         <translation>Teken een rechthoek op de kaart om meerdere AOI&apos;s te selecteren</translation>
     </message>
@@ -14031,7 +14037,7 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation>Selectie toewijzen ▶</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="146"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="145"/>
         <source>Assign the selected AOIs on the map to the chosen team</source>
         <translation>De geselecteerde AOI&apos;s op de kaart toewijzen aan het gekozen team</translation>
     </message>
@@ -14046,7 +14052,7 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation>Team-PDF exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="175"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="174"/>
         <source>Generate a PDF report for the selected team only</source>
         <translation>Een PDF-rapport genereren voor alleen het geselecteerde team</translation>
     </message>
@@ -14056,17 +14062,17 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation>Alle PDF&apos;s exporteren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="182"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="181"/>
         <source>Generate one PDF per team plus a master summary PDF</source>
         <translation>Een PDF per team plus een hoofdsamenvattings-PDF genereren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="198"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="195"/>
         <source>Click to select AOI • Ctrl+Click to multi-select • Use Rectangle Select for area selection • Scroll to zoom</source>
         <translation>Klik om AOI te selecteren • Ctrl+klik voor meervoudige selectie • Gebruik Rechthoek selecteren voor gebiedsselectie • Scrol om te zoomen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="223"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TeamPlanningDialog.py" line="222"/>
         <source>Team</source>
         <translation>Team</translation>
     </message>
@@ -14145,18 +14151,18 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation>verouderd {age}s</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="265"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="264"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="57"/>
         <source>ALT —</source>
         <translation>ALT —</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="299"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="297"/>
         <source>no AGL yet - ADIAT Flight found no terrain source here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="301"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="300"/>
         <source>no terrain-referenced AGL available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14176,47 +14182,47 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="307"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="306"/>
         <source>AGL — above the terrain beneath the aircraft; what clearance and image scale depend on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="309"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="308"/>
         <source>ATO — above the takeoff point (the drone&apos;s own reading); equal to AGL only over flat ground</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="325"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="324"/>
         <source>ADIAT Flight (fused)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="327"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="326"/>
         <source>laser rangefinder (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="329"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="328"/>
         <source>downward sensor (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="331"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="330"/>
         <source>terrain DEM (ADIAT Flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="333"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="332"/>
         <source>desktop DEM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="335"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="334"/>
         <source>no terrain source — this is the takeoff-relative reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="341"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="339"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="91"/>
         <source>HDG —</source>
         <translation>HDG —</translation>
@@ -14227,7 +14233,7 @@ Klik op markeringen of gebruik Rechthoek selecteren voor gebiedsselectie.</trans
         <translation>HDG {bearing:03d}° {cardinal}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/flight/TelemetryHud.py" line="354"/>
+        <location filename="../app/core/views/flight/TelemetryHud.py" line="349"/>
         <location filename="../resources/views/flight/telemetry_hud.ui" line="98"/>
         <source>SPD —</source>
         <translation>SPD —</translation>
@@ -14547,18 +14553,18 @@ agressief</translation>
 <context>
     <name>ThermalHistogramChart</name>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="100"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="98"/>
         <source>No histogram data available</source>
         <translation>Geen histogramgegevens beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="435"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="434"/>
         <source>All Pixels</source>
         <translation>Alle pixels</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="446"/>
-        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="457"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="445"/>
+        <location filename="../app/core/views/images/viewer/widgets/ThermalHistogramChart.py" line="456"/>
         <source>AOI Pixels</source>
         <translation>AOI-pixels</translation>
     </message>
@@ -14571,7 +14577,7 @@ agressief</translation>
         <translation>Thermisch histogram niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="34"/>
+        <location filename="../app/core/controllers/images/viewer/ThermalHistogramController.py" line="33"/>
         <source>No thermal temperature data is available for the current image.</source>
         <translation>Er zijn geen thermische temperatuurgegevens beschikbaar voor de huidige afbeelding.</translation>
     </message>
@@ -14628,7 +14634,7 @@ agressief</translation>
         <translation>Beweeg over het histogram om een temperatuurband te inspecteren.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="31"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ThermalHistogramDialog.py" line="30"/>
         <source>No thermal histogram data available</source>
         <translation>Geen thermische histogramgegevens beschikbaar</translation>
     </message>
@@ -14974,7 +14980,7 @@ agressief</translation>
         <translation>Kroonbron vervangen?</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="361"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="359"/>
         <source>A LANDFIRE canopy source is currently configured.
 
 Register the downloaded Meta/WRI canopy tiles instead? (Your LANDFIRE files stay on disk; only the selected source changes.)</source>
@@ -14988,7 +14994,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>Hoogte (DEM)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="370"/>
+        <location filename="../app/core/controllers/images/viewer/exports/TileFetchController.py" line="368"/>
         <source>Canopy height</source>
         <translation>Kroonhoogte</translation>
     </message>
@@ -15119,7 +15125,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>Voetafdrukbuffer (m):</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="110"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="109"/>
         <source>Padding added around the camera positions so downloaded tiles cover the image footprints. Auto-sized from the mission; edit and re-fill to change.</source>
         <translation>Marge rond de cameraposities zodat de gedownloade tegels de beeldvoetafdrukken dekken. Automatisch bepaald op basis van de missie; bewerk en vul opnieuw om te wijzigen.</translation>
     </message>
@@ -15134,7 +15140,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>USGS 3DEP DEM</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="125"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="123"/>
         <source>USGS 3DEP provides 1 m local elevation. Optional when you already have a terrain source configured (AWS Terrain Tiles online, or downloaded 3DEP) — enable it to download higher-resolution data.</source>
         <translation>USGS 3DEP levert lokale hoogtegegevens van 1 m. Optioneel wanneer u al een terreinbron hebt geconfigureerd (AWS Terrain Tiles online of gedownloade 3DEP) — schakel dit in om gegevens met hogere resolutie te downloaden.</translation>
     </message>
@@ -15164,7 +15170,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>Aangepaste map...</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="152"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="149"/>
         <source>The central library collects tiles from all missions in one place (they merge, nothing gets replaced) and registers automatically. Choose the results folder or a custom folder to keep tiles beside a specific mission instead.</source>
         <translation>De centrale bibliotheek verzamelt tegels van alle missies op één plek (ze worden samengevoegd, niets wordt vervangen) en registreert automatisch. Kies de resultatenmap of een aangepaste map om tegels bij een specifieke missie te bewaren.</translation>
     </message>
@@ -15194,32 +15200,32 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="207"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="206"/>
         <source>This area is already covered by your registered tiles.</source>
         <translation>Dit gebied wordt al gedekt door uw geregistreerde tegels.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="210"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="208"/>
         <source>Partially covered by your registered tiles — downloading fills the gaps.</source>
         <translation>Gedeeltelijk gedekt door uw geregistreerde tegels — downloaden vult de gaten.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="214"/>
         <source>Your downloaded 1 m tiles don&apos;t include this area — without this download, online AWS Terrain Tiles (~30 m) are used here instead.</source>
         <translation>Uw gedownloade 1 m-tegels omvatten dit gebied niet — zonder deze download worden hier online AWS Terrain Tiles (~30 m) gebruikt.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="220"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="217"/>
         <source>Your downloaded canopy tiles don&apos;t include this area — without this download, POD runs with no canopy attenuation here.</source>
         <translation>Uw gedownloade bladerdaktegels omvatten dit gebied niet — zonder deze download draait POD hier zonder bladerdakdemping.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="222"/>
         <source>No local elevation tiles registered — online AWS Terrain Tiles (~30 m) serve as the baseline.</source>
         <translation>Geen lokale hoogtetegels geregistreerd — online AWS Terrain Tiles (~30 m) dienen als basis.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="225"/>
+        <location filename="../app/core/views/images/viewer/dialogs/TileFetchDialog.py" line="224"/>
         <source>No canopy source is configured yet.</source>
         <translation>Er is nog geen bladerdakbron geconfigureerd.</translation>
     </message>
@@ -15260,7 +15266,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>Geen gegevens geselecteerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="441"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="440"/>
         <source>Please select at least one type of data to export.</source>
         <translation>Selecteer ten minste één type gegevens om te exporteren.</translation>
     </message>
@@ -15291,7 +15297,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>Kaartexport opslaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="500"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="499"/>
         <source>KML files (*.kml);;KMZ files (*.kmz)</source>
         <translation>KML-bestanden (*.kml);;KMZ-bestanden (*.kmz)</translation>
     </message>
@@ -15317,12 +15323,12 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
     </message>
     <message>
         <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="704"/>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="717"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="716"/>
         <source>POD coverage complete</source>
         <translation>POD-dekking voltooid</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="714"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="713"/>
         <source>POD coverage complete — {count} frame(s) used online elevation (outside local DEM)</source>
         <translation>POD-dekking voltooid — {count} frame(s) gebruikten online hoogte (buiten lokale DEM)</translation>
     </message>
@@ -15342,7 +15348,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>(bladerdakgegevens dekten {pct}% van het doorzochte gebied)</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="808"/>
         <source>Terrain and canopy aware probability-of-detection heatmap.</source>
         <translation>Terrein- en bladerdakbewuste detectiekans-heatmap.</translation>
     </message>
@@ -15362,7 +15368,7 @@ In plaats daarvan de gedownloade Meta/WRI-kroontegels registreren? (Uw LANDFIRE-
         <translation>POD-overlay</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="826"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="824"/>
         <source>The POD coverage was computed, but embedding it into the exported file failed:
 {error}
 
@@ -15415,7 +15421,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="748"/>
+        <location filename="../app/core/controllers/images/viewer/exports/UnifiedMapExportController.py" line="747"/>
         <source>(no takeoff elevation — POD is approximate over changing terrain)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15433,12 +15439,12 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
 <context>
     <name>UpdateController</name>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="53"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="52"/>
         <source>Disabled while Offline Only mode is enabled.</source>
         <translation>Uitgeschakeld terwijl de modus Alleen offline is ingeschakeld.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="57"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="56"/>
         <source>Check the update feed for a newer ADIAT installer.</source>
         <translation>Controleer de update-feed op een nieuwer ADIAT-installatieprogramma.</translation>
     </message>
@@ -15448,7 +15454,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>Updates uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="88"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="87"/>
         <source>Update checks are disabled while Offline Only mode is enabled.</source>
         <translation>Updatecontroles zijn uitgeschakeld terwijl de modus Alleen offline is ingeschakeld.</translation>
     </message>
@@ -15470,7 +15476,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>Geen updates beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="113"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="112"/>
         <source>You are already running the latest available version of ADIAT.</source>
         <translation>U gebruikt al de nieuwste beschikbare versie van ADIAT.</translation>
     </message>
@@ -15492,7 +15498,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>Installatieprogramma gestart</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="140"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="139"/>
         <source>The installer has been launched. Close ADIAT when you are ready to continue the update.</source>
         <translation>Het installatieprogramma is gestart. Sluit ADIAT wanneer u klaar bent om de update voort te zetten.</translation>
     </message>
@@ -15507,7 +15513,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>ADIAT {new_version} is beschikbaar. U gebruikt {current_version}.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="157"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="156"/>
         <source>Do you want to download and launch the installer now?</source>
         <translation>Wilt u het installatieprogramma nu downloaden en starten?</translation>
     </message>
@@ -15538,7 +15544,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>{value} MB</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/UpdateController.py" line="194"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="193"/>
         <source>unknown</source>
         <translation>onbekend</translation>
     </message>
@@ -15551,7 +15557,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
     </message>
     <message>
         <location filename="../app/core/controllers/UpdateController.py" line="204"/>
-        <location filename="../app/core/controllers/UpdateController.py" line="211"/>
+        <location filename="../app/core/controllers/UpdateController.py" line="210"/>
         <source>Update download canceled.</source>
         <translation>Update-download geannuleerd.</translation>
     </message>
@@ -15617,7 +15623,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>Dit opschaalvenster sluiten</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="306"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="302"/>
         <source>Resolution: {width} × {height} pixels | Original: {orig_w} × {orig_h} pixels | Upscale: {level}x | Use mouse wheel to zoom, right-click to pan</source>
         <translation>Resolutie: {width} × {height} pixels | Origineel: {orig_w} × {orig_h} pixels | Opschaal: {level}x | Gebruik muiswiel om te zoomen, rechtsklik om te pannen</translation>
     </message>
@@ -15636,7 +15642,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>Fout tijdens initiële opschaling: {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="389"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="388"/>
         <source>Unable to extract visible image portion.</source>
         <translation>Kan zichtbaar afbeeldingsgedeelte niet extraheren.</translation>
     </message>
@@ -15646,7 +15652,7 @@ De POD GeoTIFF-producten zijn wel naast de export geschreven.</translation>
         <translation>Maximale opschaling bereikt</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="401"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="399"/>
         <source>Maximum upscale level of {level}x has been reached.
 Further upscaling is not allowed to prevent memory issues.</source>
         <translation>Maximaal opschaalniveau van {level}x is bereikt.
@@ -15658,7 +15664,7 @@ Verdere opschaling is niet toegestaan om geheugenproblemen te voorkomen.</transl
         <translation>Afbeelding te groot</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="418"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="415"/>
         <source>Upscaling would result in an image of {width}×{height} pixels.
 Maximum allowed dimension is {max_dim} pixels.
 
@@ -15674,7 +15680,7 @@ Probeer in te zoomen op een kleiner gebied voordat u opschaalt.</translation>
         <translation>Afbeelding te klein</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="430"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="428"/>
         <source>Visible portion is too small ({width}×{height} pixels).
 Please zoom in to a larger area before upscaling.</source>
         <translation>Zichtbaar gedeelte is te klein ({width}×{height} pixels).
@@ -15689,7 +15695,7 @@ Zoom in op een groter gebied voordat u opschaalt.</translation>
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="490"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="487"/>
         <source>Upscaling image with AI enhancement...
 From {width}×{height} to {new_width}×{new_height} pixels
 This may take a few seconds.</source>
@@ -15721,7 +15727,7 @@ Dit kan enkele seconden duren.</translation>
         <translation>Methode niet beschikbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="607"/>
+        <location filename="../app/core/views/images/viewer/dialogs/UpscaleDialog.py" line="605"/>
         <source>Real-ESRGAN is not yet implemented.
 Falling back to Lanczos interpolation.</source>
         <translation>Real-ESRGAN is nog niet geïmplementeerd.
@@ -15931,7 +15937,7 @@ Toont realtime informatie tijdens frame-extractie:
 Toont het totaal aantal geëxtraheerde frames bij voltooien.</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="58"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="57"/>
         <source>Select a Video File</source>
         <translation>Een videobestand selecteren</translation>
     </message>
@@ -15941,7 +15947,7 @@ Toont het totaal aantal geëxtraheerde frames bij voltooien.</translation>
         <translation>Een metagegevensbestand selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="74"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="73"/>
         <source>Metadata Files (*.srt *.csv);;SRT Files (*.srt);;CSV Flight Logs (*.csv)</source>
         <translation>Metagegevensbestanden (*.srt *.csv);;SRT-bestanden (*.srt);;CSV-vluchtlogboeken (*.csv)</translation>
     </message>
@@ -15951,7 +15957,7 @@ Toont het totaal aantal geëxtraheerde frames bij voltooien.</translation>
         <translation>Map selecteren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/VideoParser.py" line="111"/>
+        <location filename="../app/core/controllers/images/VideoParser.py" line="110"/>
         <source>Please set the video file and output directory.</source>
         <translation>Stel het videobestand en de uitvoermap in.</translation>
     </message>
@@ -16024,7 +16030,7 @@ Gebruik om de originele afbeelding met detectieresultaten te vergelijken.</trans
         <translation>Overlay tonen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1346"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1343"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="225"/>
         <source>Toggle Gallery Mode (G)
 Shows all AOIs from all images in a grid view</source>
@@ -16042,7 +16048,7 @@ Toont alle AOI&apos;s van alle afbeeldingen in een rasterweergave</translation>
         <translation>AOI&apos;s tonen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1364"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1363"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="328"/>
         <source>Open Histogram</source>
         <translation>Histogram openen</translation>
@@ -16090,7 +16096,7 @@ Toont alle AOI&apos;s van alle afbeeldingen in een rasterweergave</translation>
         <translation>ruler.png</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2158"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2157"/>
         <location filename="../resources/views/images/viewer/Viewer.ui" line="427"/>
         <source>Person Size Reference (Ctrl+P)</source>
         <translation>Referentie voor persoonsgrootte (Ctrl+P)</translation>
@@ -16294,7 +16300,7 @@ Sorteren helpt bij het prioriteren van de beoordeling van grotere of nabije obje
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="139"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="138"/>
         <source>Automated Drone Image Analysis Tool v{version} - Sponsored by TEXSAR</source>
         <translation>Geautomatiseerd drone-beeldanalyse-instrument v{version} - Gesponsord door TEXSAR</translation>
     </message>
@@ -16319,7 +16325,7 @@ Sorteren helpt bij het prioriteren van de beoordeling van grotere of nabije obje
         <translation>Laden van resultaten mislukt</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="189"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="186"/>
         <source>Cannot load results without valid image and mask locations.
 
 The viewer will now close.</source>
@@ -16349,7 +16355,7 @@ De viewer wordt nu gesloten.</translation>
         <translation>Detectieresultaten van {n} afbeeldingen laden...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="307"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="304"/>
         <source>Image metadata and information.
 Click on GPS Coordinates to copy, share, or open in mapping applications.</source>
         <translation>Afbeeldingsmetagegevens en -informatie.
@@ -16371,7 +16377,7 @@ Klik op GPS-coördinaten om te kopiëren, delen of te openen in kaarttoepassinge
         <translation>Geen dataset</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="721"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="720"/>
         <source>No dataset is currently loaded.</source>
         <translation>Er is momenteel geen dataset geladen.</translation>
     </message>
@@ -16381,7 +16387,7 @@ Klik op GPS-coördinaten om te kopiëren, delen of te openen in kaarttoepassinge
         <translation>Cache genereren</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="732"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="729"/>
         <source>This will regenerate thumbnail and color caches for all AOIs in this dataset.
 
 This may take a few minutes depending on the dataset size.
@@ -16426,7 +16432,7 @@ Doorgaan?</translation>
         <translation>Cache gegenereerd</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="809"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="806"/>
         <source>Cache generation complete!
 
 Processed {images} images with {aois} AOIs.
@@ -16444,7 +16450,7 @@ De viewer laadt nu miniaturen en kleuren veel sneller.</translation>
         <translation>Fout bij cachegeneratie</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="840"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="839"/>
         <source>An error occurred during cache generation:
 
 {error}</source>
@@ -16458,7 +16464,7 @@ De viewer laadt nu miniaturen en kleuren veel sneller.</translation>
         <translation>AOI niet zichtbaar</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1032"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1028"/>
         <source>The AOI at the cursor position cannot be selected because it is currently hidden due to active filters.
 
 To select this AOI, please clear or adjust your filters.</source>
@@ -16472,7 +16478,7 @@ Wis of pas uw filters aan om deze AOI te selecteren.</translation>
         <translation>Afbeeldingsafmetingen bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1228"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1224"/>
         <source>This dataset is missing image dimensions needed for heatmap filtering ({count} images).
 
 Would you like to read dimensions from the image files and update the results file?</source>
@@ -16486,7 +16492,7 @@ Wilt u de afmetingen uit de afbeeldingsbestanden lezen en het resultatenbestand 
         <translation>Afbeeldingsafmetingen lezen ({done}/{total})...</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1355"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1354"/>
         <source>Show Pixels of Interest (H or Ctrl+I)</source>
         <translation>Interessepixels tonen (H of Ctrl+I)</translation>
     </message>
@@ -16506,7 +16512,7 @@ Wilt u de afmetingen uit de afbeeldingsbestanden lezen en het resultatenbestand 
         <translation>Ontbrekende afhankelijkheid</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1797"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1794"/>
         <source>The qimage2ndarray module is required for the upscale feature.
 Please install it using: pip install qimage2ndarray</source>
         <translation>De qimage2ndarray-module is vereist voor de opschaalfunctie.
@@ -16518,19 +16524,19 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Opschaalfout</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1806"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="1805"/>
         <source>An error occurred while opening the upscale dialog:
 {error}</source>
         <translation>Er is een fout opgetreden bij het openen van het opschaaldialoogvenster:
 {error}</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2162"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2161"/>
         <source>Person Size Reference is unavailable: no GSD for this image</source>
         <translation>Referentie voor persoonsgrootte is niet beschikbaar: geen GSD voor deze afbeelding</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2261"/>
+        <location filename="../app/core/controllers/images/viewer/Viewer.py" line="2258"/>
         <source>Unknown Reviewer</source>
         <translation>Onbekende beoordelaar</translation>
     </message>
@@ -16553,7 +16559,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>De cameraklok van deze afbeeldingen lijkt verkeerd ingesteld:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="112"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="108"/>
         <source>ADIAT can stamp a corrected capture time into the image metadata. This is non-destructive: the original EXIF fields are not changed, and sun/shadow calculations will use the corrected time. Check the preview against when the flight actually flew - if it is off by 12 hours, adjust the clock face error.</source>
         <translation>ADIAT kan een gecorrigeerde opnametijd in de afbeeldingsmetadata schrijven. Dit is niet-destructief: de oorspronkelijke EXIF-velden blijven ongewijzigd en zon- en schaduwberekeningen gebruiken de gecorrigeerde tijd. Vergelijk het voorbeeld met het werkelijke tijdstip van de vlucht; als het 12 uur afwijkt, pas dan de klokstandfout aan.</translation>
     </message>
@@ -16568,7 +16574,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Te corrigeren klokstandfout:</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="129"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoClockCorrectionDialog.py" line="128"/>
         <source>IANA time zone name (e.g. America/Los_Angeles) or a fixed UTC offset in hours (e.g. -7)</source>
         <translation>IANA-tijdzonenaam (bijv. America/Los_Angeles) of een vaste UTC-offset in uren (bijv. -7)</translation>
     </message>
@@ -16649,6 +16655,124 @@ Installeer deze met: pip install qimage2ndarray</translation>
     </message>
 </context>
 <context>
+    <name>WaldoFlightLogDialog</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="126"/>
+        <source>WALDO Flight Track Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="150"/>
+        <source>An aircraft track log can supply the true per-image camera attitude (bank and pitch) and a GPS-accurate capture time, making image footprints and AOI positions substantially more accurate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="162"/>
+        <source>Remember my choice for this folder</source>
+        <translation type="unfinished">Mijn keuze onthouden voor deze map</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="171"/>
+        <source>Reading image metadata...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="182"/>
+        <source>Apply Flight Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="186"/>
+        <source>Not Now</source>
+        <translation type="unfinished">Niet nu</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="190"/>
+        <source>Cancel</source>
+        <translation type="unfinished">Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="193"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="246"/>
+        <source>The track log does not match these images: {reason}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="258"/>
+        <source>Camera clock is {n:.1f} s {direction} of GPS time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>ahead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="259"/>
+        <source>behind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="261"/>
+        <source>Track log: {name}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="263"/>
+        <source>Images sit {d:.0f} m from the flight track on average ({p:.0%} matched)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="269"/>
+        <source>Attitude channel verified against turn physics (correlation {c:.2f}, recorded {lag:+.0f} s late)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="273"/>
+        <source>Bank during capture: {lo:+.1f}° to {hi:+.1f}°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="277"/>
+        <source>Attitude channel is NOT reliable (correlation {c:.2f}) - only the capture-time refinement will be stamped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="305"/>
+        <source>Stamping flight-log attitude...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="324"/>
+        <source>Cancelling...</source>
+        <translation type="unfinished">Annuleren...</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="347"/>
+        <source>Stamped:          {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="348"/>
+        <source>Already current:  {n}</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="349"/>
+        <source>Errors:           {n}</source>
+        <translation type="unfinished">Fouten:          {n}</translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="355"/>
+        <source>Cancelled - remaining images are unstamped.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>WaldoPrePassDialog</name>
     <message>
         <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="58"/>
@@ -16681,7 +16805,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>WALDO-prepass voltooid</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="148"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoPrePassDialog.py" line="147"/>
         <source>WALDO Pre-Pass Cancelled</source>
         <translation>WALDO-prepass geannuleerd</translation>
     </message>
@@ -16739,7 +16863,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Importsamenvatting</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="61"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="58"/>
         <source>&lt;b&gt;Matched images:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;CSV entries without match:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Result images without CSV data:&lt;/b&gt; {unmatched_images}</source>
         <translation>&lt;b&gt;Overeenkomende afbeeldingen:&lt;/b&gt; {matched}&lt;br&gt;&lt;b&gt;CSV-records zonder overeenkomst:&lt;/b&gt; {unmatched_csv}&lt;br&gt;&lt;b&gt;Resultaatafbeeldingen zonder CSV-gegevens:&lt;/b&gt; {unmatched_images}</translation>
     </message>
@@ -16749,12 +16873,12 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Hoogte &amp; GSD</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="83"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="78"/>
         <source>&lt;b&gt;AGL computed from terrain:&lt;/b&gt; {agl_count} of {matched_count} images&lt;br&gt;&lt;br&gt;Per-image AGL is derived from the CSV altitude (ASL) minus terrain elevation at each GPS location. GSD will be calculated automatically using the camera sensor data and focal length.</source>
         <translation>&lt;b&gt;AGL berekend uit terrein:&lt;/b&gt; {agl_count} van {matched_count} afbeeldingen&lt;br&gt;&lt;br&gt;De AGL per afbeelding is afgeleid van de CSV-hoogte (ASL) min de terreinhoogte op elke GPS-locatie. GSD wordt automatisch berekend met behulp van de camerasensorgegevens en de brandpuntsafstand.</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="96"/>
+        <location filename="../app/core/views/images/viewer/dialogs/WingtraDataDialog.py" line="89"/>
         <source>&lt;b&gt;Terrain data unavailable&lt;/b&gt; - AGL could not be computed.&lt;br&gt;&lt;br&gt;Orientation (yaw/pitch/roll) will still be applied from the CSV. GSD and altitude displays require terrain data or a manual altitude override (Shift+O) after import.</source>
         <translation>&lt;b&gt;Terreingegevens niet beschikbaar&lt;/b&gt; - AGL kon niet worden berekend.&lt;br&gt;&lt;br&gt;Oriëntatie (yaw/pitch/roll) wordt nog steeds toegepast vanuit het CSV-bestand. GSD- en hoogteweergaven vereisen terreingegevens of een handmatige hoogteoverschrijving (Shift+O) na import.</translation>
     </message>
@@ -16777,7 +16901,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Zip-bestand opslaan</translation>
     </message>
     <message>
-        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="133"/>
+        <location filename="../app/core/controllers/images/viewer/exports/ZipExportController.py" line="132"/>
         <source>Zip files (*.zip)</source>
         <translation>Zip-bestanden (*.zip)</translation>
     </message>
@@ -16810,7 +16934,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Zip-exportopties</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="30"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="26"/>
         <source>Choose what to export:
 
 - Native: Original images, TIFF masks, and XML (paths made portable).
@@ -16836,7 +16960,7 @@ Installeer deze met: pip install qimage2ndarray</translation>
         <translation>Afbeeldingen zonder gemarkeerde AOI&apos;s opnemen</translation>
     </message>
     <message>
-        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="55"/>
+        <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="53"/>
         <source>When unchecked, only images with at least one flagged AOI will be exported.
 When checked, all images will be exported regardless of flagged AOI status.</source>
         <translation>Indien uitgevinkt, worden alleen afbeeldingen met ten minste één gemarkeerde AOI geëxporteerd.
@@ -16851,6 +16975,24 @@ Indien aangevinkt, worden alle afbeeldingen geëxporteerd, ongeacht de status va
         <location filename="../app/core/views/images/viewer/dialogs/ZipExportDialog.py" line="60"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
+    </message>
+</context>
+<context>
+    <name>_CalibrateWorker</name>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="66"/>
+        <source>No images with resolvable GPS + capture time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="68"/>
+        <source>No ForeFlight track log found for this folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/core/views/images/viewer/dialogs/WaldoFlightLogDialog.py" line="73"/>
+        <source>Calibrating {name}...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## What this does

WALDO pod imagery carries no attitude data and its camera clock drifts, so footprints and sun math degrade whenever the aircraft banks. This PR lets the operator attach the pilot's ForeFlight track-log CSV; ADIAT fits it to the images and stamps per-image **true bank/pitch** and a **GPS-anchored refined capture time**.

Field-verified on the Inyo Aug 7 sortie (N183CP): the pod clock was **17 s fast** — solved by fitting image GPS to the track, cutting along-track error from ~830 m to 14–17 m. The ForeFlight attitude channel logs ~4–5 s late; the lag is solved by correlating recorded bank against the coordinated-turn prediction tan(bank) = v·ω/g (correlation 0.29 → 0.96 after alignment).

## Implementation

- **`WaldoFlightLog`** — tolerant ForeFlight CSV parser (sniffs the `Pilot,Tail Number` header line, knots→m/s, `Course −1` treated as invalid), attitude-lag calibration, and the clock-offset fit of image GPS against the track.
- **`WaldoMetadataService.apply_flight_log_attitude`** — exact inversion of the consumer orientation model (un-roll via r = atan2(x_D, (k×x)_D); of the two exact roots the pitch<0 branch is taken — cam0 nose-up legitimately gives pitch < −90°). Roll guard at 60° (consumers flip at |roll|>90°), constants restamp on fallback, and an idempotence signature over log hash + clock params + stage version so re-opens don't rewrite.
- **`waldo:CaptureUtcRefined`** — a separate XMP field, deliberately not an in-place refinement of `CaptureUtcCorrected` (that would loop against the remembered clock-correction auto-apply). New top rung in `resolve_capture_utc`.
- **`WaldoFlightLogDialog`** — calibrate → confirm → apply, work on background workers; per-folder remembered decisions (`WaldoFlightLogDecisions`, QSettings). The pre-pass controller offers it strictly **after** the clock-correction offer, because the fit needs corrected times (verified: uncorrected times reject cleanly rather than fitting garbage). `PersonReferenceDialog` gains a "Flight track log…" button and invalidates its attitude caches when stamps change.
- **Coverage gate** — WALDO-scoped composite off-nadir ≤ 40° (keyed on `waldo:ProcessorVersion` presence, not `FlightPitchDegree`, which is a real DJI field) plus an along-track pitch offset; DJI behaviour unchanged. `get_asl_altitude` now prefers the stamped orthometric `AbsoluteAltitude` for WALDO imagery.

## Known limitation

Crab angle remains unfixed — the ForeFlight log has no heading channel, so heading still comes from the trigger-log/derivation pipeline.

## Testing

Two new test modules (parser/fits and attitude application) plus updates to the pre-pass controller, clock-correction, solar-position, coverage-extent, and image-service suites. Targeted run: 225 passed. flake8 clean on all changed files. Translations re-extracted on top of dev_2_2's catalogs.