### PR TITLE
Fix _streaming_ AI Person Detector requesting DirectML unconditionally and will now attempt to load CoreML on Mac OS.

### DIFF
--- a/app/algorithms/streaming/AIPersonDetector/services/AIPersonStreamingService.py
+++ b/app/algorithms/streaming/AIPersonDetector/services/AIPersonStreamingService.py
@@ -652,7 +652,22 @@ class AIPersonStreamingService(QObject):
             self._tiled_inference_fallback_active = True
 
     def _get_session(self, cfg: AIPersonStreamingConfig):
-        """Get cached ONNX session for current model/provider settings."""
+        """Get cached ONNX session for current model/provider settings.
+
+        Requests a hardware-accelerated provider first -- CoreMLExecutionProvider
+        (Neural Engine/GPU) on macOS, DmlExecutionProvider (DirectML, any
+        DirectX12 GPU) on Windows -- and falls back to CPUExecutionProvider if
+        that fails or if cpu_only is True. Neither accelerator exists on Linux,
+        which reaches CPU by the same route as an accelerator-less Windows box.
+
+        Whichever provider the session ends up on is logged, because ONNX
+        Runtime does not raise when a requested provider is unavailable: it
+        emits a Python warning and silently builds a CPU session. Without the
+        log line there is no way to tell an accelerated run from a CPU one
+        after the fact, and the difference is not only speed -- CoreML routes
+        to the Neural Engine at fp16, so detections near the confidence
+        threshold can differ from a CPU run of the same image.
+        """
         model_path = self._resolve_model_path(cfg)
         cache_key = (model_path, bool(cfg.cpu_only))
         cached = self._session_cache.get(cache_key)
@@ -662,7 +677,6 @@ class AIPersonStreamingService(QObject):
         if not ONNXRUNTIME_AVAILABLE or ort is None:
             raise RuntimeError("onnxruntime is not available")
 
-        providers = ["CPUExecutionProvider"] if cfg.cpu_only else ["DmlExecutionProvider", "CPUExecutionProvider"]
         session_options = ort.SessionOptions()
         session_options.execution_mode = ort.ExecutionMode.ORT_SEQUENTIAL
         session_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -670,12 +684,64 @@ class AIPersonStreamingService(QObject):
         session_options.enable_profiling = False
         session_options.intra_op_num_threads = 1
 
+        providers_cpu_only = ["CPUExecutionProvider"]
+        if cfg.cpu_only:
+            session = self._log_session_providers(
+                ort.InferenceSession(model_path, sess_options=session_options, providers=providers_cpu_only),
+                requested=providers_cpu_only
+            )
+            self._session_cache[cache_key] = session
+            return session
+
+        accelerated_provider = self.accelerated_provider_name()
+        providers_accelerated = [accelerated_provider, "CPUExecutionProvider"]
+
         try:
-            session = ort.InferenceSession(model_path, sess_options=session_options, providers=providers)
-        except Exception:
-            session = ort.InferenceSession(model_path, sess_options=session_options, providers=["CPUExecutionProvider"])
+            session = self._log_session_providers(
+                ort.InferenceSession(model_path, sess_options=session_options, providers=providers_accelerated),
+                requested=providers_accelerated
+            )
+        except Exception as e:
+            self.logger.warning(f"{accelerated_provider} failed: {e}")
+            try:
+                session = self._log_session_providers(
+                    ort.InferenceSession(model_path, sess_options=session_options, providers=providers_cpu_only),
+                    requested=providers_cpu_only
+                )
+            except Exception as cpu_e:
+                self.logger.error(f"Failed to load model even with CPUExecutionProvider: {cpu_e}")
+                raise RuntimeError("ONNX model could not be loaded with any provider.")
 
         self._session_cache[cache_key] = session
