### PR TITLE
Adjust E2E tests, address 3 affine matmul warnings,  minor test addition

### DIFF
--- a/app/core/services/coverage/contracts.py
+++ b/app/core/services/coverage/contracts.py
@@ -130,7 +130,7 @@ class CoverageResult:
             from pyproj import Transformer
             self._transformer = Transformer.from_crs("EPSG:4326", self.crs, always_xy=True)
         x, y = self._transformer.transform(lon, lat)
-        col, row = (~self.transform) * (x, y)
+        col, row = (~self.transform) @ (x, y)
         r, c = int(row), int(col)
         if not (0 <= r < self.pod.shape[0] and 0 <= c < self.pod.shape[1]):
             return None

--- a/app/core/services/terrain/USGS3DEPProvider.py
+++ b/app/core/services/terrain/USGS3DEPProvider.py
@@ -324,7 +324,7 @@ class USGS3DEPProvider(ElevationProvider):
         """Bilinear sample of the first band at projected coordinate (x, y)."""
         from rasterio.windows import Window
         # Convert projected (x, y) to fractional (row, col)
-        col_f, row_f = ~ds.transform * (x, y)
+        col_f, row_f = ~ds.transform @ (x, y)
         col_i = int(col_f)
         row_i = int(row_f)
         fx = col_f - col_i

--- a/app/core/services/terrain/grid.py
+++ b/app/core/services/terrain/grid.py
@@ -254,7 +254,7 @@ def read_window(ds, spec: GridSpec, nodata=None, pad_px: int = 4):
         if raw.size == 0:
             return None, None
         # Scale the window transform so the decimated array stays registered.