+        return session
+
+    @staticmethod
+    def accelerated_provider_name():
+        """Name of the hardware-accelerated ONNX provider for this platform.
+
+        Shared with any GPU-status UI so it and the session cannot disagree
+        about which accelerator ADIAT would even try.
+        """
+        if sys.platform == 'darwin':
+            return "CoreMLExecutionProvider"
+        return "DmlExecutionProvider"
+
+    def _log_session_providers(self, session, requested):
+        """Record which providers the session actually got, and flag a downgrade."""
+        try:
+            active = session.get_providers()
+        except Exception:  # pragma: no cover - a session with no provider list
+            return session
+
+        wanted = [p for p in requested if p != "CPUExecutionProvider"]
+        if wanted and not any(p in active for p in wanted):
+            self.logger.warning(
+                f"AI Person Detector (streaming): {wanted[0]} was requested but is not available "
+                f"(ONNX Runtime offers {ort.get_available_providers()}); "
+                f"running on {active}. Detection is unaccelerated but unchanged."
+            )
+        else:
+            self.logger.info(f"AI Person Detector (streaming): inference providers {active}")
         return session
 
     def _resolve_model_path(self, cfg: AIPersonStreamingConfig) -> str:

--- a/app/algorithms/streaming/AIPersonDetector/views/AIPersonDetectorControlWidget.py
+++ b/app/algorithms/streaming/AIPersonDetector/views/AIPersonDetectorControlWidget.py
@@ -77,7 +77,7 @@ class AIPersonDetectorControlWidget(TranslationMixin, QWidget):
 
         model_group = QGroupBox(self.tr("Model"))
         model_layout = QVBoxLayout(model_group)
-        self.cpu_only_checkbox = QCheckBox(self.tr("Force CPU (disable DirectML)"))
+        self.cpu_only_checkbox = QCheckBox(self.tr("Force CPU (disable hardware acceleration)"))
         self.high_res_checkbox = QCheckBox(self.tr("Use 1024 model (higher quality, slower)"))
         model_layout.addWidget(self.cpu_only_checkbox)
         model_layout.addWidget(self.high_res_checkbox)

--- a/app/tests/streaming/unit/test_ai_person_streaming_providers.py
+++ b/app/tests/streaming/unit/test_ai_person_streaming_providers.py
@@ -1,0 +1,213 @@
+"""Tests for ONNX execution-provider selection in the streaming AI Person Detector.
+
+Mirrors app/tests/algorithms/images/AIPersonDetector/test_ai_person_detector_providers.py:
+this is the streaming counterpart to that service, and previously requested
+DmlExecutionProvider unconditionally on every platform (never checking
+sys.platform at all), which is why a Mac would see ONNX Runtime warn that
+DirectML was unavailable even though CoreMLExecutionProvider was never tried.
+
+Provider selection cannot be tested by running it: the machine running the
+suite has whichever accelerator it has. So the platform check and the
+onnxruntime call are both patched, and these tests assert what gets
+*requested* and what gets *logged* - which is all that platform branching
+can promise.
+
+Why the logging matters enough to test: ONNX Runtime does not raise when a
+requested provider is unavailable. It emits a Python warning and quietly
+returns a CPU session. Nothing else in the app would reveal that, and on
+macOS the difference is not only speed - CoreML runs on the Neural Engine at
+fp16, so scores near the confidence threshold can move.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from algorithms.streaming.AIPersonDetector.services.AIPersonStreamingService import (
+    AIPersonStreamingConfig,
+    AIPersonStreamingService,
+)
+
+MODULE = 'algorithms.streaming.AIPersonDetector.services.AIPersonStreamingService'
+
+
+@pytest.fixture
+def service():
+    """A service with the ONNX-dependent constructor bypassed."""
+    svc = AIPersonStreamingService.__new__(AIPersonStreamingService)
+    svc.logger = MagicMock()
+    svc._session_cache = {}
+    return svc
+
+
+def fake_session(active_providers):
+    session = MagicMock()
+    session.get_providers.return_value = list(active_providers)
+    return session
+
+
+def _get_session(service, cpu_only=False):
+    cfg = AIPersonStreamingConfig(cpu_only=cpu_only)
+    with patch.object(service, '_resolve_model_path', return_value='model.onnx'):
+        return service._get_session(cfg)
+
+
+# ---------------------------------------------------------------------------
+# accelerated_provider_name
+# ---------------------------------------------------------------------------
+
+def test_macos_uses_coreml():
+    with patch(f'{MODULE}.sys.platform', 'darwin'):
+        assert AIPersonStreamingService.accelerated_provider_name() == 'CoreMLExecutionProvider'
+
+
+@pytest.mark.parametrize("platform_name", ['win32', 'linux', 'cygwin'])
+def test_non_macos_uses_directml(platform_name):
+    with patch(f'{MODULE}.sys.platform', platform_name):
+        assert AIPersonStreamingService.accelerated_provider_name() == 'DmlExecutionProvider'
+
+
+# ---------------------------------------------------------------------------
+# which providers get requested
+# ---------------------------------------------------------------------------
+
+def test_macos_requests_coreml_then_cpu(service):
+    with patch(f'{MODULE}.sys.platform', 'darwin'), \
+            patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.return_value = fake_session(['CoreMLExecutionProvider'])
+
+        _get_session(service)
+
+        assert mock_ort.InferenceSession.call_args.kwargs['providers'] == [
+            'CoreMLExecutionProvider', 'CPUExecutionProvider'
+        ]
+
+
+def test_windows_requests_directml_then_cpu(service):
+    with patch(f'{MODULE}.sys.platform', 'win32'), \
+            patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.return_value = fake_session(['DmlExecutionProvider'])
+
+        _get_session(service)
+
+        assert mock_ort.InferenceSession.call_args.kwargs['providers'] == [
+            'DmlExecutionProvider', 'CPUExecutionProvider'
+        ]
+
+
+def test_cpu_only_never_requests_an_accelerator(service):
+    """cpu_only must not be second-guessed by the platform branch."""
+    with patch(f'{MODULE}.sys.platform', 'darwin'), \
+            patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.return_value = fake_session(['CPUExecutionProvider'])
+
+        _get_session(service, cpu_only=True)
+
+        assert mock_ort.InferenceSession.call_count == 1
+        assert mock_ort.InferenceSession.call_args.kwargs['providers'] == ['CPUExecutionProvider']
+
+
+# ---------------------------------------------------------------------------
+# fallback
+# ---------------------------------------------------------------------------
+
+def test_falls_back_to_cpu_when_the_accelerated_session_raises(service):
+    with patch(f'{MODULE}.sys.platform', 'darwin'), \
+            patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        cpu_session = fake_session(['CPUExecutionProvider'])
+        mock_ort.InferenceSession.side_effect = [RuntimeError('no CoreML here'), cpu_session]
+
+        result = _get_session(service)
+
+        assert result is cpu_session
+        assert mock_ort.InferenceSession.call_count == 2
+        assert mock_ort.InferenceSession.call_args.kwargs['providers'] == ['CPUExecutionProvider']
+        service.logger.warning.assert_called()
+        assert 'CoreMLExecutionProvider' in service.logger.warning.call_args[0][0]
+
+
+def test_raises_a_clear_error_when_even_cpu_fails(service):
+    with patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.side_effect = RuntimeError('model is corrupt')
+
+        with pytest.raises(RuntimeError, match='could not be loaded with any provider'):
+            _get_session(service)
+
+        service.logger.error.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# the silent-downgrade log (the reason this file exists)
+# ---------------------------------------------------------------------------
+
+def test_warns_when_onnx_silently_downgrades_to_cpu(service):
+    """ORT returns a CPU session without raising if the provider is missing."""
+    with patch(f'{MODULE}.sys.platform', 'darwin'), \
+            patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        # no exception - just a session that did not get what was asked for
+        mock_ort.InferenceSession.return_value = fake_session(['CPUExecutionProvider'])
+        mock_ort.get_available_providers.return_value = ['CPUExecutionProvider']
+
+        _get_session(service)
+
+        service.logger.warning.assert_called_once()
+        message = service.logger.warning.call_args[0][0]
+        assert 'CoreMLExecutionProvider' in message
+        assert 'not available' in message
+
+
+def test_logs_the_active_providers_when_acceleration_is_used(service):
+    with patch(f'{MODULE}.sys.platform', 'win32'), \
+            patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.return_value = fake_session(
+            ['DmlExecutionProvider', 'CPUExecutionProvider']
+        )
+
+        _get_session(service)
+
+        service.logger.warning.assert_not_called()
+        service.logger.info.assert_called_once()
+        assert 'DmlExecutionProvider' in service.logger.info.call_args[0][0]
+
+
+def test_cpu_only_run_is_logged_without_a_downgrade_warning(service):
+    """Asking for CPU and getting CPU is not a downgrade."""
+    with patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.return_value = fake_session(['CPUExecutionProvider'])
+
+        _get_session(service, cpu_only=True)
+
+        service.logger.warning.assert_not_called()
+        service.logger.info.assert_called_once()
+
+
+def test_a_session_without_a_provider_list_is_still_returned(service):
+    """Diagnostics must never be the reason analysis cannot start."""
+    with patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        session = MagicMock()
+        session.get_providers.side_effect = AttributeError('no such method')
+        mock_ort.InferenceSession.return_value = session
+
+        assert _get_session(service, cpu_only=True) is session
+
+
+def test_session_is_cached_per_model_and_cpu_only(service):
+    """_get_session should not re-create a session already built for this key."""
+    with patch(f'{MODULE}.ONNXRUNTIME_AVAILABLE', True), \
+            patch(f'{MODULE}.ort') as mock_ort:
+        mock_ort.InferenceSession.return_value = fake_session(['CPUExecutionProvider'])
+
+        first = _get_session(service, cpu_only=True)
+        second = _get_session(service, cpu_only=True)
+
+        assert first is second
+        assert mock_ort.InferenceSession.call_count == 1


### PR DESCRIPTION
### Fix streaming AI Person Detector requesting DirectML unconditionally

The streaming variant of the AI Person Detector duplicates the
still-image one's ONNX session setup, and had the bug the images
version's TryUseCoreML/dev_2_2 fixes already addressed there: it
requested DmlExecutionProvider on every platform with no check at
all, so a Mac would see ONNX Runtime warn that DirectML was
unavailable and silently fall back to CPU, never trying
CoreMLExecutionProvider.

Ports the pattern from the current dev_2_2 images version (not the
earlier TryUseCoreML shape) to
AIPersonStreamingService._get_session(): a shared
accelerated_provider_name() static method picks CoreMLExecutionProvider
on macOS / DmlExecutionProvider elsewhere, and a new
_log_session_providers() logs a warning naming the gap when ONNX
Runtime silently downgrades to CPU, or an info line with the active
providers otherwise -- the same reasoning applies here: CoreML runs
the Neural Engine at fp16, so a silent CPU downgrade can also mean a
silent shift in which detections cross the confidence threshold.
Also corrected the docstring's "Windows/Linux" claim to Windows-only,
and the "Force CPU (disable DirectML)" checkbox label, which was
inaccurate on macOS.

Added app/tests/streaming/unit/test_ai_person_streaming_providers.py,
mirroring test_ai_person_detector_providers.py's structure: platform
selection, request shape, fallback, the silent-downgrade warning, and
session caching. Every line touched in AIPersonStreamingService.py is
covered; the one pre-existing uncovered line in that stretch
(the "onnxruntime is not available" guard) was not modified here.
The checkbox label change is exercised by existing widget-construction
tests but its text isn't asserted on -- left as-is (static string, low
risk).

flake8 clean; 45 passed across the directly relevant streaming test
files. Running the entire streaming suite at once hit an unrelated
native crash in test_stream_viewer_window.py, the same pre-existing
Qt/PySide6 instability seen earlier and unrelated to this change.

**Note**: There is session-provider logic duplicated between images/streaming AI Person Detector
AIPersonDetectorService (images) and AIPersonStreamingService
(streaming) each now carry their own copy of accelerated_provider_name(),
_log_session_providers(), and the accelerated-then-CPU-fallback
try/except shape -- identical logic, duplicated in this PR
rather than shared.

A follow-up could extract those three into something like
app/helpers/OnnxSessionHelper.py. Session caching and model-path
resolution should stay where they are: they differ by design
(streaming caches across frames and re-resolves the model per config
change; images builds fresh per image from a path fixed at
construction), so forcing them into the shared piece would be
consolidating things that aren't actually the same operation.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>