-        transform = ds.window_transform(win) * Affine.scale(
+        transform = ds.window_transform(win) @ Affine.scale(
             win.width / out_w, win.height / out_h)
         return raw, transform
 

--- a/app/tests/algorithms/images/AIPersonDetector/test_ai_person_detector.py
+++ b/app/tests/algorithms/images/AIPersonDetector/test_ai_person_detector.py
@@ -1,4 +1,3 @@
-from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt
 
 
@@ -17,41 +16,32 @@ def testAIPersonDetectorE2E(main_window, testData, qtbot):
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
-    qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
-    qtbot.wait(100)  # Small wait for UI to update
 
+    qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-
-    # ONNX inference on CPU can exceed 20s; Start re-enables when the run finishes,
-    # while View Results stays off unless at least one image had AOIs.
-    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    if main_window.viewResultsButton.isEnabled():
-        qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
-        assert main_window.viewer is not None
-        viewer = main_window.viewer
-        assert viewer.fileNameLabel.text() is not None
-        assert viewer.images is not None
-        assert len(viewer.images) != 0
-        assert viewer.main_image is not None
-        assert viewer.aoiListWidget is not None
-        assert viewer.aoiListWidget.count() != 0
-        assert viewer.statusBar.text() != ""
-        qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-        assert viewer.fileNameLabel.text() is not None
-        assert viewer.images is not None
-        assert len(viewer.images) != 0
-        assert viewer.main_image is not None
-        assert viewer.aoiListWidget is not None
-        assert viewer.aoiListWidget.count() != 0
-        assert viewer.statusBar.text() != ""
-        qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-        assert viewer.fileNameLabel.text() is not None
-        assert viewer.images is not None
-        assert len(viewer.images) != 0
-        assert viewer.main_image is not None
-        assert viewer.aoiListWidget is not None
-        assert viewer.aoiListWidget.count() != 0
-        assert viewer.statusBar.text() != ""
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
+    qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
+    assert main_window.viewer is not None
+    viewer = main_window.viewer
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
+    qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
+    qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ColorRange/test_color_range.py
+++ b/app/tests/algorithms/images/ColorRange/test_color_range.py
@@ -20,7 +20,6 @@ def testColorRangeE2E(main_window, testData, qtbot):
         # G: 170 ± 75 = 95 to 245
         # B: 255 ± 75 = 180 to 255 (clamped to 0-255)
         algorithmWidget.add_color_row(color, r_min=0, r_max=75, g_min=95, g_max=245, b_min=180, b_max=255)
-        # Verify color was added
         assert len(algorithmWidget.color_rows) > 0, "Color should be added to color_rows"
     else:
         # Legacy fallback
@@ -30,7 +29,6 @@ def testColorRangeE2E(main_window, testData, qtbot):
         algorithmWidget.selectedColor = QColor(0, 170, 255)
         algorithmWidget.update_colors()
 
-    # Verify validation passes
     validation_error = algorithmWidget.validate()
     assert validation_error is None, f"Algorithm validation failed: {validation_error}"
 
@@ -38,48 +36,31 @@ def testColorRangeE2E(main_window, testData, qtbot):
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
 
-    # Start processing
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
-    qtbot.wait(100)  # Small wait for UI to update
-
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-
-    # Wait for processing to complete (increased timeout to 60 seconds)
-    # Processing is complete when start button is enabled again (regardless of whether AOIs were found)
-    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    # viewResultsButton may be disabled if no AOIs were found, which is valid
-    # Just check that processing completed
-    # Only click view results if button is enabled (AOIs were found)
-    if main_window.viewResultsButton.isEnabled():
-        qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
-        assert main_window.viewer is not None
-        viewer = main_window.viewer
-        assert viewer.fileNameLabel.text() is not None
-        assert viewer.images is not None
-        assert len(viewer.images) != 0
-        assert viewer.main_image is not None
-        assert viewer.aoiListWidget is not None
-        # Only check AOI count if viewer was opened (meaning AOIs were found)
-        if viewer.aoiListWidget.count() > 0:
-            assert viewer.statusBar.text() != ""
-            qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-            assert viewer.fileNameLabel.text() is not None
-            assert viewer.images is not None
-            assert len(viewer.images) != 0
-            assert viewer.main_image is not None
-            assert viewer.aoiListWidget is not None
-            assert viewer.statusBar.text() != ""
-            qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-            assert viewer.fileNameLabel.text() is not None
-            assert viewer.images is not None
-            assert len(viewer.images) != 0
-            assert viewer.main_image is not None
-            assert viewer.aoiListWidget is not None
-            assert viewer.statusBar.text() != ""
-    else:
-        # Processing completed but no AOIs were found - this is a valid outcome
-        # but we can't test the viewer in this case
-        pass
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
+    qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
+    assert main_window.viewer is not None
+    viewer = main_window.viewer
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
+    qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
+    qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/HSVColorRange/test_hsv_color_range.py
+++ b/app/tests/algorithms/images/HSVColorRange/test_hsv_color_range.py
@@ -14,7 +14,6 @@ def testHSVColorRangeE2E(main_window, testData, qtbot):
     # Use new wizard-based API
     if hasattr(algorithmWidget, 'add_color_row'):
         color = QColor(0, 170, 255)
-        # Add color with HSV ranges (h_minus=25, h_plus=25, s_minus=75, s_plus=75, v_minus=75, v_plus=75)
         algorithmWidget.add_color_row(color, h_minus=15, h_plus=15, s_minus=50, s_plus=50, v_minus=50, v_plus=50)
     else:
         # Legacy fallback
@@ -26,40 +25,32 @@ def testHSVColorRangeE2E(main_window, testData, qtbot):
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
+
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-    assert not main_window.startButton.isEnabled()
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=20000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/MRMap/test_mrmap.py
+++ b/app/tests/algorithms/images/MRMap/test_mrmap.py
@@ -17,40 +17,32 @@ def testMrMapE2E(main_window, testData, qtbot):
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
+
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-    assert not main_window.startButton.isEnabled()
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=20000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/MatchedFilter/test_matched_filter.py
+++ b/app/tests/algorithms/images/MatchedFilter/test_matched_filter.py
@@ -14,7 +14,6 @@ def testMatchedFilterE2E(main_window, testData, qtbot):
     # Use new wizard-based API
     if hasattr(algorithmWidget, 'add_color_row'):
         color = QColor(0, 170, 255)
-        # Use default threshold of 0.3 (more reasonable than 0.07)
         algorithmWidget.add_color_row(color, threshold=0.3)
     else:
         # Legacy fallback
@@ -24,40 +23,32 @@ def testMatchedFilterE2E(main_window, testData, qtbot):
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
+
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-    assert not main_window.startButton.isEnabled()
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=20000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/RXAnomaly/test_rx_anomaly.py
+++ b/app/tests/algorithms/images/RXAnomaly/test_rx_anomaly.py
@@ -15,40 +15,32 @@ def testRXAnomalyE2E(main_window, testData, qtbot):
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
+
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-    assert not main_window.startButton.isEnabled()
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=80000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""
+
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
     assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ThermalAnomaly/test_temperature_anomaly.py
+++ b/app/tests/algorithms/images/ThermalAnomaly/test_temperature_anomaly.py
@@ -45,17 +45,16 @@ def testTemperatureAnomalyE2E(main_window, testData, qtbot, thermal_sdk_availabl
     assert len(viewer.images) > 0
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""
+    # No status bar assert (the RGB E2Es keep one): the thermal fixtures carry
+    # no GPS, altitude or gimbal yaw, so their status bar is legitimately empty.
 
     start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
     assert viewer.current_image == (start_index + 1) % len(viewer.images)
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""
 
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
     assert viewer.current_image == start_index
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ThermalAnomaly/test_temperature_anomaly.py
+++ b/app/tests/algorithms/images/ThermalAnomaly/test_temperature_anomaly.py
@@ -2,7 +2,7 @@ import platform
 
 import pytest
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QApplication, QDialog
+from PySide6.QtWidgets import QDialog
 from unittest.mock import patch, MagicMock
 
 
@@ -20,54 +20,42 @@ def testTemperatureAnomalyE2E(main_window, testData, qtbot, thermal_sdk_availabl
     algorithmWidget = main_window.algorithmWidget
     algorithmWidget.anomalySpinBox.setValue(6)
     algorithmWidget.anomalyTypeComboBox.setCurrentText('Above Mean')
-    # colorMapComboBox doesn't exist in ThermalAnomalyController - color map is handled elsewhere
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
+
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-    assert not main_window.startButton.isEnabled()
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=200000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
-    # Patch BearingRecoveryDialog to automatically skip (returns Rejected = Skip)
-    # This prevents the modal dialog from blocking test execution
-    # Create a mock dialog that returns Rejected when exec() is called (Skip action)
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
     mock_dialog = MagicMock()
     mock_dialog.exec.return_value = QDialog.DialogCode.Rejected
     mock_dialog.get_results.return_value = None
 
-    # Patch where the dialog is instantiated in BearingRecoveryController
     with patch('core.controllers.images.viewer.bearing.BearingRecoveryController.BearingRecoveryDialog', return_value=mock_dialog):
         qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
-
-        # Wait for viewer to initialize (dialog.exec() is mocked, so it won't block)
         qtbot.waitUntil(lambda: main_window.viewer is not None, timeout=5000)
 
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ThermalRange/test_temperature_range.py
+++ b/app/tests/algorithms/images/ThermalRange/test_temperature_range.py
@@ -18,54 +18,42 @@ def testTemperatureRangeE2E(main_window, testData, qtbot, thermal_sdk_available)
     algorithmWidget = main_window.algorithmWidget
     algorithmWidget.minTempSpinBox.setValue(100)
     algorithmWidget.maxTempSpinBox.setValue(110)
-    # colorMapComboBox doesn't exist in ThermalRangeController - color map is handled elsewhere
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
     assert not main_window.viewResultsButton.isEnabled()
+
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-    assert not main_window.startButton.isEnabled()
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=45000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
-    # Patch BearingRecoveryDialog to automatically skip (returns Rejected = Skip)
-    # This prevents the modal dialog from blocking test execution
-    # Create a mock dialog that returns Rejected when exec() is called (Skip action)
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
+
     mock_dialog = MagicMock()
     mock_dialog.exec.return_value = QDialog.DialogCode.Rejected
     mock_dialog.get_results.return_value = None
 
-    # Patch where the dialog is instantiated in BearingRecoveryController
     with patch('core.controllers.images.viewer.bearing.BearingRecoveryController.BearingRecoveryDialog', return_value=mock_dialog):
         qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
-
-        # Wait for viewer to initialize (dialog.exec() is mocked, so it won't block)
         qtbot.waitUntil(lambda: main_window.viewer is not None, timeout=5000)
 
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
+
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ThermalRange/test_temperature_range.py
+++ b/app/tests/algorithms/images/ThermalRange/test_temperature_range.py
@@ -43,17 +43,16 @@ def testTemperatureRangeE2E(main_window, testData, qtbot, thermal_sdk_available)
     assert len(viewer.images) > 0
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""
+    # No status bar assert (the RGB E2Es keep one): the thermal fixtures carry
+    # no GPS, altitude or gimbal yaw, so their status bar is legitimately empty.
 
     start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
     assert viewer.current_image == (start_index + 1) % len(viewer.images)
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""
 
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
     assert viewer.current_image == start_index
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ThermalResidualAnomaly/test_temperature_residual_anomaly.py
+++ b/app/tests/algorithms/images/ThermalResidualAnomaly/test_temperature_residual_anomaly.py
@@ -48,17 +48,16 @@ def testTemperatureResidualAnomalyE2E(main_window, testData, qtbot, thermal_sdk_
     assert len(viewer.images) > 0
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""
+    # No status bar assert (the RGB E2Es keep one): the thermal fixtures carry
+    # no GPS, altitude or gimbal yaw, so their status bar is legitimately empty.
 
     start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
     assert viewer.current_image == (start_index + 1) % len(viewer.images)
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""
 
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
     assert viewer.current_image == start_index
     assert viewer.main_image.hasImage()
     assert viewer.aoiListWidget.count() > 0
-    assert viewer.statusBar.text() != ""

--- a/app/tests/algorithms/images/ThermalResidualAnomaly/test_temperature_residual_anomaly.py
+++ b/app/tests/algorithms/images/ThermalResidualAnomaly/test_temperature_residual_anomaly.py
@@ -30,11 +30,10 @@ def testTemperatureResidualAnomalyE2E(main_window, testData, qtbot, thermal_sdk_
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
     assert not main_window.startButton.isEnabled()
     assert main_window.cancelButton.isEnabled()
-
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=45000)
-    assert main_window.startButton.isEnabled()
+    # A generous budget for the slow Windows VM; Start re-enables when the run finishes.
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
 
     mock_dialog = MagicMock()
     mock_dialog.exec.return_value = QDialog.DialogCode.Rejected
@@ -46,25 +45,20 @@ def testTemperatureResidualAnomalyE2E(main_window, testData, qtbot, thermal_sdk_
 
     assert main_window.viewer is not None
     viewer = main_window.viewer
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
+    assert len(viewer.images) > 0
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
 
+    start_index = viewer.current_image
     qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == (start_index + 1) % len(viewer.images)
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""
 
     qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-    assert viewer.main_image is not None
-    assert viewer.aoiListWidget is not None
-    assert viewer.aoiListWidget.count() != 0
+    assert viewer.current_image == start_index
+    assert viewer.main_image.hasImage()
+    assert viewer.aoiListWidget.count() > 0
+    assert viewer.statusBar.text() != ""

--- a/app/tests/core/controllers/images/test_main_window.py
+++ b/app/tests/core/controllers/images/test_main_window.py
@@ -57,11 +57,10 @@ def _open_viewer_with_sample_data(main_window, testData, qtbot):
             algorithmWidget.update_colors()
 
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
-    qtbot.wait(100)
-    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
-
-    if not main_window.viewResultsButton.isEnabled():
-        pytest.skip("No AOIs found - viewer cannot be opened without results")
+    qtbot.waitUntil(lambda: not main_window.startButton.isEnabled(), timeout=5000)
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=200000)
+    assert not main_window.cancelButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
 
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
@@ -118,34 +117,22 @@ def testBasicEndToEnd(main_window, testData, qtbot):
 
     # Start processing
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
-    assert not main_window.startButton.isEnabled()
+    qtbot.waitUntil(lambda: not main_window.startButton.isEnabled(), timeout=5000)
     assert main_window.cancelButton.isEnabled()
-
-    # Wait for processing to complete
-    qtbot.waitUntil(lambda: main_window.viewResultsButton.isEnabled(), timeout=20000)
-    assert main_window.startButton.isEnabled()
+    qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
     assert not main_window.cancelButton.isEnabled()
-    assert main_window.viewResultsButton.isEnabled()
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
 
     # Open viewer
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
     viewer = main_window.viewer
-
-    # Verify viewer has loaded data
-    assert viewer.fileNameLabel is not None
-    assert viewer.fileNameLabel.text() is not None
-    assert viewer.images is not None
-    assert len(viewer.images) != 0
-
-    # Test navigation
-    if hasattr(viewer, 'nextImageButton'):
-        qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
-        assert viewer.fileNameLabel.text() is not None
-
-    if hasattr(viewer, 'previousImageButton'):
-        qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
-        assert viewer.fileNameLabel.text() is not None
+    assert viewer.images and len(viewer.images) > 0
+    assert viewer.aoiListWidget.count() > 0
+    qtbot.mouseClick(viewer.nextImageButton, Qt.MouseButton.LeftButton)
+    assert viewer.aoiListWidget.count() > 0
+    qtbot.mouseClick(viewer.previousImageButton, Qt.MouseButton.LeftButton)
+    assert viewer.aoiListWidget.count() > 0
 
 
 def test_viewer_toolbar_buttons(main_window, testData, qtbot):
@@ -229,13 +216,11 @@ def testNormalizeHistogram(main_window, testData, qtbot):
             main_window.histogramLine.setText(histogram_path)
 
         qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
-        qtbot.wait(100)  # Small wait for UI to update
-
-        # Wait for processing to complete (increased timeout to 60 seconds)
-        # Processing is complete when start button is enabled again (regardless of whether AOIs were found)
+        qtbot.waitUntil(lambda: not main_window.startButton.isEnabled(), timeout=5000)
         qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
         assert main_window.startButton.isEnabled()
         assert not main_window.cancelButton.isEnabled()
+        assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
 
 
 def testKmlCollection(main_window, testData, qtbot):
@@ -266,17 +251,11 @@ def testKmlCollection(main_window, testData, qtbot):
 
     # Run the analysis and wait for results
     qtbot.mouseClick(main_window.startButton, Qt.MouseButton.LeftButton)
-    qtbot.wait(100)  # Small wait for UI to update
-
-    # Wait for processing to complete (increased timeout to 60 seconds)
-    # Processing is complete when start button is enabled again (regardless of whether AOIs were found)
+    qtbot.waitUntil(lambda: not main_window.startButton.isEnabled(), timeout=5000)
     qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
-
-    # Only proceed if AOIs were found (viewResultsButton is enabled)
-    if not main_window.viewResultsButton.isEnabled():
-        pytest.skip("No AOIs found - cannot test KML export without results")
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
 
     qtbot.mouseClick(main_window.viewResultsButton, Qt.MouseButton.LeftButton)
     assert main_window.viewer is not None
@@ -327,17 +306,11 @@ def testPdfGenerator(main_window, testData, qtbot):
 
     # Ensure Viewer is initialized and ready
     qtbot.mouseClick(main_window.startButton, Qt.LeftButton)
-    qtbot.wait(100)  # Small wait for UI to update
-
-    # Wait for processing to complete (increased timeout to 60 seconds)
-    # Processing is complete when start button is enabled again (regardless of whether AOIs were found)
+    qtbot.waitUntil(lambda: not main_window.startButton.isEnabled(), timeout=5000)
     qtbot.waitUntil(lambda: main_window.startButton.isEnabled(), timeout=60000)
     assert main_window.startButton.isEnabled()
     assert not main_window.cancelButton.isEnabled()
-
-    # Only proceed if AOIs were found (viewResultsButton is enabled)
-    if not main_window.viewResultsButton.isEnabled():
-        pytest.skip("No AOIs found - cannot test PDF generation without results")
+    assert main_window.viewResultsButton.isEnabled(), "expected AOIs for this fixture/params"
 
     qtbot.mouseClick(main_window.viewResultsButton, Qt.LeftButton)
 

--- a/app/tests/helpers/test_geodesic_helper.py
+++ b/app/tests/helpers/test_geodesic_helper.py
@@ -1,0 +1,74 @@
+"""Direct unit tests for GeodesicHelper (bearing / circular geometry)."""
+
+import pytest
+
+from helpers.GeodesicHelper import GeodesicHelper as G
+
+
+def test_circular_mean_empty_and_wraparound():
+    assert G.circular_mean([]) == 0.0
+    assert G.circular_mean([350.0, 10.0]) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_circular_median_empty_single_small_and_large():
+    assert G.circular_median([]) == 0.0
+    assert G.circular_median([405.0]) == pytest.approx(45.0)
+    assert G.circular_median([10.0, 20.0, 30.0]) == pytest.approx(20.0)
+    # len > 5 uses the normalized-candidate branch
+    median = G.circular_median([10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+    assert 10.0 <= median <= 60.0
+
+
+@pytest.mark.parametrize(
+    "angle, expected",
+    [(-90.0, 270.0), (360.0, 0.0), (725.0, 5.0)],
+)
+def test_normalize_angle_deg(angle, expected):
+    assert G.normalize_angle_deg(angle) == pytest.approx(expected)
+
+
+def test_angle_difference_deg_wraparound():
+    assert G.angle_difference_deg(350.0, 10.0) == pytest.approx(20.0)
+    assert G.angle_difference_deg(10.0, 350.0) == pytest.approx(-20.0)
+
+
+def test_point_to_segment_distance_degenerate_and_normal():
+    # Identical endpoints → distance to that point
+    d0 = G.point_to_segment_distance(30.001, -97.0, 30.0, -97.0, 30.0, -97.0)
+    assert d0 == pytest.approx(G.haversine_distance(30.001, -97.0, 30.0, -97.0), rel=0.05)
+
+    # Point near midpoint of a short N–S segment
+    d = G.point_to_segment_distance(30.005, -97.001, 30.0, -97.0, 30.01, -97.0)
+    assert d > 0.0
+
+
+def test_smooth_bearings_circular_short_even_window_and_savgol():
+    short = [1.0, 2.0, 3.0]
+    out = G.smooth_bearings_circular(short, window=5)
+    assert out == short
+    assert out is not short
+
+    long_flat = [10.0] * 7
+    even = G.smooth_bearings_circular(long_flat, window=4, use_savgol=False)
+    assert len(even) == 7
+    assert all(0.0 <= b < 360.0 for b in even)
+
+    no_sg = G.smooth_bearings_circular(long_flat, window=5, use_savgol=False)
+    assert len(no_sg) == 7
+
+    wrap = [350.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+    with_sg = G.smooth_bearings_circular(wrap, window=5, use_savgol=True)
+    assert len(with_sg) == len(wrap)
+    assert all(0.0 <= b < 360.0 for b in with_sg)
+
+
+def test_unwrap_angles_empty_single_and_crossing():
+    assert G.unwrap_angles([]) == []
+    assert G.unwrap_angles([45.0]) == [45.0]
+
+    unwrapped = G.unwrap_angles([350.0, 10.0, 20.0])
+    assert unwrapped[0] == pytest.approx(350.0)
+    assert unwrapped[1] == pytest.approx(370.0)
+    assert unwrapped[2] == pytest.approx(380.0)
+    assert unwrapped[1] > unwrapped[0]
+    assert unwrapped[2] > unwrapped[1]


### PR DESCRIPTION
`pytest` green on MacOS, Linux and Windows VM with a tiny test coverage bump.


## Affine matmul (`*` → `@`)

Replaced deprecated Affine `*` with `@` in `app/core/services/coverage/contracts.py`, `terrain/USGS3DEPProvider.py`, and `terrain/grid.py` to remove 3x warnings. These were the only changes to functional code. However, lots of related warnings from third-party dependencies remain.

## Image-algorithm E2E test hardening

The nine algorithm E2Es were marginally inconsistent in places and sometimes brittle. They now share one consistent contract: click Start, assert Start/Cancel switched, wait up to 200s for Start to re-enable (for a slow Windows VM), then the series of assertions. The RGB six assert a non-empty status bar, but the thermal three do not since some fixtures carry no GPS, altitude or gimbal yaw. In general, the approach/coverage of these tests hasn't really changed -- just polish/cleanUp.

In `app/tests/core/controllers/images/test_main_window.py` the soft-skips became the same hard assert, but its waits are still 60s and its viewer asserts are the older ones. 

# GeodesicHelper unit tests

Added `app/tests/helpers/test_geodesic_helper.py` for circular mean/median (incl. wraparound), normalize / angle difference, degenerate point-to-segment distance, bearing smoothing, and unwrap. No production code changes.